### PR TITLE
parameterize testeng-ci branch

### DIFF
--- a/platform/jobs/edxPlatformBokChoyMaster.groovy
+++ b/platform/jobs/edxPlatformBokChoyMaster.groovy
@@ -106,20 +106,6 @@ secretMap.each { jobConfigs ->
             env('REPO_NAME', jobConfig['repoName'])
         }
         multiscm {
-            git { //using git on the branch and url, clean before checkout
-                remote {
-                    url(JENKINS_PUBLIC_GITHUB_BASEURL + jobConfig['testengUrl'] + '.git')
-                    if (!jobConfig['open'].toBoolean()) {
-                        credentials(jobConfig['testengCredential'])
-                    }
-                }
-                branch(jobConfig['defaultTestengBranch'])
-                browser()
-                extensions {
-                    cleanBeforeCheckout()
-                    relativeTargetDirectory('testeng-ci')
-                }
-            }
            git { //using git on the branch and url, clone, clean before checkout
                 remote {
                     url(JENKINS_PUBLIC_GITHUB_BASEURL + jobConfig['platformUrl'] + '.git')
@@ -137,6 +123,20 @@ secretMap.each { jobConfigs ->
                     }
                     cleanBeforeCheckout()
                     relativeTargetDirectory(jobConfig['repoName'])
+                }
+            }
+            git { //using git on the branch and url, clean before checkout
+                remote {
+                    url(JENKINS_PUBLIC_GITHUB_BASEURL + jobConfig['testengUrl'] + '.git')
+                    if (!jobConfig['open'].toBoolean()) {
+                        credentials(jobConfig['testengCredential'])
+                    }
+                }
+                branch(jobConfig['defaultTestengBranch'])
+                browser()
+                extensions {
+                    cleanBeforeCheckout()
+                    relativeTargetDirectory('testeng-ci')
                 }
             }
         }

--- a/platform/jobs/edxPlatformBokChoyMaster.groovy
+++ b/platform/jobs/edxPlatformBokChoyMaster.groovy
@@ -27,6 +27,7 @@ publicJobConfig:
     refSpec : '+refs/heads/master:refs/remotes/origin/master'
     context : 'jenkins/test'
     defaultBranch : 'master'
+    defaultTestengBranch: 'master'
 */
 
 
