### PR TITLE
Build image with Python 3.5.2 installed

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -10,3 +10,13 @@ RUN echo "jenkins ALL=NOPASSWD: ALL" >> /etc/sudoers
 USER jenkins
 COPY plugins.txt /usr/share/jenkins/plugins.txt
 RUN /usr/local/bin/plugins.sh /usr/share/jenkins/plugins.txt
+
+USER root
+RUN apt-get update \
+    && apt-get install -y libssl-dev openssl \
+    && wget https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tgz \
+    && tar xzvf Python-3.5.2.tgz \
+    && cd Python-3.5.2 \
+    && ./configure --prefix=/usr/local \
+    && make \
+    && make install


### PR DESCRIPTION
Builds Python 3.5.2 from source. There's no Jessie PPA available.

@jibsheet 