### PR TITLE
fix issue with git browser

### DIFF
--- a/platform/jobs/ecommerceEndToEndTestJobs.groovy
+++ b/platform/jobs/ecommerceEndToEndTestJobs.groovy
@@ -177,7 +177,13 @@ job(jobName) {
     /* Run on jenkins-worker */
     label(JENKINS_PUBLIC_WORKER)
     scm {
-        github('edx/ecommerce', '*/master')
+        git {
+            remote {
+                url('https://github.com/edx/ecommerce.git')
+            }
+            browser()
+            branch('*/master')
+        }
     }
     wrappers {
         maskPasswords() //can't see passwords in console

--- a/platform/jobs/marketingSiteEndToEndTestJobs.groovy
+++ b/platform/jobs/marketingSiteEndToEndTestJobs.groovy
@@ -56,9 +56,10 @@ job(jobName) {
     scm {
         git {
             remote {
-                github('edx/edx-mktg')
+                url('https://github.com/edx/edx-mktg.git')
                 credentials(secretMap['credential'])
             }
+            browser()
             branch('*/master')
         }
     }

--- a/platform/jobs/programsEndToEndTestJobs.groovy
+++ b/platform/jobs/programsEndToEndTestJobs.groovy
@@ -130,7 +130,13 @@ job(jobName) {
     /* Run on jenkins-worker */
     label(JENKINS_PUBLIC_WORKER)
     scm {
-        github('edx/programs', '*/master')
+        git {
+            remote {
+                url('https://github.com/edx/programs.git')
+            }
+            browser()
+            branch('*/master')
+        }
     }
     wrappers {
         maskPasswords() //can't see passwords in console


### PR DESCRIPTION
@benpatterson @jzoldak 
this fixes the stacktrace jenkins throws when the github browser is used, and then you try to manually edit a job.