### PR TITLE
TNL-6278 Adds in ora2 run acceptance tests job

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER edxops
 USER root
 RUN apt-get update \
       && apt-get install -y sudo python-dev python-pip libmysqlclient-dev \
-         libssl-dev libffi-dev  \
+         libssl-dev libffi-dev xvfb iceweasel  \
       && rm -rf /var/lib/apt/lists/*
 RUN echo "jenkins ALL=NOPASSWD: ALL" >> /etc/sudoers
 

--- a/docker/plugins.txt
+++ b/docker/plugins.txt
@@ -44,7 +44,6 @@ job-dsl 1.50
 jobConfigHistory 2.15
 jquery 1.11.2-0
 junit 1.15
-junit 1.2-beta-4
 ldap 1.11
 mailer 1.16
 mailer 1.17

--- a/ora2/jobs/RunAcceptanceTests.groovy
+++ b/ora2/jobs/RunAcceptanceTests.groovy
@@ -1,0 +1,103 @@
+/*
+    Variables consumed from the EXTRA_VARS input to your seed job in addition
+    to those listed in the seed job.
+
+    * BASIC_AUTH_PASS : some-password
+    * BASIC_AUTH_USER : some-user
+    * FOLDER_NAME: some-folder
+    * NOTIFY_ON_FAILURE : e-mail-contact@example.com
+*/
+
+package ora2.jobs
+
+class RunAcceptanceTests {
+
+    public static def job = { dslFactory, extraVars ->
+        return dslFactory.job(extraVars.get('FOLDER_NAME', 'ora2') + '/run-acceptance-tests') {
+            description('Run ORA2 acceptance tests on a sandbox.')
+            logRotator{
+                daysToKeep(10)
+                numToKeep(1)
+                artifactDaysToKeep(1)
+                artifactNumToKeep(1)
+            }
+            properties {
+                githubProjectProperty {
+                    projectUrlStr('https://github.com/edx/edx-ora2')
+                }
+                parameters {
+                    stringParam(
+                        'TEST_HOST',
+                        'ora2.sandbox.edx.org',
+                        "The hostname of the sandbox."
+                    )
+                    stringParam(
+                        'BASIC_AUTH_USER',
+                        extraVars.get('BASIC_AUTH_USER', ''),
+                        'Basic auth user name'
+                    )
+                    stringParam(
+                        'BASIC_AUTH_PASSWORD',
+                        extraVars.get('BASIC_AUTH_PASS', ''),
+                        'Basic auth password'
+                    )
+                    stringParam(
+                        'BRANCH',
+                        'origin/master',
+                        ''
+                    )
+                    stringParam(
+                        'SLEEP_TIME',
+                        '300',
+                        'How long to wait before actually starting the tests (apparently this is necessary to ensure environment is ready?)'
+                    )
+                }
+            }
+            scm {
+                git {
+                    remote {
+                        url('https://github.com/edx/edx-ora2.git')
+                    }
+                    branch('${BRANCH}')
+                    extensions {
+                        cleanCheckout()
+                    }
+                }
+            }
+            steps {
+                virtualenv {
+                    name('shell')
+                    command(dslFactory.readFileFromWorkspace('ora2/resources/run-ora2-acceptance-tests.sh'))
+                    clear()
+                }
+            }
+            publishers {
+                artifactArchiver {
+                    artifacts('test/acceptance/screenshots/*.png,test/acceptance/xunit*.xml,test/logs/*')
+                    allowEmptyArchive(true)
+                    onlyIfSuccessful(false)
+                    fingerprint(false)
+                    defaultExcludes(true)
+                    caseSensitive(true)
+                }
+                jUnitResultArchiver {
+                    testResults("**/build/test-reports/*.xml")
+                    allowEmptyResults(true)
+                }
+                mailer(extraVars['NOTIFY_ON_FAILURE'], true, false)
+            }
+            wrappers {
+                buildTimeoutWrapper {
+                    strategy {
+                        absoluteTimeOutStrategy {
+                            timeoutMinutes('75')
+                        }
+                    }
+                    timeoutEnvVar('')
+                }
+                timestamperBuildWrapper()
+            }
+        }
+    }
+
+}

--- a/ora2/resources/run-ora2-acceptance-tests.sh
+++ b/ora2/resources/run-ora2-acceptance-tests.sh
@@ -1,0 +1,4 @@
+# The environment needs a time to start. TODO: Make this wait more intelligent.
+sleep ${SLEEP_TIME}
+
+xvfb-run --server-args="-screen 0 1600x1200x24" ./scripts/jenkins-acceptance-tests.sh


### PR DESCRIPTION
## [TNL-6278](https://openedx.atlassian.net/browse/TNL-6278)

### Description

Adds a job to the ora2 directory to create the run-acceptance-job. Adds required dependencies to the dockerfile

Should be merged in the same time as https://github.com/edx/jenkins-job-dsl-internal/pull/73 and https://github.com/edx/configuration/pull/3686

**FYI**
@staubina 
@cahrens 