### PR TITLE
JS PR DSL and A11y DSL Improvements

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -37,7 +37,6 @@ try {
     out.println('Successfully parsed secret YAML file')
 }
 catch (any) {
-    out.println(any)
     out.println('Jenkins DSL: Error parsing secret YAML file')
     out.println('Exiting with error code 1')
     return 1


### PR DESCRIPTION
@estute @jzoldak 
There are 3 things here. 1) Creating the JS PR DSL script. 2) Fixing the A11y PR DSL script to correctly work with both repos. 3) Using the combined GHPRB secret instead of having it in each individual file.

Whenever you have a chance please look it over :)