### PR TITLE
Permit run-simple-loadtest to run concurrently

### DIFF
--- a/testeng/jobs/loadtestDriver.groovy
+++ b/testeng/jobs/loadtestDriver.groovy
@@ -124,6 +124,8 @@ buildFlowJob('run-simple-loadtest') {
         }
     }
 
+    concurrentBuild(true)
+
     wrappers {
         buildUserVars() /* gives us access to BUILD_USER_ID, among other things */
         buildName('#${BUILD_NUMBER} by ${ENV,var="BUILD_USER_ID"}')


### PR DESCRIPTION
This was the original intention (to permit multiple simultaneous load
tests), but this line was just accidentally omitted in a previous
refactor.