### PR TITLE
Fix edx.org theme issue on sandboxes

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -129,7 +129,7 @@ class CreateSandbox {
                 stringParam("configuration_secure_version","master","")
                 stringParam("configuration_internal_version","master","")
                 booleanParam("reconfigure",false,"Reconfigure and deploy, this will also run with --skip-tags deploy against all role <br />Leave this unchecked unless you know what you are doing")
-                choiceParam("edxapp_comprehensive_theme_dir",["/edx/app/edxapp/edx-platform/themes/edx.org","unset"],"")
+                choiceParam("edxapp_comprehensive_theme_dirs",["/edx/app/edxapp/edx-platform/themes","unset"],"")
                 booleanParam("testcourses",true,"")
                 booleanParam("performance_course",true,"")
                 booleanParam("demo_test_course",true,"")


### PR DESCRIPTION
See WL-1104. Variable name was changed in configuration files and was
not mirrored in sandbox creation scripts. Also, theme directory was
incorrect.