### PR TITLE
tweak script to use keys instead of roles

### DIFF
--- a/src/test/groovy/testeng/backupJenkinsSpec.groovy
+++ b/src/test/groovy/testeng/backupJenkinsSpec.groovy
@@ -160,8 +160,6 @@ class backupJenkinsSpec extends Specification {
         Node content = info.childNodes().find { it.name == 'propertiesContent' }
         String envVars = content.text()
         envVars.contains("REGION=${region}")
-        envVars.contains("AWS_ACCESS_KEY_ID=${accessKeyId}")
-        envVars.contains("AWS_SECRET_ACCESS_KEY=${secretAccessKey}")
         // Command
         Node builders = project.childNodes().find { it.name == 'builders' }
         Node venv = builders.childNodes().find { it.name == 'jenkins.plugins.shiningpanda.builders.VirtualenvBuilder' }

--- a/src/test/groovy/testeng/backupJenkinsSpec.groovy
+++ b/src/test/groovy/testeng/backupJenkinsSpec.groovy
@@ -160,7 +160,7 @@ class backupJenkinsSpec extends Specification {
         Node content = info.childNodes().find { it.name == 'propertiesContent' }
         String envVars = content.text()
         envVars.contains("REGION=${region}")
-        envVars.contains("AWS_ACCESS_KEY_ID=${accessKey}")
+        envVars.contains("AWS_ACCESS_KEY_ID=${accessKeyId}")
         envVars.contains("AWS_SECRET_ACCESS_KEY=${secretAccessKey}")
         // Command
         Node builders = project.childNodes().find { it.name == 'builders' }
@@ -171,9 +171,9 @@ class backupJenkinsSpec extends Specification {
         }
 
         where:
-        job                     | instance | region      | vol       | accessKey | secretAccessKey
-        'backup-build-jenkins'  | 'build'  | 'us-east.1' | 'vol-123' | 'b123'    | 'b1234'
-        'backup-test-jenkins'   | 'test'   | 'us-west.1' | 'vol-456' | 't123'    | 't1234'
+        job                     | instance | region      | vol       | accessKeyId | secretAccessKey
+        'backup-build-jenkins'  | 'build'  | 'us-east.1' | 'vol-123' | 'b123'      | 'b1234'
+        'backup-test-jenkins'   | 'test'   | 'us-west.1' | 'vol-456' | 't123'      | 't1234'
 
     }
 

--- a/src/test/groovy/testeng/backupJenkinsSpec.groovy
+++ b/src/test/groovy/testeng/backupJenkinsSpec.groovy
@@ -160,6 +160,8 @@ class backupJenkinsSpec extends Specification {
         Node content = info.childNodes().find { it.name == 'propertiesContent' }
         String envVars = content.text()
         envVars.contains("REGION=${region}")
+        envVars.contains("AWS_ACCESS_KEY_ID=${accessKey}")
+        envVars.contains("AWS_SECRET_ACCESS_KEY=${secretAccessKey}")
         // Command
         Node builders = project.childNodes().find { it.name == 'builders' }
         Node venv = builders.childNodes().find { it.name == 'jenkins.plugins.shiningpanda.builders.VirtualenvBuilder' }
@@ -169,9 +171,9 @@ class backupJenkinsSpec extends Specification {
         }
 
         where:
-        job                     | instance | region      | vol
-        'backup-build-jenkins'  | 'build'  | 'us-east.1' | 'vol-123'
-        'backup-test-jenkins'   | 'test'   | 'us-west.1' | 'vol-456'
+        job                     | instance | region      | vol       | accessKey | secretAccessKey
+        'backup-build-jenkins'  | 'build'  | 'us-east.1' | 'vol-123' | 'b123'    | 'b1234'
+        'backup-test-jenkins'   | 'test'   | 'us-west.1' | 'vol-456' | 't123'    | 't1234'
 
     }
 

--- a/src/test/resources/testeng/secrets/backup-jenkins-secret.yml
+++ b/src/test/resources/testeng/secrets/backup-jenkins-secret.yml
@@ -2,7 +2,7 @@ buildJenkinsConfig:
     jenkinsInstance : build
     region : us-east.1
     volumeId : vol-123
-    accessKey : b123
+    accessKeyId : b123
     secretAccessKey : b1234
     hipchat : 123abc
     email : email@address.com
@@ -10,7 +10,7 @@ testJenkinsConfig:
     jenkinsInstance : test
     region : us-west.1
     volumeId : vol-456
-    accessKey : t123
+    accessKeyId : t123
     secretAccessKey : t1234
     hipchat : 123abc
     email : email@address.com

--- a/src/test/resources/testeng/secrets/backup-jenkins-secret.yml
+++ b/src/test/resources/testeng/secrets/backup-jenkins-secret.yml
@@ -2,11 +2,15 @@ buildJenkinsConfig:
     jenkinsInstance : build
     region : us-east.1
     volumeId : vol-123
+    accessKey : b123
+    secretAccessKey : b1234
     hipchat : 123abc
     email : email@address.com
 testJenkinsConfig:
     jenkinsInstance : test
     region : us-west.1
     volumeId : vol-456
+    accessKey : t123
+    secretAccessKey : t1234
     hipchat : 123abc
     email : email@address.com

--- a/testeng/jobs/backupJenkins.groovy
+++ b/testeng/jobs/backupJenkins.groovy
@@ -28,7 +28,7 @@ Config:
     jenkinsInstance : test
     volumeId : vol-123
     region : us-west.1
-    accessKey : 123
+    accessKeyId : 123
     secretAccessKey: 123
     hipchat : hipchat token
     email : email@address.com
@@ -42,7 +42,7 @@ secretMap.each { jobConfigs ->
     assert jobConfig.containsKey('jenkinsInstance')
     assert jobConfig.containsKey('volumeId')
     assert jobConfig.containsKey('region')
-    assert jobConfig.containsKey('accessKey')
+    assert jobConfig.containsKey('accessKeyId')
     assert jobConfig.containsKey('secretAccessKey')
     assert jobConfig.containsKey('hipchat')
     assert jobConfig.containsKey('email')
@@ -94,7 +94,7 @@ secretMap.each { jobConfigs ->
 
         // load env vars for executing awscli commands
         environmentVariables {
-            env('AWS_ACCESS_KEY_ID', jobConfig['accessKey'])
+            env('AWS_ACCESS_KEY_ID', jobConfig['accessKeyId'])
             env('AWS_SECRET_ACCESS_KEY', jobConfig['secretAccessKey'])
             env('AWS_DEFAULT_REGION', jobConfig['region'])
         }

--- a/testeng/jobs/backupJenkins.groovy
+++ b/testeng/jobs/backupJenkins.groovy
@@ -28,6 +28,8 @@ Config:
     jenkinsInstance : test
     volumeId : vol-123
     region : us-west.1
+    accessKey : 123
+    secretAccessKey: 123
     hipchat : hipchat token
     email : email@address.com
 */
@@ -40,6 +42,8 @@ secretMap.each { jobConfigs ->
     assert jobConfig.containsKey('jenkinsInstance')
     assert jobConfig.containsKey('volumeId')
     assert jobConfig.containsKey('region')
+    assert jobConfig.containsKey('accessKey')
+    assert jobConfig.containsKey('secretAccessKey')
     assert jobConfig.containsKey('hipchat')
     assert jobConfig.containsKey('email')
 
@@ -68,9 +72,15 @@ secretMap.each { jobConfigs ->
             }
         }
 
-        // Run snapshotting script once a day, at 1:00 AM
+        // Run snapshotting script once a day, when there is usually no Jenkins activity
         triggers {
-            cron('0 1 * * *')
+            if (jobConfig['jenkinsInstance'] == 'build') {
+                cron('0 1 * * *')
+            }
+            // test jenkins
+            else {
+                cron('0 2 * * *')
+            }
         }
 
         wrappers {
@@ -82,19 +92,22 @@ secretMap.each { jobConfigs ->
             colorizeOutput('xterm')
         }
 
+        // load env vars for executing awscli commands
         environmentVariables {
+            env('AWS_ACCESS_KEY_ID', jobConfig['accessKey'])
+            env('AWS_SECRET_ACCESS_KEY', jobConfig['secretAccessKey'])
             env('AWS_DEFAULT_REGION', jobConfig['region'])
         }
         
         // Sync currently paged files to disk
-        String script = "set -o pipefail\n"
-        script += "sync\n"
+        String script = "sync\n"
         // This might seem overkill, but in case the pip requirements change, read them from
         // the requirements file in the workspace
         readFileFromWorkspace('testeng/resources/requirements.txt').split("\n").each { line ->
             script += "pip install --exists-action w ${line}\n"
         }
-        script += "aws ec2 create-snapshot --volume-id ${jobConfig['volumeId']} --description 'Automatic ${jobConfig['jenkinsInstance']} jenkins snapshot' |tee \${WORKSPACE}/snapshot-out"
+        script += "aws ec2 create-snapshot --volume-id ${jobConfig['volumeId']} --description 'Automatic ${jobConfig['jenkinsInstance']} jenkins snapshot' > \${WORKSPACE}/snapshot-out\n"
+        script += "cat \${WORKSPACE}/snapshot-out"
         steps {
             virtualenv {
                 clear()


### PR DESCRIPTION
@JZ switched script to use aws keys following our conversation this morning. Also, set the jobs produced by this to run at different times. Also, I simply cat out the script output, since the virtualenv plugin is hardwired to use dash, not bash, and therefore no pipefail options.