@@ -76,6 +77,7 @@ secretMap.each { jobConfigs ->
     assert jobConfig.containsKey('refSpec')
     assert jobConfig.containsKey('context')
     assert jobConfig.containsKey('defaultBranch')
+    assert jobConfig.containsKey('defaultTestengBranch')
 
     buildFlowJob(jobConfig['jobName']) {
 
@@ -111,7 +113,7 @@ secretMap.each { jobConfigs ->
                         credentials(jobConfig['testengCredential'])
                     }
                 }
-                branch('*/master')
+                branch(jobConfig['defaultTestengBranch'])
                 browser()
                 extensions {
                     cleanBeforeCheckout()

--- a/platform/jobs/edxPlatformBokChoyPr.groovy
+++ b/platform/jobs/edxPlatformBokChoyPr.groovy
@@ -22,6 +22,7 @@ publicJobConfig:
     whitelistBranchRegex: 'release/*'
     context: jenkins/test
     triggerPhrase: 'jenkins run test'
+    defaultTestengBranch: 'master'
 */
 
 /* stdout logger */
@@ -68,6 +69,7 @@ secretMap.each { jobConfigs ->
     assert jobConfig.containsKey('whitelistBranchRegex')
     assert jobConfig.containsKey('context')
     assert jobConfig.containsKey('triggerPhrase')
+    assert jobConfig.containsKey('defaultTestengBranch')
     assert ghprbMap.containsKey('admin')
     assert ghprbMap.containsKey('userWhiteList')
     assert ghprbMap.containsKey('orgWhiteList')
@@ -103,7 +105,7 @@ secretMap.each { jobConfigs ->
                         credentials(jobConfig['testengCredential'])
                     }
                 }
-                branch('*/master')
+                branch(jobConfig['defaultTestengBranch'])
                 browser()
                 extensions {
                     relativeTargetDirectory('testeng-ci')

--- a/platform/jobs/edxPlatformLettuceMaster.groovy
+++ b/platform/jobs/edxPlatformLettuceMaster.groovy
@@ -27,6 +27,7 @@ publicJobConfig:
     refSpec : '+refs/heads/master:refs/remotes/origin/master'
     context : 'jenkins/test'
     defaultBranch : 'master'
+    defaultTestengBranch: 'master'
 */
 
 /* stdout logger */
@@ -75,6 +76,7 @@ secretMap.each { jobConfigs ->
     assert jobConfig.containsKey('refSpec')
     assert jobConfig.containsKey('context')
     assert jobConfig.containsKey('defaultBranch')
+    assert jobConfig.containsKey('defaultTestengBranch')
 
 
     buildFlowJob(jobConfig['jobName']) {
@@ -109,7 +111,7 @@ secretMap.each { jobConfigs ->
                         credentials(jobConfig['testengCredential'])
                     }
                 }
-                branch('*/master')
+                branch(jobConfig['defaultTestengBranch'])
                 browser()
                 extensions {
                     cleanBeforeCheckout()

--- a/platform/jobs/edxPlatformLettuceMaster.groovy
+++ b/platform/jobs/edxPlatformLettuceMaster.groovy
@@ -104,20 +104,6 @@ secretMap.each { jobConfigs ->
             env('REPO_NAME', jobConfig['repoName'])
         }
         multiscm {
-            git { //using git on the branch and url, clean before checkout
-                remote {
-                    url(JENKINS_PUBLIC_GITHUB_BASEURL + jobConfig['testengUrl'] + '.git')
-                    if (!jobConfig['open'].toBoolean()) {
-                        credentials(jobConfig['testengCredential'])
-                    }
-                }
-                branch(jobConfig['defaultTestengBranch'])
-                browser()
-                extensions {
-                    cleanBeforeCheckout()
-                    relativeTargetDirectory('testeng-ci')
-                }
-            }
             git { //using git on the branch and url, clone, clean before checkout
                 remote {
                     url(JENKINS_PUBLIC_GITHUB_BASEURL + jobConfig['platformUrl'] + '.git')
@@ -135,6 +121,20 @@ secretMap.each { jobConfigs ->
                     }
                     relativeTargetDirectory(jobConfig['repoName'])
                     cleanBeforeCheckout()
+                }
+            }
+            git { //using git on the branch and url, clean before checkout
+                remote {
+                    url(JENKINS_PUBLIC_GITHUB_BASEURL + jobConfig['testengUrl'] + '.git')
+                    if (!jobConfig['open'].toBoolean()) {
+                        credentials(jobConfig['testengCredential'])
+                    }
+                }
+                branch(jobConfig['defaultTestengBranch'])
+                browser()
+                extensions {
+                    cleanBeforeCheckout()
+                    relativeTargetDirectory('testeng-ci')
                 }
             }
         }

--- a/platform/jobs/edxPlatformLettucePr.groovy
+++ b/platform/jobs/edxPlatformLettucePr.groovy
@@ -22,6 +22,7 @@ publicJobConfig:
     whitelistBranchRegex: 'release/*'
     context: jenkins/test
     triggerPhrase: 'jenkins run test'
+    defaultTestengBranch: 'master'
 */
 
 /* stdout logger */
@@ -67,6 +68,7 @@ secretMap.each { jobConfigs ->
     assert jobConfig.containsKey('whitelistBranchRegex')
     assert jobConfig.containsKey('context')
     assert jobConfig.containsKey('triggerPhrase')
+    assert jobConfig.containsKey('defaultTestengBranch')
     assert ghprbMap.containsKey('admin')
     assert ghprbMap.containsKey('userWhiteList')
     assert ghprbMap.containsKey('orgWhiteList')
@@ -101,7 +103,7 @@ secretMap.each { jobConfigs ->
                         credentials(jobConfig['testengCredential'])
                     }
                 }
-                branch('*/master')
+                branch(jobConfig['defaultTestengBranch'])
                 browser()
                 extensions {
                     relativeTargetDirectory('testeng-ci')

--- a/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
@@ -27,6 +27,7 @@ publicJobConfig:
     refSpec : '+refs/heads/master:refs/remotes/origin/master'
     context : 'jenkins/test'
     defaultBranch : 'master'
+    defaultTestengBranch: 'master'
 */
 
 /* stdout logger */
@@ -75,6 +76,7 @@ secretMap.each { jobConfigs ->
     assert jobConfig.containsKey('refSpec')
     assert jobConfig.containsKey('context')
     assert jobConfig.containsKey('defaultBranch')
+    assert jobConfig.containsKey('defaultTestengBranch')
 
     buildFlowJob(jobConfig['jobName']) {
 
@@ -109,7 +111,7 @@ secretMap.each { jobConfigs ->
                         credentials(jobConfig['testengCredential'])
                     }
                 }
-                branch('*/master')
+                branch(jobConfig['defaultTestengBranch'])
                 browser()
                 extensions {
                     cleanBeforeCheckout()

--- a/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
@@ -104,20 +104,6 @@ secretMap.each { jobConfigs ->
             env('COVERAGE_JOB', jobConfig['coverageJob'])
         }
         multiscm {
-            git { //using git on the branch and url, clean before checkout
-                remote {
-                    url(JENKINS_PUBLIC_GITHUB_BASEURL + jobConfig['testengUrl'] + '.git')
-                    if (!jobConfig['open'].toBoolean()) {
-                        credentials(jobConfig['testengCredential'])
-                    }
-                }
-                branch(jobConfig['defaultTestengBranch'])
-                browser()
-                extensions {
-                    cleanBeforeCheckout()
-                    relativeTargetDirectory('testeng-ci')
-                }
-            }
            git { //using git on the branch and url, clone, clean before checkout
                 remote {
                     url(JENKINS_PUBLIC_GITHUB_BASEURL + jobConfig['platformUrl'] + '.git')
@@ -135,6 +121,20 @@ secretMap.each { jobConfigs ->
                         timeout(10)
                     }
                     relativeTargetDirectory(jobConfig['repoName'])
+                }
+            }
+            git { //using git on the branch and url, clean before checkout
+                remote {
+                    url(JENKINS_PUBLIC_GITHUB_BASEURL + jobConfig['testengUrl'] + '.git')
+                    if (!jobConfig['open'].toBoolean()) {
+                        credentials(jobConfig['testengCredential'])
+                    }
+                }
+                branch(jobConfig['defaultTestengBranch'])
+                browser()
+                extensions {
+                    cleanBeforeCheckout()
+                    relativeTargetDirectory('testeng-ci')
                 }
             }
         }

--- a/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
@@ -23,6 +23,7 @@ publicJobConfig:
     whitelistBranchRegex: 'release/*'
     context: jenkins/test
     triggerPhrase: 'jenkins run test'
+    defaultTestengBranch: 'master'
 */
 
 /* stdout logger */
@@ -68,6 +69,7 @@ secretMap.each { jobConfigs ->
     assert jobConfig.containsKey('whitelistBranchRegex')
     assert jobConfig.containsKey('context')
     assert jobConfig.containsKey('triggerPhrase')
+    assert jobConfig.containsKey('defaultTestengBranch')
     assert ghprbMap.containsKey('admin')
     assert ghprbMap.containsKey('userWhiteList')
     assert ghprbMap.containsKey('orgWhiteList')
@@ -102,7 +104,7 @@ secretMap.each { jobConfigs ->
                         credentials(jobConfig['testengCredential'])
                     }
                 }
-                branch('*/master')
+                branch(jobConfig['defaultTestengBranch'])
                 browser()
                 extensions {
                     cleanBeforeCheckout()


### PR DESCRIPTION
@jzoldak @benpatterson 

this will fix broken eucalyptus test, because testeng-ci needs to be tagged/branched in relative lockstep with the edx-platform