### PR TITLE
Ansible 2 needs these libraries to build deps

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER edxops
 USER root
 RUN apt-get update \
       && apt-get install -y sudo python-dev python-pip libmysqlclient-dev \
+         libssl-dev libffi-dev  \
       && rm -rf /var/lib/apt/lists/*
 RUN echo "jenkins ALL=NOPASSWD: ALL" >> /etc/sudoers
 


### PR DESCRIPTION
Otherwise the pip install of cryptography fails.

@e0d and I'll push a new edxops/jenkins:latest shortly