### PR TITLE
add closure for masking passwords

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     
     compile 'org.yaml:snakeyaml:1.17'
     compile 'org.codehaus.groovy:groovy:2.1.3'
+    compile "org.jenkins-ci.main:jenkins-war:${jenkinsVersion}"
 
     jobsCompile 'org.yaml:snakeyaml:1.17'
     jobsCompile 'org.codehaus.groovy:groovy:2.1.3'

--- a/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
@@ -1,6 +1,7 @@
 package org.edx.jenkins.dsl
 
 import org.yaml.snakeyaml.Yaml
+import hudson.util.Secret
 
 class JenkinsPublicConstants {
 
@@ -165,4 +166,17 @@ class JenkinsPublicConstants {
         }
     }
 
+    // Reusable closure for configuring a masked password user parameter with a default value
+    // Input must be structured in the following format:
+    // [ name: String x, description: String y, default: String z ]
+    public static final Closure JENKINS_PUBLIC_MASKED_PASSWORD = { param ->
+        return {
+            it / 'properties' / 'hudson.model.ParametersDefinitionProperty' / parameterDefinitions << 'hudson.model.PasswordParameterDefinition' {
+                name param.name
+                defaultValue Secret.fromString(param.default.toString()).getEncryptedValue()
+                description param.description
+            }
+        }
+
+    }
 }

