### PR TITLE
refactor e2e job for gocd pipeline testing

### DIFF
--- a/platform/jobs/edxEndToEndTestsJob.groovy
+++ b/platform/jobs/edxEndToEndTestsJob.groovy
@@ -1,0 +1,96 @@
+package platform
+
+import org.yaml.snakeyaml.Yaml
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_WORKER
+
+// The edx-e2e-tests job is run automatically on every deployment of the edx-platform
+// from the gocd pipeline.
+
+/* stdout logger */
+/* use this instead of println, because you can pass it into closures or other scripts. */
+Map config = [:]
+Binding bindings = getBinding()
+config.putAll(bindings.getVariables())
+PrintStream out = config['out']
+
+/* Map to hold the k:v pairs parsed from the secret file */
+Map mailingListMap = [:]
+try {
+    out.println('Parsing secret YAML file')
+    String mailingListSecretContents  = new File("${MAILING_LIST_SECRET}").text
+    Yaml yaml = new Yaml()
+    mailingListMap = yaml.load(mailingListSecretContents)
+    out.println('Successfully parsed secret YAML file')
+}
+catch (any) {
+    out.println('Jenkins DSL: Error parsing secret YAML file')
+    out.println('Exiting with error code 1')
+    return 1
+}
+
+assert mailingListMap.containsKey('e2e_test_mailing_list')
+
+job('edx-e2e-tests') {
+
+    description('Run end-to-end tests against an instance of the edx-platform')
+
+    authorization {
+        blocksInheritance(true)
+        permissionAll('edx')
+    }
+
+    logRotator JENKINS_PUBLIC_LOG_ROTATOR()
+    label(JENKINS_PUBLIC_WORKER)
+    // Disable concurrent builds because the environment in use is a shared
+    // resource, and concurrent builds can cause spurious test results
+    concurrentBuild(false)
+
+    parameters {
+        stringParam('COURSE_ORG', 'ArbiRaees', 'Organization name of the course')
+        stringParam('COURSE_NUMBER', 'AR-1000', 'Course number')
+        stringParam('COURSE_RUN', 'fall', 'Term in which course will run')
+        stringParam('COURSE_DISPLAY_NAME', 'Manual Smoke Test Course 1 - Auto', 'Display name of the course')
+    }
+
+    scm {
+        git {
+            remote {
+                url('https://github.com/edx/edx-e2e-tests.git')
+            }
+            branch('*/master')
+            browser()
+        }
+    }
+
+    wrappers {
+        timeout {
+            absolute(75)
+        }
+        timestamps()
+        colorizeOutput('gnome-terminal')
+        credentialsBinding {
+            string('BASIC_AUTH_USER', 'BASIC_AUTH_USER')
+            string('BASIC_AUTH_PASSWORD', 'BASIC_AUTH_PASSWORD')
+            string('USER_LOGIN_EMAIL', 'USER_LOGIN_EMAIL')
+            string('USER_LOGIN_PASSWORD', 'USER_LOGIN_PASSWORD')
+        }
+    }
+
+    steps {
+        shell('jenkins/end_to_end_tests.sh')
+    }
+
+    publishers {
+        archiveJunit('reports/*.xml') {
+            allowEmptyResults(false)
+        }
+        archiveArtifacts {
+            pattern('reports/*.xml')
+            pattern('log/*')
+            pattern('screenshots/*')
+        }
+        mailer(mailingListMap['e2e_test_mailing_list'])
+    }
+
+}

--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -136,7 +136,7 @@ secretMap.each { jobConfigs ->
                 sshAgent(jobConfig['credential'])
             }
         }
-        
+
         Map <String, String> predefinedPropsMap  = [:]
         predefinedPropsMap.put('GIT_SHA', '${GIT_COMMIT}')
         predefinedPropsMap.put('GITHUB_ORG', 'edx')

--- a/platform/jobs/edxPlatformBokChoyMaster.groovy
+++ b/platform/jobs/edxPlatformBokChoyMaster.groovy
@@ -30,14 +30,12 @@ publicJobConfig:
     defaultTestengBranch: 'master'
 */
 
-
 /* stdout logger */
 /* use this instead of println, because you can pass it into closures or other scripts. */
 Map config = [:]
 Binding bindings = getBinding()
 config.putAll(bindings.getVariables())
 PrintStream out = config['out']
-
 
 /* Map to hold the k:v pairs parsed from the secret file */
 Map secretMap = [:]


### PR DESCRIPTION
@jzoldak @benpatterson 

Notes:
* We had conflated the use cases for e2e tests in the past, i.e. PRs and merge testing for the tests and running the test as part of a CD pipeline. This job is only for the latter.
* Name will change once I get a thumb to 'edx-e2e-tests', so that no change is required from the pipeline code. I have this other name just for testing on build jenkins.
* I think we can eschew yaml-secrets in favor of credential binding for this, especially because we don't need to create variants on this job. However this exposes the env var names. Are you concerned or am I paranoid?
* I plan on putting in a PR to edx-e2e-tests to change the default screenshot dir, and will change this once I do. But this will get it working with the current state of the tests & pipeline.