### PR TITLE
adjust ghprb in platform jobs to handle named release prs

### DIFF
--- a/platform/jobs/edxPlatformBokChoyPr.groovy
+++ b/platform/jobs/edxPlatformBokChoyPr.groovy
@@ -4,7 +4,7 @@ import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_BASEURL
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_WORKER
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_WHITELIST_BRANCH
 
 /*
 Example secret YAML file used by this script
@@ -18,6 +18,10 @@ publicJobConfig:
     testengCredential : n/a
     platformCredential : n/a
     platformCloneReference : clone/.git
+    workerLabel: worker-label
+    whitelistBranchRegex: 'release/*'
+    context: jenkins/test
+    triggerPhrase: 'jenkins run test'
 */
 
 /* stdout logger */
@@ -60,6 +64,10 @@ secretMap.each { jobConfigs ->
     assert jobConfig.containsKey('testengCredential')
     assert jobConfig.containsKey('platformCredential')
     assert jobConfig.containsKey('platformCloneReference')
+    assert jobConfig.containsKey('workerLabel')
+    assert jobConfig.containsKey('whitelistBranchRegex')
+    assert jobConfig.containsKey('context')
+    assert jobConfig.containsKey('triggerPhrase')
     assert ghprbMap.containsKey('admin')
     assert ghprbMap.containsKey('userWhiteList')
     assert ghprbMap.containsKey('orgWhiteList')
@@ -85,7 +93,7 @@ secretMap.each { jobConfigs ->
             env('REPO_NAME', jobConfig['repoName'])
         }
         parameters {
-            stringParam('WORKER_LABEL', JENKINS_PUBLIC_WORKER, 'Jenkins worker for running the test subset jobs')
+            stringParam('WORKER_LABEL', jobConfig['workerLabel'], 'Jenkins worker for running the test subset jobs')
         }
         multiscm {
             git { //using git on the branch and url, clean before checkout
@@ -126,16 +134,19 @@ secretMap.each { jobConfigs ->
             pullRequest {
                 admins(ghprbMap['admin'])
                 useGitHubHooks()
-                triggerPhrase('jenkins run bokchoy')
+                triggerPhrase(jobConfig['triggerPhrase'])
                 userWhitelist(ghprbMap['userWhiteList'])
                 orgWhitelist(ghprbMap['orgWhiteList'])
                 extensions {
                     commitStatus {
-                        context('jenkins/bokchoy')
+                        context(jobConfig['context'])
                     }
                 }
             }
         }
+
+        configure GHPRB_WHITELIST_BRANCH(jobConfig['whitelistBranchRegex'])
+
         dslFile('testeng-ci/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy')
         publishers { //publish JUnit Test report
             archiveJunit(JENKINS_PUBLIC_JUNIT_REPORTS)

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -2,9 +2,9 @@ package devops
 
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_WORKER
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_BASEURL
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_WHITELIST_BRANCH
 
 /*
 Example secret YAML file used by this script
@@ -16,7 +16,10 @@ publicJobConfig:
     repoName : name-of-github-edx-repo
     credential : n/a
     cloneReference : clone/.git
-*/
+    workerLabel: worker-label
+    whitelistBranchRegex: 'release/*'
+    context: jenkins/test
+    triggerPhrase: 'jenkins run test' */
 
 String archiveReports = 'edx-platform*/reports/**/*,edx-platform*/test_root/log/*.png,'
 archiveReports += 'edx-platform*/test_root/log/*.log,edx-platform*/test_root/log/hars/*.har,'
@@ -62,6 +65,10 @@ secretMap.each { jobConfigs ->
     assert jobConfig.containsKey('repoName')
     assert jobConfig.containsKey('credential')
     assert jobConfig.containsKey('cloneReference')
+    assert jobConfig.containsKey('workerLabel')
+    assert jobConfig.containsKey('whitelistBranchRegex')
+    assert jobConfig.containsKey('context')
+    assert jobConfig.containsKey('triggerPhrase')
     assert ghprbMap.containsKey('admin')
     assert ghprbMap.containsKey('userWhiteList')
     assert ghprbMap.containsKey('orgWhiteList')
@@ -82,7 +89,7 @@ secretMap.each { jobConfigs ->
         parameters {
             labelParam('WORKER_LABEL') {
                 description('Select a Jenkins worker label for running this job')
-                defaultValue(JENKINS_PUBLIC_WORKER)
+                defaultValue(jobConfig['workerLabel'])
             }
         }
         scm {
@@ -109,16 +116,19 @@ secretMap.each { jobConfigs ->
             pullRequest {
                 admins(ghprbMap['admin'])
                 useGitHubHooks()
-                triggerPhrase('jenkins run js')
+                triggerPhrase(jobConfig['triggerPhrase'])
                 userWhitelist(ghprbMap['userWhiteList'])
                 orgWhitelist(ghprbMap['orgWhiteList'])
                 extensions {
                     commitStatus {
-                        context('jenkins/js')
+                        context(jobConfig['context'])
                     }
                 }
             }
         }
+
+        configure GHPRB_WHITELIST_BRANCH(jobConfig['whitelistBranchRegex'])
+
         wrappers {
             timeout {
                absolute(45)

--- a/platform/jobs/edxPlatformLettucePr.groovy
+++ b/platform/jobs/edxPlatformLettucePr.groovy
@@ -4,7 +4,7 @@ import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_BASEURL
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_WORKER
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_WHITELIST_BRANCH
 
 /*
 Example secret YAML file used by this script
@@ -18,6 +18,10 @@ publicJobConfig:
     testengCredential : n/a
     platformCredential : n/a
     platformCloneReference : clone/.git
+    workerLabel: worker-label
+    whitelistBranchRegex: 'release/*'
+    context: jenkins/test
+    triggerPhrase: 'jenkins run test'
 */
 
 /* stdout logger */
@@ -59,6 +63,10 @@ secretMap.each { jobConfigs ->
     assert jobConfig.containsKey('testengCredential')
     assert jobConfig.containsKey('platformCredential')
     assert jobConfig.containsKey('platformCloneReference')
+    assert jobConfig.containsKey('workerLabel')
+    assert jobConfig.containsKey('whitelistBranchRegex')
+    assert jobConfig.containsKey('context')
+    assert jobConfig.containsKey('triggerPhrase')
     assert ghprbMap.containsKey('admin')
     assert ghprbMap.containsKey('userWhiteList')
     assert ghprbMap.containsKey('orgWhiteList')
@@ -83,7 +91,7 @@ secretMap.each { jobConfigs ->
             env('REPO_NAME', jobConfig['repoName'])
         }
         parameters {
-            stringParam('WORKER_LABEL', JENKINS_PUBLIC_WORKER, 'Jenkins worker for running the test subset jobs')
+            stringParam('WORKER_LABEL', jobConfig['workerLabel'], 'Jenkins worker for running the test subset jobs')
         }
         multiscm {
             git {
@@ -124,16 +132,19 @@ secretMap.each { jobConfigs ->
             pullRequest {
                 admins(ghprbMap['admin'])
                 useGitHubHooks()
-                triggerPhrase('jenkins run lettuce')
+                triggerPhrase(jobConfig['triggerPhrase'])
                 userWhitelist(ghprbMap['userWhiteList'])
                 orgWhitelist(ghprbMap['orgWhiteList'])
                 extensions {
                     commitStatus {
-                        context('jenkins/lettuce')
+                        context(jobConfig['context'])
                     }
                 }
             }
         }
+
+        configure GHPRB_WHITELIST_BRANCH(jobConfig['whitelistBranchRegex'])
+
         dslFile('testeng-ci/jenkins/flow/pr/edx-platform-lettuce-pr.groovy')
         publishers {
             archiveJunit(JENKINS_PUBLIC_JUNIT_REPORTS)

--- a/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
@@ -166,6 +166,16 @@ class JenkinsPublicConstants {
         }
     }
 
+    public static final Closure GHPRB_WHITELIST_BRANCH(String branchRegex) {
+        return {
+            it / triggers / 'org.jenkinsci.plugins.ghprb.GhprbTrigger' << whiteListTargetBranches {
+                'org.jenkinsci.plugins.ghprb.GhprbBranch' {
+                    branch branchRegex
+                }
+            }
+        }
+    }
+
     // Reusable closure for configuring a masked password user parameter with a default value
     // Input must be structured in the following format:
     // [ name: String x, description: String y, default: String z ]

--- a/src/test/resources/platform/secrets/edx-platform-quality-pr-secret.yml
+++ b/src/test/resources/platform/secrets/edx-platform-quality-pr-secret.yml
@@ -6,7 +6,11 @@ publicJobConfig:
     platformCredential : n/a
     platformCloneReference : edx-platform-clone/.git
     protocol : "https://github.com/"
- 
+    workerLabel: worker-label
+    whitelistBranchRegex: 'master'
+    context: 'jenkins/quality'
+    triggerPhrase : 'jenkins run quality'
+
 privateJobConfig:
     open : false
     jobName : edx-platform-quality-pr_2
@@ -15,3 +19,7 @@ privateJobConfig:
     platformCredential : password
     platformCloneReference : edx-platform-2-clone/.git
     protocol : "git@github.com:"
+    workerLabel: worker-label
+    whitelistBranchRegex: 'master'
+    context: 'jenkins/quality'
+    triggerPhrase : 'jenkins run quality'


### PR DESCRIPTION
@jzoldak @benpatterson 
PTAL when you get a chance. This allows a job to only build via GHPRB if the target branch of PR is in the jobs white list (or not in the white list ;) ). What that means is:
* normal PRs trigger the normal "edx-platform...pr" jobs. In the normal jobs, we white list every branch EXCEPT those who contain the "open-release/tree.master" naming scheme
* PRs against named release branches can only trigger the Jenkins job for that named release. Named release jobs ONLY white lists the target branch with the "open-release/tree.master" naming scheme