### PR TITLE
BokChoy Pr Changes

### DIFF
--- a/platform/jobs/edxPlatformBokChoyPr.groovy
+++ b/platform/jobs/edxPlatformBokChoyPr.groovy
@@ -4,6 +4,7 @@ import hudson.model.Build
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_PARSE_SECRET
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_BASEURL
 
 /*
 Example secret YAML file used by this script
@@ -75,7 +76,9 @@ secretMap.each { jobConfigs ->
                 permissionAll('edx')
             }
         }
-
+        properties {
+              githubProjectUrl(JENKINS_PUBLIC_GITHUB_BASEURL + jobConfig['platformUrl'])
+        }
         logRotator JENKINS_PUBLIC_LOG_ROTATOR() //Discard build after a certain amount of time
         concurrentBuild() //concurrent builds can happen
         label('flow-worker-bokchoy') //restrict to jenkins-worker
@@ -83,7 +86,7 @@ secretMap.each { jobConfigs ->
         multiscm {
             git { //using git on the branch and url, clean before checkout
                 remote {
-                    github(jobConfig['testengUrl'])
+                    url(JENKINS_PUBLIC_GITHUB_BASEURL + jobConfig['testengUrl'] + '.git')
                     if (!jobConfig['open'].toBoolean()) {
                         credentials(jobConfig['testengCredential'])
                     }
@@ -97,7 +100,7 @@ secretMap.each { jobConfigs ->
             }
             git { //using git on the branch and url, clone, clean before checkout
                 remote {
-                    github(jobConfig['platformUrl'])
+                    url(JENKINS_PUBLIC_GITHUB_BASEURL + jobConfig['platformUrl'] + '.git')
                     refspec('+refs/pull/*:refs/remotes/origin/pr/*')
                     if (!jobConfig['open'].toBoolean()) {
                         credentials(jobConfig['platformCredential'])

--- a/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
@@ -15,7 +15,7 @@ class JenkinsPublicConstants {
     }
   }
 
-  public static final String JENKINS_PUBLIC_GITHUB_BASEURL = "http://github.com/"
+  public static final String JENKINS_PUBLIC_GITHUB_BASEURL = "https://github.com/"
 
   public static final String JENKINS_PUBLIC_WORKER = "jenkins-worker"
 

--- a/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
@@ -15,6 +15,8 @@ class JenkinsPublicConstants {
     }
   }
 
+  public static final String JENKINS_PUBLIC_GITHUB_BASEURL = "http://github.com/"
+
   public static final String JENKINS_PUBLIC_WORKER = "jenkins-worker"
 
   public static final Closure JENKINS_PUBLIC_ARCHIVE_ARTIFACTS = {


### PR DESCRIPTION
These changes are for fixing Bok Choy Pr Job for deployment. They were done because the job dsl automatically generated some xml that was confusing the GHPRB on where to listen to, the testeng-ci repo or edx-platform. 
@estute @jzoldak  Whenever you have time please look it over :)