### PR TITLE
Refactor Job DSLs

### DIFF
--- a/platform/jobs/edxPlatformBokChoyPr.groovy
+++ b/platform/jobs/edxPlatformBokChoyPr.groovy
@@ -39,10 +39,9 @@ Map secretMap = [:]
 try {
     out.println('Parsing secret YAML file')
     /* Parse k:v pairs from the secret file referenced by secretFileVariable */
-    Thread thread = Thread.currentThread()
-    Build build = thread?.executable
-    Map envVarsMap = build.parent.builds[0].properties.get("envVars")
-    secretMap = JENKINS_PUBLIC_PARSE_SECRET.call(secretFileVariable, envVarsMap, out)
+    String contents = new File("${EDX_PLATFORM_TEST_BOK_CHOY_PR_SECRET}").text
+    Yaml yaml = new Yaml()
+    secretMap = yaml.load(contents)
     out.println('Successfully parsed secret YAML file')
 }
 catch (any) {

--- a/platform/jobs/edxPlatformJsMaster.groovy
+++ b/platform/jobs/edxPlatformJsMaster.groovy
@@ -10,6 +10,7 @@ import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_RE
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_STATUS_PENDING
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_STATUS_SUCCESS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_STATUS_UNSTABLE_OR_WORSE
+import org.yaml.snakeyaml.Yaml
 
 /*
 Example secret YAML file used by this script
@@ -17,6 +18,7 @@ publicJobConfig:
     open : true/false
     jobName : name-of-jenkins-job-to-be
     url : github-url-segment
+    repoName : name-of-github-edx-repo
     credential : n/a
     cloneReference : clone/.git
     email : email-address@email.com
@@ -30,9 +32,9 @@ predefinedPropsMap.put('GITHUB_REPO', 'edx-platform')
 predefinedPropsMap.put('TARGET_URL', JENKINS_PUBLIC_BASE_URL +  'job/edx-platform-js-master/${BUILD_NUMBER}/')
 predefinedPropsMap.put('CONTEXT', 'jenkins/js')
 
-String archiveReports = 'edx-platform/reports/**/*,edx-platform/test_root/log/*.png,'
-archiveReports += 'edx-platform/test_root/log/*.log,edx-platform/test_root/log/hars/*.har,'
-archiveReports += 'edx-platform/**/nosetests.xml,edx-platform/**/TEST-*.xml'
+String archiveReports = 'edx-platform*/reports/**/*,edx-platform*/test_root/log/*.png,'
+archiveReports += 'edx-platform*/test_root/log/*.log,edx-platform*/test_root/log/hars/*.har,'
+archiveReports += 'edx-platform*/**/nosetests.xml,edx-platform*/**/TEST-*.xml'
 
 /* stdout logger */
 /* use this instead of println, because you can pass it into closures or other scripts. */
@@ -55,10 +57,9 @@ Map secretMap = [:]
 try {
     out.println('Parsing secret YAML file')
     /* Parse k:v pairs from the secret file referenced by secretFileVariable */
-    Thread thread = Thread.currentThread()
-    Build build = thread?.executable
-    Map envVarsMap = build.parent.builds[0].properties.get("envVars")
-    secretMap = JENKINS_PUBLIC_PARSE_SECRET.call(secretFileVariable, envVarsMap, out)
+    String contents = new File("${EDX_PLATFORM_TEST_JS_SECRET}").text
+    Yaml yaml = new Yaml()
+    secretMap = yaml.load(contents)
     out.println('Successfully parsed secret YAML file')
 }
 catch (any) {
@@ -77,6 +78,7 @@ secretMap.each { jobConfigs ->
     assert jobConfig.containsKey('open')
     assert jobConfig.containsKey('jobName')
     assert jobConfig.containsKey('url')
+    assert jobConfig.containsKey('repoName')
     assert jobConfig.containsKey('credential')
     assert jobConfig.containsKey('cloneReference')
     assert jobConfig.containsKey('hipchat')
@@ -115,7 +117,7 @@ secretMap.each { jobConfigs ->
                         timeout(10)
                     }
                     cleanBeforeCheckout()
-                    relativeTargetDirectory('edx-platform')
+                    relativeTargetDirectory(jobConfig['repoName'])
                 }
             }
         }
