### PR TITLE
Script Changes After Deployment

### DIFF
--- a/platform/jobs/edxPlatformBokChoyPr.groovy
+++ b/platform/jobs/edxPlatformBokChoyPr.groovy
@@ -28,12 +28,6 @@ Binding bindings = getBinding()
 config.putAll(bindings.getVariables())
 PrintStream out = config['out']
 
-stringParams = [
-    name: 'sha1',
-    description: 'Sha1 hash of branch to build. Default branch : master',
-    default: '*/master'
-]
-
 /* Environment variable (set in Seeder job config) to reference a Jenkins secret file */
 String secretFileVariable = 'EDX_PLATFORM_TEST_BOK_CHOY_PR_SECRET'
 
@@ -82,9 +76,6 @@ secretMap.each { jobConfigs ->
             }
         }
 
-        parameters {
-            stringParam(stringParams.name, stringParams.default, stringParams.description)
-        }
         logRotator JENKINS_PUBLIC_LOG_ROTATOR() //Discard build after a certain amount of time
         concurrentBuild() //concurrent builds can happen
         label('flow-worker-bokchoy') //restrict to jenkins-worker

--- a/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
@@ -141,7 +141,6 @@ secretMap.each { jobConfigs ->
            archiveJunit(JENKINS_PUBLIC_JUNIT_REPORTS)
            configure { node ->
                node /publishers << 'jenkins.plugins.shiningpanda.publishers.CoveragePublisher' {
-                   htmlDir ''
                }
            }
            downstreamParameterized JENKINS_PUBLIC_GITHUB_STATUS_SUCCESS.call(predefinedPropsMap)

--- a/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
@@ -79,7 +79,7 @@ class JenkinsPublicConstants {
     
     public static final String JENKINS_PUBLIC_JUNIT_REPORTS = 'edx-platform/**/nosetests.xml,edx-platform/reports/acceptance/*.xml,' +
                                                               'edx-platform/reports/quality.xml,edx-platform/reports/javascript/' +
-                                                              'javascript_xunit.xml,edx-platform/reports/bok_choy/xunit.xml,edx-platform/' +
+                                                              'javascript_xunit*.xml,edx-platform/reports/bok_choy/xunit.xml,edx-platform/' +
                                                               'reports/bok_choy/**/xunit.xml'
 
     public static final Closure JENKINS_PUBLIC_GITHUB_STATUS_PENDING = { predefinedPropsMap ->


### PR DESCRIPTION
@estute @jzoldak 

Changes made:
1) In Bok Choy PR, removed the parameterized variable that was never used. Still need to figure out why the job wasn't being triggered by 'jenkins run bokchoy'

2) In Python Unit Tests Master, removed the line about the relative html directory. The XML now reads:
<jenkins.plugins.shiningpanda.publishers.CoveragePublisher plugin="shiningpanda@0.21"/> which matches that of Build Jenkins: <jenkins.plugins.shiningpanda.publishers.CoveragePublisher plugin="shiningpanda@0.21"/>. The only difference is that the DSL scripted version has coverage.py as the first node in publishers while the version in Build Jenkins has it as a later node.

3) In Jenkins Public Constants added an * in the list of file names for the jUnit Archiver. This was to resolve the issues with JS Master failing because it was unable to publish the files. 

Whenever you get a chance please look this over :D Thanks!