### PR TITLE
Added seed job and updated docker-compose.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ build/*
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+# JetBrains
+*.iml
+.idea/

--- a/README-Hacking.md
+++ b/README-Hacking.md
@@ -1,27 +1,23 @@
 # Local Development
 
-The simplest way to get started with local development targeted for tools-edx-jenkins is to use our Docker container.
-This container is pre-configured  to run Jenkins. The `docker-compose.yml` file in the root of this repository contains 
-the configuration necessary to  bring a new container online with the proper ports exposed, and volumes shared.
-
-Execute this command from the root of the repository:
+A `docker-compose.yml` file is included to aid local development. This file is configured to use the [official Jenkins
+ Docker image](https://hub.docker.com/_/jenkins/) with data stored in a data volume.
+ 
+Start by running this command from the root of the repository:
 
     $ docker-compose up
 
-If you opt not to use `docker-compose`, the following command will achieve the same results.
+Go to `http://localhost:8080` in your browser and follow the on-screen instructions to login complete the initial 
+configuration of Jenkins. When asked about plugins, choose the recommended set of plugins.
 
-    $ docker run -p 8080:8080 -v jenkins:/edx/var/jenkins tools_jenkins
+It is up to you if you want to create a new administrative user. Since this is not going to production, you might find 
+it simpler to continue using the default `admin` account but assign it memorable password at 
+http://localhost:8080/user/admin/configure.
 
-In both instances port 8080 will be exposed to the host system, and a volume will be created on the 
-container. This volume contains all of the configuration for Jenkins, and will be preserved between container
-stops and starts, except in the case of plugin updates or installs (see WIP: Updating the Docker Image below).
+Once Jenkins has been configured, create the seed job which will be used to run the DSL and create other jobs. From the 
+root of the repository run the following command. Remember to use the username/password from the initial configuration.
 
-Once the container is running, you can connect to Jenkins at `http://localhost:8080`.
-
-In order to bootstrap Jenkins in a container you will need to do two things:
-
-1. Set up any credentials required for pulling private repositories.
-2. Set up a seed job to process the job DSL.
+    $ ./gradlew rest -Dpattern=jobs/seed.groovy -DbaseUrl=http://localhost:8080/api -Dusername=admin -Dpassword=admin
 
 ### Credentials
 
@@ -30,51 +26,6 @@ You will need credentials--SSH key, or username and password--to clone private G
 
 Credentials can be added using the Jenkins UI.
 
-Note that if using a personal access token, you can only clone https://github.com/ URLs, and ssh keys only work on git@github.com:edx
-URLs.  We use git@github.com URLs on tools-edx-jenkins with deployment keys, but you can use whatever is simpler in testing.
-
-### Testing DSL
-
-You will need to create a new Jenkins job that executes the DSL, and creates other jobs. This can be done with the steps
-below.  Note that these instructions are for a simple DSL, your seed job documentation may specify cloning multiple DSL/configuration
-repos, or running Gradle.
-
-1. Use the Jenkins UI to create a new **Freestyle project** job named **Job Creator**.
-2. Configure the job to use **Multiple SCMs** for *Source Control Management*, and add a Git repository. (Note that we 
-are NOT using the Git plugin here.)
-    1. Set the Repository URL to the repo containing your job DSL (e.g. git@github.com:edx/jenkins-job-dsl-internal.git).
-    2. If necessary, select your authentication credentials (e.g. SSH key).
-    3. Repeat for jenkins-job-dsl and edx-internal (and possibly edge-internal).  These will likely be checked out into
-       a subdirectory documented in your seed job.
-4. If specified in your documentation, add a **Invoke Gradle scrip** job and follow the settings in your docs.
-3. Add a **Process Job DSLs** build step and configure it using the settings below. Remember to click the  *Advanced* 
-button to expose the final fields.
-    1. DSL Scripts: jobs/hacking-edx-jenkins.edx.org/*Jobs.groovy 
-       (You may opt to change this if you're developing for a different Jenkins server.)
-    2. Action for existing jobs and views: Unchecked
-    3. Action for removed jobs: Delete
-    4. Action for removed views: Ignore
-    5. Context to use for relative job names: Jenkins Root
-    6. Additional classpath: Click on the down-arrow to get a text box and enter the classpath specified by your seed job.
-    7. Fail build if a plugin must be installed or update: checked
-    8. Mark build as unstable when using deprecated features: checked
-4. Save the job, and Build it with Parameters.
-
-
-## WIP: Updating the Docker Image
-
-The [edxops/tools_jenkins](https://hub.docker.com/r/edxops/tools_jenkins/) image is used in the Docker steps above. The required plugins have been pre-installed on the container. Feel free to install additional plugins. If you'd like to add or modify Jenkins plugins, follow the steps below.
-
-Note: Adding or modifying Jenkins plugin(s) will wipe your Jenkins workspace.
-
-Update the plugin list by changing the plugin version number(s) or by adding additional plugin(s) in the tools_jenkins Ansible role in the configuration repository on your local machine. The role is available [here](https://github.com/edx/configuration/blob/master/playbooks/roles/tools_jenkins/defaults/main.yml). Build a new Docker image that incorporates your changes by running the following command from the root of the configuration repository:
-
-	$ docker build -f docker/build/tools_jenkins/Dockerfile -t edxops/tools_jenkins:latest .
-
-In order for your change(s) to be reflected in the Docker container running Jenkins, you must remove the jenkins volume, which is mounted by the docker-compose.yml file. Run the following command to remove the volume:
-
-	$ docker-compose down -v
-
-Run the following command to restart a Docker container running Jenkins with update or new plugin(s).
-
-	$ docker-compose up
+Note that if using a personal access token, you can only clone https://github.com/ URLs, and ssh keys only work on 
+git@github.com:edx URLs.  We use git@github.com URLs on tools-edx-jenkins with deployment keys, but you can use 
+whatever is simpler in testing.

--- a/build.gradle
+++ b/build.gradle
@@ -6,20 +6,19 @@ defaultTasks 'clean', 'libs'
 sourceSets {
     jobs {
         groovy {
-            srcDir 'sample/jobs'
-            srcDir 'platform/jobs'
-            srcDir 'testeng/jobs'
+            srcDirs 'jobs'
             srcDir 'mobileApp/jobs'
+            srcDir 'platform/jobs'
+            srcDir 'sample/jobs'
+            srcDir 'testeng/jobs'
+            compileClasspath += main.compileClasspath
         }
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
     }
     views {
         groovy {
             srcDir 'platform/views'
-        }
-    }
-    src {
-        groovy {
-            srcDir 'src/main/groovy'
         }
     }
     test {
@@ -37,29 +36,20 @@ repositories {
 
 configurations {
     libs
+    testPlugins {}
 }
 
+// Exclude buggy Xalan dependency this way the JRE default TransformerFactory is used
+// The xalan pulled in by htmlunit does not properly deal with spaces folder / job names
+configurations.all*.exclude group: 'xalan'
+
 dependencies {
-
-    libs 'org.yaml:snakeyaml:1.17'
-    
     compile 'org.yaml:snakeyaml:1.17'
-    compile 'org.codehaus.groovy:groovy:2.1.3'
-    compile "org.jenkins-ci.main:jenkins-war:${jenkinsVersion}"
+    compile 'org.codehaus.groovy:groovy-all:2.4.7'
+    compile "org.jenkins-ci.plugins:job-dsl-core:${jobDslVersion}"
 
-    jobsCompile 'org.yaml:snakeyaml:1.17'
-    jobsCompile 'org.codehaus.groovy:groovy:2.1.3'
-    jobsCompile "org.jenkins-ci.plugins:job-dsl-core:${jobDslVersion}"
-
-    testCompile('org.spockframework:spock-core:0.7-groovy-2.0') {
-        exclude module: 'groovy-all'
-    }
-
-    testCompile('org.spockframework:spock-core:0.7-groovy-2.0') {
-        exclude module: 'groovy-all'
-    }
-    // Needed for mocking in tests
-    testCompile 'cglib:cglib:3.1' 
+    testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
+    testCompile 'cglib:cglib-nodep:2.2.2' // used by Spock
 
     // Jenkins test harness dependencies
     testCompile 'org.jenkins-ci.main:jenkins-test-harness:2.8'
@@ -69,10 +59,22 @@ dependencies {
     // Job DSL plugin including plugin dependencies
     testCompile "org.jenkins-ci.plugins:job-dsl:${jobDslVersion}"
     testCompile "org.jenkins-ci.plugins:job-dsl:${jobDslVersion}@jar"
-    testCompile 'org.jenkins-ci.plugins:structs:1.1@jar'
-    testCompile 'org.jenkins-ci.plugins:cloudbees-folder:4.4@jar'
+    testCompile 'org.jenkins-ci.plugins:structs:1.2@jar'
+    testCompile 'org.jenkins-ci.plugins:cloudbees-folder:5.0@jar'
     testCompile 'com.cloudbees.plugins:build-flow-plugin:0.17@jar'
 
+    // plugins to install in test instance
+    testPlugins 'org.jenkins-ci.plugins:ghprb:1.31.4'
+    testPlugins 'com.coravy.hudson.plugins.github:github:1.19.0'
+    testPlugins 'org.jenkins-ci.plugins:cloudbees-folder:5.0'
+
+    // for the RestApiScriptRunner
+    compile('org.codehaus.groovy.modules.http-builder:http-builder:0.7.2') {
+        exclude(module: 'groovy')
+    }
+
+    // for the RestApiScriptRunner
+    compile('org.apache.ant:ant:1.9.7')
 }
 
 codenarc {
@@ -87,13 +89,40 @@ task libs(type: Copy) {
     from configurations.libs
 }
 
-tasks.getByName('test').inputs.files(sourceSets.jobs.groovy.srcDirs)
+task resolveTestPlugins(type: Copy) {
+    from configurations.testPlugins
+    into new File(sourceSets.test.output.resourcesDir, 'test-dependencies')
+    include '*.hpi'
+    include '*.jpi'
+    def mapping = [:]
+
+    doFirst {
+        configurations.testPlugins.resolvedConfiguration.resolvedArtifacts.each {
+            mapping[it.file.name] = "${it.name}.${it.extension}"
+        }
+    }
+    rename { mapping[it] }
+
+    doLast {
+        List<String> baseNames = source*.name.collect { mapping[it] }.collect { it[0..it.lastIndexOf('.') - 1] }
+        new File(destinationDir, 'index').setText(baseNames.join('\n'), 'UTF-8')
+    }
+}
 
 test {
+    dependsOn tasks.resolveTestPlugins
     inputs.files sourceSets.jobs.groovy.srcDirs
+
+    // set build directory for Jenkins test harness, JENKINS-26331
     systemProperty 'buildDirectory', project.buildDir.absolutePath
 }
 
+task rest(dependsOn: 'classes', type: JavaExec) {
+    main = 'com.dslexample.rest.RestApiScriptRunner'
+    classpath = sourceSets.main.runtimeClasspath
+    systemProperties System.getProperties()
+}
+
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.4'
+    gradleVersion = '3.4.1'
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 version: "3"
 services:
-  edxops-jenkins:
-    image: edxops/tools_jenkins:latest
+  jenkins:
+    image: jenkins:alpine
     container_name: tools_jenkins
     volumes:
-        - jenkins:/edx/var/jenkins
+        - jenkins:/var/jenkins_home
     ports:
       - "127.0.0.1:8080:8080"
 

--- a/jobs/seed.groovy
+++ b/jobs/seed.groovy
@@ -1,0 +1,24 @@
+// If you want, you can define your seed job in the DSL and create it via the REST API.
+// See https://github.com/sheehan/job-dsl-gradle-example#rest-api-runner
+// ./gradlew rest -Dpattern=<pattern> -DbaseUrl=<baseUrl> [-Dusername=<username>] [-Dpassword=<password>]
+// Example (without authentication): ./gradlew rest -Dpattern=jobs/seed.groovy -DbaseUrl=http://localhost:8080/api
+
+// TODO: When testing locally, change this to your own branch.
+String branch = 'master'
+
+job('seed') {
+    description('Seed job that creates other jobs.')
+    scm {
+        github 'edx/jenkins-job-dsl', branch
+    }
+    steps {
+        gradle 'clean test'
+        dsl {
+            external '**/jobs/**/*Jobs.groovy'
+            additionalClasspath 'src/main/groovy'
+        }
+    }
+    publishers {
+        archiveJunit 'build/test-results/**/*.xml'
+    }
+}

