### PR TITLE
remove false e2e view

### DIFF
--- a/platform/views/platformViews.groovy
+++ b/platform/views/platformViews.groovy
@@ -47,14 +47,3 @@ branchList.each { branch ->
     }
 
 }
-
-
-listView() {
-    description('Jobs used to run e2e tests against a deployed edx-platform instance')
-    filterBuildQueue(true)
-    filterExecutors(true)
-    jobs {
-        regex('edx-e2e-.*|.*staging.*')
-    }
-    columns DEFAULT_VIEW.call()
-}


### PR DESCRIPTION
Not sure why this was in the platform view, but:
A) it was causing the DSL to fail
B) not all microsites jobs have 'staging' in the name (use https://github.com/edx/jenkins-job-dsl/blob/master/platform/views/e2eViews.groovy instead)