--- a/src/test/groovy/testeng/buildPackerAMIjobSpec.groovy
+++ b/src/test/groovy/testeng/buildPackerAMIjobSpec.groovy
@@ -1,0 +1,137 @@
+package testeng
+
+import groovy.util.slurpersupport.GPathResult
+import groovy.util.slurpersupport.Node
+import javaposse.jobdsl.plugin.JenkinsJobManagement
+import javaposse.jobdsl.dsl.GeneratedItems
+import javaposse.jobdsl.dsl.GeneratedJob
+import javaposse.jobdsl.dsl.DslScriptLoader
+import javaposse.jobdsl.dsl.JobManagement
+import org.junit.ClassRule
+import org.jvnet.hudson.test.JenkinsRule
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class buildPackerAMIjobSpec extends Specification {
+
+    @Shared @ClassRule
+    JenkinsRule jenkinsRule = new JenkinsRule()
+
+    @Shared DslScriptLoader loader
+    @Shared JobManagement jm
+
+    @Shared File dslScript = new File('testeng/jobs/buildPackerAMIjob.groovy')
+    @Shared String baseSecretPath = 'src/test/resources/testeng/secrets'
+    @Shared String secretVar = 'BUILD_PACKER_AMI_SECRET'
+
+    @Shared List pList = [ 'com.cloudbees.plugins.credentials.CredentialsProvider.Delete:edx',
+                                'com.cloudbees.plugins.credentials.CredentialsProvider.ManageDomains:edx',
+                                'hudson.model.Item.Read:edx', 'hudson.model.Item.Configure:edx',
+                                'hudson.model.Item.Workspace:edx', 'hudson.model.Run.Delete:edx',
+                                'hudson.model.Item.Discover:edx', 'hudson.scm.SCM.Tag:edx',
+                                'com.cloudbees.plugins.credentials.CredentialsProvider.View:edx',
+                                'hudson.model.Item.Build:edx', 'hudson.model.Item.Move:edx',
+                                'com.cloudbees.plugins.credentials.CredentialsProvider.Create:edx',
+                                'hudson.model.Item.Cancel:edx', 'hudson.model.Item.Delete:edx',
+                                'hudson.model.Run.Update:edx',
+                                'com.cloudbees.plugins.credentials.CredentialsProvider.Update:edx' ]
+    /*
+    * Helper function: loadSecret
+    * return a JenkinsJobManagement object containing a mapping of secret variables to secret values
+    */
+    JenkinsJobManagement loadSecret(secretKey, secretValue) {
+        Map<String,String> envVars = [:]
+        envVars.put(secretKey, secretValue)
+        JenkinsJobManagement jjm = new JenkinsJobManagement(System.out, envVars, new File('.'))
+        jjm
+    }
+
+    /*
+    * TODO: condense this into a shared helper
+    * Helper function: loadSecrets
+    * return a JenkinsJobManagement object containing a mapping of secret variables to secret values
+    */
+    JenkinsJobManagement loadSecrets(envVars) {
+        JenkinsJobManagement jjm = new JenkinsJobManagement(System.out, envVars, new File('.'))
+        jjm
+    }
+
+    /**
+    * Using an evironment variable that points to a non-existent secret file, ensure that no
+    * jobs are created.
+    **/
+    void 'test non-existent secret file is handled correctly'() {
+
+        setup:
+        String secretPath = baseSecretPath + '/non-existent-file.yml'
+        jm =  loadSecret(secretVar, secretPath)
+        loader = new DslScriptLoader(jm)
+
+        when:
+        GeneratedItems generatedItems = loader.runScript(dslScript.text)
+
+        then:
+        generatedItems.jobs.size() == 0
+    }
+
+    /**
+    * Using an invalid yaml secret, ensure that the appropriate exceptions are thrown, and
+    * that no jobs are created.
+    **/
+    void 'test invalid yaml is handled correctly'() {
+
+        setup:
+        String secretPath = baseSecretPath + '/corrupt-secret.yml'
+        jm =  loadSecret(secretVar, secretPath)
+        loader = new DslScriptLoader(jm)
+
+        when:
+        GeneratedItems generatedItems = loader.runScript(dslScript.text)
+
+        then:
+        generatedItems.jobs.size() == 0
+    }
+
+    /**
+    * Run the DSL script and verify that no exceptions were thrown by the dslScriptRunner
+    **/
+    void 'test no exceptions are thrown'() {
+
+        setup:
+        String secretPath = baseSecretPath + '/build-packer-ami-secret.yml'
+        jm =  loadSecret(secretVar, secretPath)
+        loader = new DslScriptLoader(jm)
+
+        when:
+        loader.runScript(dslScript.text)
+
+        then:
+        noExceptionThrown()
+
+    }
+
+    /**
+    * Run DSL jobs and verify that the output jobs are private to the organization
+    **/
+    void 'test jobs are private'() {
+
+        setup:
+        String secretPath = baseSecretPath + '/build-packer-ami-secret.yml'
+        jm =  loadSecret(secretVar, secretPath)
+        loader = new DslScriptLoader(jm)
+
+        when:
+        loader.runScript(dslScript.text)
+        GPathResult project = new XmlSlurper().parseText(jm.getConfig('build-packer-ami'))
+
+        then:
+        Node prop = project.childNodes().find { it.name == 'properties' }
+        Node privacyBlock = prop.childNodes().find { it.name == 'hudson.security.AuthorizationMatrixProperty' }
+        privacyBlock.childNodes().any { it.name == 'blocksInheritance' && it.text() == 'true' }
+        ArrayList<Node> permissions = privacyBlock.childNodes().findAll { it.name == 'permission' } 
+        permissions.each { pList.contains(it.text()) }
+
+    }
+
+}

--- a/src/test/resources/testeng/secrets/build-packer-ami-secret.yml
+++ b/src/test/resources/testeng/secrets/build-packer-ami-secret.yml
@@ -1,0 +1,9 @@
+BuildPackerAMIConfig:
+    awsAccessKeyId: ABC123
+    awsSecretAccessKey: qwerty123
+    jenkinsWorkerAMI: ami-12345
+    webPageTestBaseAMI: ami-67890
+    githubToken: aaabbbccc123
+    toolsTeam: [ 'apple', 'banana', 'cherry' ]
+    email : email@address.com
+    hipchat : abc123


### PR DESCRIPTION
@benpatterson @jzoldak 
this will allow users to input an ami base id (rather than having to make the change in the packer scripts. masked the param, as per @jibsheet advice