--- a/src/main/groovy/com/dslexample/GradleCiJobBuilder.groovy
+++ b/src/main/groovy/com/dslexample/GradleCiJobBuilder.groovy
@@ -1,0 +1,47 @@
+package com.dslexample
+
+import javaposse.jobdsl.dsl.DslFactory
+import javaposse.jobdsl.dsl.Job
+
+/**
+ * Example Class for creating a Gradle build
+ */
+class GradleCiJobBuilder {
+
+    String name
+    String description
+    String ownerAndProject
+    String gitBranch = 'master'
+    String pollScmSchedule = '@daily'
+    String tasks
+    String switches
+    Boolean useWrapper = true
+    String junitResults = '**/build/test-results/*.xml'
+    String artifacts = '**/build/libs/*.jar'
+    List<String> emails = []
+
+    Job build(DslFactory dslFactory) {
+        dslFactory.job(name) {
+            it.description this.description
+            logRotator {
+                numToKeep 5
+            }
+            scm {
+                github this.ownerAndProject, gitBranch
+            }
+            triggers {
+                scm pollScmSchedule
+            }
+            steps {
+                gradle tasks, switches, useWrapper
+            }
+            publishers {
+                archiveArtifacts artifacts
+                archiveJunit junitResults
+                if (emails) {
+                    mailer emails.join(' ')
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/com/dslexample/GrailsCiJobBuilder.groovy
+++ b/src/main/groovy/com/dslexample/GrailsCiJobBuilder.groovy
@@ -1,0 +1,51 @@
+package com.dslexample
+
+import javaposse.jobdsl.dsl.DslFactory
+import javaposse.jobdsl.dsl.Job
+
+/**
+ *  Example Class for creating a Grails build
+ */
+class GrailsCiJobBuilder {
+
+    String name
+    String description
+    String ownerAndProject
+    String gitBranch = 'master'
+    String pollScmSchedule = '*/5 * * * *'
+    List<String> emails
+
+    Job build(DslFactory dslFactory) {
+        dslFactory.job(name) {
+            it.description description
+            logRotator {
+                numToKeep 5
+            }
+            scm {
+                github ownerAndProject, gitBranch
+            }
+            triggers {
+                scm pollScmSchedule
+            }
+            steps {
+                shell 'chmod a+x ./grailsw'
+                grails {
+                    target 'test-app'
+                    target 'war'
+                    grailsWorkDir './grails-work'
+                    projectWorkDir './project-work'
+                    projectBaseDir ''
+                    serverPort ''
+                    useWrapper true
+                }
+            }
+            publishers {
+                archiveArtifacts 'target/**/*.war'
+                archiveJunit 'target/test-reports/**/*Spec.xml'
+                if (emails) {
+                    mailer emails.join(' ')
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/com/dslexample/StepsUtil.groovy
+++ b/src/main/groovy/com/dslexample/StepsUtil.groovy
@@ -1,0 +1,19 @@
+package com.dslexample
+
+class StepsUtil {
+
+    static void proxiedGradle(context, String gradleTasks) {
+        context.with {
+            gradle {
+                useWrapper true
+                tasks gradleTasks
+                switches '''
+                    -Dhttp.proxyHost=xxx
+                    -Dhttps.proxyHost=xxx
+                    -Dhttp.proxyPort=xxx
+                    -Dhttps.proxyPort=xxx
+                '''.stripIndent().trim()
+            }
+        }
+    }
+}

--- a/src/main/groovy/com/dslexample/rest/RestApiJobManagement.groovy
+++ b/src/main/groovy/com/dslexample/rest/RestApiJobManagement.groovy
@@ -1,0 +1,137 @@
+package com.dslexample.rest
+
+import groovyx.net.http.ContentType
+import groovyx.net.http.HttpResponseDecorator
+import groovyx.net.http.RESTClient
+import javaposse.jobdsl.dsl.*
+
+class RestApiJobManagement extends MockJobManagement {
+
+    final RESTClient restClient
+    private boolean crumbHeaderSet = false
+
+    RestApiJobManagement(String baseUrl) {
+        restClient = new RESTClient(baseUrl)
+        restClient.handler.failure = { it }
+    }
+
+    void setCredentials(String username, String password) {
+        crumbHeaderSet = false
+        restClient.headers['Authorization'] = 'Basic ' + "$username:$password".bytes.encodeBase64()
+    }
+
+    @Override
+    String getConfig(String jobName) throws JobConfigurationNotFoundException {
+        String xml = fetchExistingXml(jobName)
+        if (!xml) {
+            throw new JobConfigurationNotFoundException(jobName)
+        }
+
+        xml
+    }
+
+    @Override
+    boolean createOrUpdateConfig(Item item, boolean ignoreExisting) throws NameNotProvidedException {
+        createOrUpdateConfig(item.name, item.xml, ignoreExisting, false)
+    }
+
+    @Override
+    void createOrUpdateView(String viewName, String config, boolean ignoreExisting) throws NameNotProvidedException, ConfigurationMissingException {
+        createOrUpdateConfig(viewName, config, ignoreExisting, true)
+    }
+
+    boolean createOrUpdateConfig(String name, String xml, boolean ignoreExisting, boolean isView) throws NameNotProvidedException {
+        boolean success
+        String status
+
+        String existingXml = fetchExistingXml(name, isView)
+        if (existingXml) {
+            if (ignoreExisting) {
+                success = true
+                status = 'ignored'
+            } else {
+                success = update(name, xml, isView)
+                status = success ? 'updated' : 'update failed'
+            }
+        } else {
+            success = create(name, xml, isView)
+            status = success ? 'created' : 'create failed'
+        }
+
+        println "$name - $status"
+        success
+    }
+
+    @Override
+    InputStream streamFileInWorkspace(String filePath) throws IOException {
+        new File(filePath).newInputStream()
+    }
+
+    @Override
+    String readFileInWorkspace(String filePath) throws IOException {
+        new File(filePath).text
+    }
+
+    private boolean create(String name, String xml, boolean isView) {
+        String job
+        String path
+        if (name.contains('/')) {
+            int index = name.lastIndexOf('/')
+            String folder = name[0..(index - 1)]
+            job = name[(index + 1)..-1]
+            path = getPath(folder, isView) + '/createItem'
+        } else {
+            job = name
+            path = isView ? 'createView' : 'createItem'
+        }
+
+        setCrumbHeader()
+        HttpResponseDecorator resp = restClient.post(
+            path: path,
+            body: xml,
+            query: [name: job],
+            requestContentType: 'application/xml'
+        )
+
+        resp.status == 200
+    }
+
+    private boolean update(String name, String xml, boolean isView) {
+        setCrumbHeader()
+        HttpResponseDecorator resp = restClient.post(
+            path: getPath(name, isView) + '/config.xml',
+            body: xml,
+            requestContentType: 'application/xml'
+        )
+
+        resp.status == 200
+    }
+
+    private String fetchExistingXml(String name, boolean isView) {
+        setCrumbHeader()
+        HttpResponseDecorator resp = restClient.get(
+            contentType: ContentType.TEXT,
+            path: getPath(name, isView) + '/config.xml',
+            headers: [Accept: 'application/xml'],
+        )
+        resp?.data?.text
+    }
+
+    static String getPath(String name, boolean isView) {
+        if (name.startsWith('/')) {
+            return '/' + getPath(name[1..-1], isView)
+        }
+        isView ? "view/$name" : "job/${name.replaceAll('/', '/job/')}"
+    }
+
+    private setCrumbHeader() {
+        if (crumbHeaderSet)
+            return
+
+        HttpResponseDecorator resp = restClient.get(path: 'crumbIssuer/api/xml')
+        if (resp.status == 200) {
+            restClient.headers[resp.data.crumbRequestField] = resp.data.crumb
+        }
+        crumbHeaderSet = true
+    }
+}

--- a/src/main/groovy/com/dslexample/rest/RestApiScriptRunner.groovy
+++ b/src/main/groovy/com/dslexample/rest/RestApiScriptRunner.groovy
@@ -1,0 +1,26 @@
+package com.dslexample.rest
+
+import javaposse.jobdsl.dsl.DslScriptLoader
+
+String pattern = System.getProperty('pattern')
+String baseUrl = System.getProperty('baseUrl')
+String username = System.getProperty('username')
+String password = System.getProperty('password') // password or token
+
+if (!pattern || !baseUrl) {
+    println 'usage: -Dpattern=<pattern> -DbaseUrl=<baseUrl> [-Dusername=<username>] [-Dpassword=<password>]'
+    System.exit 1
+}
+
+RestApiJobManagement jm = new RestApiJobManagement(baseUrl)
+if (username && password) {
+    jm.setCredentials username, password
+}
+
+DslScriptLoader scriptLoader = new DslScriptLoader(jm)
+
+new FileNameFinder().getFileNames('.', pattern).each { String fileName ->
+    println "\nprocessing file: $fileName"
+    File file = new File(fileName)
+    scriptLoader.runScript(file.text)
+}

--- a/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
@@ -1,7 +1,6 @@
 package org.edx.jenkins.dsl
 
 import org.yaml.snakeyaml.Yaml
-import hudson.util.Secret
 
 class JenkinsPublicConstants {
 
@@ -187,19 +186,4 @@ class JenkinsPublicConstants {
             buildButton()
         }
     }
-
-    // Reusable closure for configuring a masked password user parameter with a default value
-    // Input must be structured in the following format:
-    // [ name: String x, description: String y, default: String z ]
-    public static final Closure JENKINS_PUBLIC_MASKED_PASSWORD = { param ->
-        return {
-            it / 'properties' / 'hudson.model.ParametersDefinitionProperty' / parameterDefinitions << 'hudson.model.PasswordParameterDefinition' {
-                name param.name
-                defaultValue Secret.fromString(param.default.toString()).getEncryptedValue()
-                description param.description
-            }
-        }
-
-    }
-
 }

--- a/testeng/jobs/buildPackerAMIjob.groovy
+++ b/testeng/jobs/buildPackerAMIjob.groovy
@@ -4,7 +4,6 @@ import hudson.util.Secret
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_TEAM_SECURITY
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_MASKED_PASSWORD
 
 Map config = [:]
 Binding bindings = getBinding()


### PR DESCRIPTION
A seed job has been added from https://github.com/sheehan/job-dsl-gradle-example. This allows developers to run a command against the Jenkins REST API to create the seed job rather than manually creating the job.

Additionally, the Docker Compose file has been updated to use the official Jenkins image. It is unclear what happened to the original Dockerfile.

LEARNER-509