@@ -132,14 +134,14 @@ secretMap.each { jobConfigs ->
        }
        steps { //trigger GitHub-Build-Status and run accessibility tests
            downstreamParameterized JENKINS_PUBLIC_GITHUB_STATUS_PENDING.call(predefinedPropsMap)
-           shell('cd edx-platform; TEST_SUITE=js-unit ./scripts/all-tests.sh')
+           shell('cd ' + jobConfig['repoName'] + '; TEST_SUITE=js-unit ./scripts/all-tests.sh')
        }
        publishers { //publish artifacts, coverage, JUnit Test report, trigger GitHub-Build-Status, email, message hipchat
            archiveArtifacts {
                pattern(archiveReports)
                defaultExcludes()
            }
-           cobertura ('edx-platform/**/reports/**/coverage*.xml') {
+           cobertura ('edx-platform*/**/reports/**/coverage*.xml') {
                failNoReports(true)
                sourceEncoding('ASCII')
                methodTarget(80, 0, 0)

--- a/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
@@ -6,15 +6,19 @@ import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_WORKER
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_PARSE_SECRET
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_BASE_URL
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_BASEURL
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_STATUS_SUCCESS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_STATUS_UNSTABLE_OR_WORSE
+import org.yaml.snakeyaml.Yaml
 
 /*
 Example secret YAML file used by this script
 publicJobConfig:
     open : true/false
     jobName : name-of-jenkins-job-to-be
+    subsetJob : name-of-test-subset-job
+    repoName : name-of-github-edx-repo
     testengUrl: testeng-github-url-segment
     platformUrl : platform-github-url-segment
     testengCredential : n/a
@@ -54,10 +58,9 @@ Map secretMap = [:]
 try {
     out.println('Parsing secret YAML file')
     /* Parse k:v pairs from the secret file referenced by secretFileVariable */
-    Thread thread = Thread.currentThread()
-    Build build = thread?.executable
-    Map envVarsMap = build.parent.builds[0].properties.get("envVars")
-    secretMap = JENKINS_PUBLIC_PARSE_SECRET.call(secretFileVariable, envVarsMap, out)
+    String contents = new File("${EDX_PLATFORM_TEST_PYTHON_SECRET}").text
+    Yaml yaml = new Yaml()
+    secretMap = yaml.load(contents)
     out.println('Successfully parsed secret YAML file')
 }
 catch (any) {
@@ -74,6 +77,8 @@ secretMap.each { jobConfigs ->
     /* TODO: Use/Build a more robust test framework for this */
     assert jobConfig.containsKey('open')
     assert jobConfig.containsKey('jobName')
+    assert jobConfig.containsKey('subsetJob')
+    assert jobConfig.containsKey('repoName')
     assert jobConfig.containsKey('testengUrl')
     assert jobConfig.containsKey('platformUrl')
     assert jobConfig.containsKey('testengCredential')
@@ -81,6 +86,7 @@ secretMap.each { jobConfigs ->
     assert jobConfig.containsKey('platformCloneReference')
     assert jobConfig.containsKey('hipchat')
     assert jobConfig.containsKey('email')
+
     buildFlowJob(jobConfig['jobName']) {
 
         /* For non-open jobs, enable project based security */
@@ -94,14 +100,21 @@ secretMap.each { jobConfigs ->
         parameters {
             stringParam(stringParams.name, stringParams.default, stringParams.description)
         }        
+        properties {
+              githubProjectUrl(JENKINS_PUBLIC_GITHUB_BASEURL + jobConfig['platformUrl'])
+        }    
         logRotator JENKINS_PUBLIC_LOG_ROTATOR() //Discard build after a certain amount of days
         concurrentBuild() //concurrent builds can happen
         label('flow-worker-python') //restrict to flow-worker-lettuce
         checkoutRetryCount(5)
+        environmentVariables {
+            env("SUBSET_JOB", jobConfig['subsetJob'])
+            env("REPO_NAME", jobConfig['repoName'])
+        }
         multiscm {
             git { //using git on the branch and url, clean before checkout
                 remote {
-                    github(jobConfig['testengUrl'])
+                    url(JENKINS_PUBLIC_GITHUB_BASEURL + jobConfig['testengUrl'] + '.git')
                     if (!jobConfig['open'].toBoolean()) {
                         credentials(jobConfig['testengCredential'])
                     }
@@ -115,7 +128,7 @@ secretMap.each { jobConfigs ->
             }
            git { //using git on the branch and url, clone, clean before checkout
                 remote {
-                    github(jobConfig['platformUrl'])
+                    url(JENKINS_PUBLIC_GITHUB_BASEURL + jobConfig['platformUrl'] + '.git')
                     refspec('+refs/heads/master:refs/remotes/origin/master')
                     if (!jobConfig['open'].toBoolean()) {
                         credentials(jobConfig['platformCredential'])
@@ -129,7 +142,7 @@ secretMap.each { jobConfigs ->
                         reference("\$HOME/" + jobConfig['platformCloneReference'])
                         timeout(10)
                     }
-                    relativeTargetDirectory('edx-platform')
+                    relativeTargetDirectory(jobConfig['repoName'])
                 }
             }
         }

--- a/platform/jobs/edxPlatformTestSubset.groovy
+++ b/platform/jobs/edxPlatformTestSubset.groovy
@@ -13,7 +13,7 @@ Example secret YAML file used by this script
 publicJobConfig:
     open : true/false
     jobName : name-of-jenkins-job-to-be
-    url : github-url-segment 
+    url : full-github-url
     credential : n/a
     cloneReference : clone/.git
 */
@@ -94,7 +94,7 @@ secretMap.each { jobConfigs ->
 
         logRotator JENKINS_PUBLIC_LOG_ROTATOR()
         properties {
-            githubProjectUrl('https://github.com/'.concat(jobConfig['url']))
+            githubProjectUrl(jobConfig['url'])
         }
         
         /* For non-open jobs, enable project based security */
@@ -119,7 +119,7 @@ secretMap.each { jobConfigs ->
         scm {
             git {
                 remote {
-                    github(jobConfig['url'], 'https', 'github.com')
+                    url(jobConfig['url'] + '.git')
                     refspec('+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/*')
                     if (!jobConfig['open'].toBoolean()) {
                         credentials(jobConfig['credential'])
@@ -150,6 +150,9 @@ secretMap.each { jobConfigs ->
             colorizeOutput('gnome-terminal')
             environmentVariables {
                 groovy(envVarScript)
+            }
+            if (!jobConfig['open'].toBoolean()) {
+                sshAgent(jobConfig['credential'])
             }
             buildName('#\${BUILD_NUMBER}: \${ENV,var=\"TEST_SUITE\"} \${ENV,var=\"SHARD\"}')
         }

--- a/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
@@ -79,9 +79,9 @@ class JenkinsPublicConstants {
         return secretMap
     }
     
-    public static final String JENKINS_PUBLIC_JUNIT_REPORTS = 'edx-platform/**/nosetests.xml,edx-platform/reports/acceptance/*.xml,' +
-                                                              'edx-platform/reports/quality.xml,edx-platform/reports/javascript/' +
-                                                              'javascript_xunit*.xml,edx-platform/reports/bok_choy/xunit.xml,edx-platform/' +
+    public static final String JENKINS_PUBLIC_JUNIT_REPORTS = 'edx-platform*/**/nosetests.xml,edx-platform*/reports/acceptance/*.xml,' +
+                                                              'edx-platform*/reports/quality.xml,edx-platform*/reports/javascript/' +
+                                                              'javascript_xunit*.xml,edx-platform*/reports/bok_choy/xunit.xml,edx-platform*/' +
                                                               'reports/bok_choy/**/xunit.xml'
 
     public static final Closure JENKINS_PUBLIC_GITHUB_STATUS_PENDING = { predefinedPropsMap ->

--- a/src/test/groovy/platform/edxPlatformTestSubsetSpec.groovy
+++ b/src/test/groovy/platform/edxPlatformTestSubsetSpec.groovy
@@ -167,7 +167,7 @@ class edxPlatformTestSubsetSpec extends Specification {
         Node scm = project.childNodes().find { it.name == "scm" }
         Node urc = scm.childNodes().find { it.name == "userRemoteConfigs" }
         Node giturc = urc.childNodes().find { it.name == "hudson.plugins.git.UserRemoteConfig" }
-        giturc.childNodes().any { it.name == "url"  && it.text() == url }
+        giturc.childNodes().any { it.name == "url" && it.text() == url }
         if (!open) {
             giturc.childNodes().any { it.name == "credentialsId" && it.text() ==  cred }
         }

--- a/src/test/groovy/platform/edxPlatformTestSubsetSpec.groovy
+++ b/src/test/groovy/platform/edxPlatformTestSubsetSpec.groovy
@@ -167,7 +167,7 @@ class edxPlatformTestSubsetSpec extends Specification {
         Node scm = project.childNodes().find { it.name == "scm" }
         Node urc = scm.childNodes().find { it.name == "userRemoteConfigs" }
         Node giturc = urc.childNodes().find { it.name == "hudson.plugins.git.UserRemoteConfig" }
-        giturc.childNodes().any { it.name == "url" && it.text() == "https://github.com/${url}.git" }
+        giturc.childNodes().any { it.name == "url"  && it.text() == url }
         if (!open) {
             giturc.childNodes().any { it.name == "credentialsId" && it.text() ==  cred }
         }
@@ -176,9 +176,9 @@ class edxPlatformTestSubsetSpec extends Specification {
         cloneOption.childNodes().any { it.name == "reference" && it.text() == "\$HOME/${clone}"}
 
         where:
-        job                                 | open  | url                           | cred          | clone
-        "edx-platform-test-subset"          | true  | "edx/edx-platform"            | false         | "edx-platform-clone/.git"
-        "edx-platform-test-subset_2"        | false | "edx/edx-platform-2"          | "password"    | "edx-platform-2-clone/.git"
+        job                                 | open  | url                                           | cred          | clone
+        "edx-platform-test-subset"          | true  | "https://github.com/edx/edx-platform.git"     | false         | "edx-platform-clone/.git"
+        "edx-platform-test-subset_2"        | false | "ssh://github.com/edx/edx-platform-2.git"     | "password"    | "edx-platform-2-clone/.git"
 
 
     }

--- a/src/test/resources/platform/secrets/edx-platform-test-subset-secret.yml
+++ b/src/test/resources/platform/secrets/edx-platform-test-subset-secret.yml
@@ -3,12 +3,12 @@
 publicJobConfig:
     open : true
     jobName : edx-platform-test-subset
-    url : edx/edx-platform
+    url : https://github.com/edx/edx-platform
     credential : n/a
     cloneReference : edx-platform-clone/.git
 privateJobConfig:
     open : false
     jobName : edx-platform-test-subset_2
-    url : edx/edx-platform-2
+    url : ssh://github.com/edx/edx-platform-2
     credential : password
     cloneReference : edx-platform-2-clone/.git


### PR DESCRIPTION
@benpatterson @jzoldak @estute 
Hi All! This is a large PR but the goal was to go through and refactor all the jobs to work well various repos. Also, a lot of the manual changing of the bok choy pr job and test subset job is reflected here. 
 
Changes to All Files:
1) References to edx-platform were changed to edx-platform* (in various archivers) or something specific to the directory the files were checked out to
2) Instead of always checking out to a directory called edx-platform, it checks out to one whose name matches the repo name
3) Added the new parsing method that works better with testing
4) In general, calling github() was replaced by url()

Changes to Buildflow Jobs (in particular):
1) Inject environment variables to specify which test-subset job to use, changes will be reflected in the sharding scripts as well

Changes to Test-Subset:
1) Use different urls to access the repo
2) Use ssh agent if the job is not open