### PR TITLE
Inject Env Var for Python Unit Tests to work

### DIFF
--- a/platform/jobs/edxPlatformUnitCoverage.groovy
+++ b/platform/jobs/edxPlatformUnitCoverage.groovy
@@ -121,6 +121,9 @@ secretMap.each { jobConfigs ->
         }
         concurrentBuild(true)
         label('coverage-worker')
+        environmentVariables {
+            env('SUBSET_JOB', jobConfig['subsetJob'])
+        }
         scm {
             git {
                 remote {


### PR DESCRIPTION
@estute @jzoldak @benpatterson 
In order to allow the .coveragerc file to be more flexible and work for the repos, we need to inject the name of the subset job as an environment variable. The name of the coverage job is already present as an environment variable. 