### PR TITLE
load tests use build flows to generate summaries

### DIFF
--- a/testeng/resources/flow-run-simple-loadtest.groovy
+++ b/testeng/resources/flow-run-simple-loadtest.groovy
@@ -1,0 +1,30 @@
+import hudson.FilePath
+import hudson.model.*
+
+def toolbox = extension."build-flow-toolbox"
+def driver_build = null
+
+/* Kick off the load test, directly copying all parameters.  Ignore the
+ * scenario where the load test is manually aborted by the user because this is
+ * considered normal behavior.
+ */
+ignore(ABORTED) {
+    driver_build = build(
+        "loadtest-driver",
+        TARGET_URL: params["TARGET_URL"],
+        TEST_COMPONENT: params["TEST_COMPONENT"],
+        REMOTE_BRANCH: params["REMOTE_BRANCH"],
+        NUM_CLIENTS: params["NUM_CLIENTS"],
+        HATCH_RATE: params["HATCH_RATE"],
+        MAX_RUN_TIME: params["MAX_RUN_TIME"],
+        LOADTEST_OVERRIDES: params["LOADTEST_OVERRIDES"]
+    )
+}
+toolbox.slurpArtifacts(driver_build)
+
+/* Kick off a build to generate a load test summary */
+def summary_build = build(
+    'loadtest-summary',
+    REMOTE_BRANCH: params["REMOTE_BRANCH"]
+)
+toolbox.slurpArtifacts(summary_build)

--- a/testeng/resources/run-loadtest-wrapper.sh
+++ b/testeng/resources/run-loadtest-wrapper.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 
-JOB_OVERRIDES_FILE="${WORKSPACE}/job_param_overrides.yml"
+LOADTEST_OVERRIDES_PATH="${WORKSPACE}/job_param_overrides.yml"
+
+# Create a file containing loadtest overrides.  The user may not have specified
+# any overrides, in which case this line will create an empty file.
+echo "$LOADTEST_OVERRIDES" > "$LOADTEST_OVERRIDES_PATH"
 
 # Construct the list of overrides files which the loadtest entry point expects.
 OVERRIDES_FILES="$SECRET_SETTINGS_FILE"
-if [ -e $JOB_OVERRIDES_FILE ]; then
-    # The user uploaded an overrides file, so we append it to the list:
-    OVERRIDES_FILES="${OVERRIDES_FILES} ${JOB_OVERRIDES_FILE}"
+if [ -n "$LOADTEST_OVERRIDES" ]; then
+    # The user specified loadtest overrides, so we append it to the list:
+    OVERRIDES_FILES="${OVERRIDES_FILES} ${LOADTEST_OVERRIDES_PATH}"
 fi
 export OVERRIDES_FILES
 


### PR DESCRIPTION
Create a layer of indirection by changing the user-facing load test job
to a new build flow job (run-simple-loadtest) that builds downstream
jobs to run load tests (loadtest-driver) and generate summaries
(loadtest-summary) upon completion.

---

All artifacts, including the logfile and the summary report, become slurped up to the top level job.

This PR depends on https://github.com/edx/edx-load-tests/pull/106

An example jenkins test run containing two build artifacts (one logfile, one summary file): https://test-jenkins.testeng.edx.org/job/run-simple-loadtest/44/