### PR TITLE
Ansible libraries hardcode #!/usr/bin/python

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
       && apt-get install -y sudo python-dev python-pip libmysqlclient-dev \
       && rm -rf /var/lib/apt/lists/*
 RUN echo "jenkins ALL=NOPASSWD: ALL" >> /etc/sudoers
+RUN curl https://raw.githubusercontent.com/edx/configuration/master/requirements.txt > /tmp/system-ansible.txt && pip install -r /tmp/system-ansible.txt
 
 USER jenkins
 COPY plugins.txt /usr/share/jenkins/plugins.txt


### PR DESCRIPTION
This fails when a library requires boto or some other package which has
not been installed in the system python.

@e0d this is horrible
