### PR TITLE
parameterize worker in subset job

### DIFF
--- a/platform/jobs/edxPlatformTestSubset.groovy
+++ b/platform/jobs/edxPlatformTestSubset.groovy
@@ -110,10 +110,13 @@ secretMap.each { jobConfigs ->
             stringParams.each { param ->
                 stringParam(param.name, param.default, param.description)
             }
+            labelParam('WORKER_LABEL') {
+                description('Select a Jenkins worker label for running this job')
+                defaultValue(JENKINS_PUBLIC_WORKER)
+            }
         }
 
         concurrentBuild(true)
-        label(JENKINS_PUBLIC_WORKER)
 
         /*  configure project to pull from a github repo */
         scm {


### PR DESCRIPTION
@benpatterson 
stage 1: subset job can take a worker label. if deployed this will not affect our current set up, bc the testeng-ci dsls don't yet know about this param and the default value will be chosen