### PR TITLE
fix var names and add xunit archival

### DIFF
--- a/platform/jobs/edxEndToEndRepoMasterWeeklyJob.groovy
+++ b/platform/jobs/edxEndToEndRepoMasterWeeklyJob.groovy
@@ -146,9 +146,12 @@ secretMap.each { jobConfigs ->
         }
 
         publishers {
+            // Achive XML report as XUnit for ease of analysis
             archiveJunit('reports/*.xml') {
                 allowEmptyResults(false)
             }
+            // Also, archive XML reports so they can be downloaded
+            archiveArtifacts('reports/*.xml')
             mailer(jobConfig['email'])
       }
     }

--- a/platform/jobs/edxEndToEndRepoMasterWeeklyJob.groovy
+++ b/platform/jobs/edxEndToEndRepoMasterWeeklyJob.groovy
@@ -28,22 +28,22 @@ PrintStream out = config['out']
 
 stringParams = [
     [
-    name: 'courseOrg',
+    name: 'COURSE_ORG',
     description: 'Organization name of the course',
     default: 'ArbiRaees'
     ],
     [
-    name: 'courseNumber',
+    name: 'COURSE_NUMBER',
     description: 'Course number',
     default: 'AR-1000'
     ],
     [
-    name: 'courseRun',
+    name: 'COURSE_RUN',
     description: 'Term in which course will run',
     default: 'fall'
     ],
     [
-    name: 'courseDisp',
+    name: 'COURSE_DISPLAY_NAME',
     description: 'Display name of the course',
     default: 'Manual Smoke Test Course 1 - Auto'
     ]
@@ -140,14 +140,16 @@ secretMap.each { jobConfigs ->
         wrappers {
             timeout {
                absolute(75)
-           }
-           timestamps()
-           colorizeOutput('gnome-terminal')
+            }
+            timestamps()
+            colorizeOutput('gnome-terminal')
         }
 
         publishers {
-          archiveArtifacts('reports/*.xml')
-          mailer(jobConfig['email'])
+            archiveJunit('reports/*.xml') {
+                allowEmptyResults(false)
+            }
+            mailer(jobConfig['email'])
       }
     }
 }


### PR DESCRIPTION
@benpatterson @MuddasserHussain changed env var names to match test script. Also, if we use the JUnit archiver, it is much easier to navigate the results via Jenkins. However, I am not sure if we want this- is it crucial that the result xml is downloadable?