### PR TITLE
add the gh project url to e2e merge jobs

### DIFF
--- a/platform/jobs/edxEndToEndTestsJob.groovy
+++ b/platform/jobs/edxEndToEndTestsJob.groovy
@@ -194,7 +194,7 @@ jobConfigs.each { jobConfig ->
             }
         }
 
-        if (jobConfig.trigger == 'ghprb') {
+        if (jobConfig.trigger == 'ghprb' || jobConfig.trigger == 'merge') {
             properties {
                 githubProjectUrl('https://github.com/edx/edx-e2e-tests')
             }


### PR DESCRIPTION
I had missed this in the initial setup of these jobs. Should fix the merge jobs