### PR TITLE
Revert "Fix edx.org theme issue on sandboxes"

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -129,7 +129,7 @@ class CreateSandbox {
                 stringParam("configuration_secure_version","master","")
                 stringParam("configuration_internal_version","master","")
                 booleanParam("reconfigure",false,"Reconfigure and deploy, this will also run with --skip-tags deploy against all role <br />Leave this unchecked unless you know what you are doing")
-                choiceParam("edxapp_comprehensive_theme_dirs",["/edx/app/edxapp/edx-platform/themes","unset"],"")
+                choiceParam("edxapp_comprehensive_theme_dir",["/edx/app/edxapp/edx-platform/themes/edx.org","unset"],"")
                 booleanParam("testcourses",true,"")
                 booleanParam("performance_course",true,"")
                 booleanParam("demo_test_course",true,"")


### PR DESCRIPTION
Reverts edx/jenkins-job-dsl#194

This is being reverted because ansible-provision.sh was changed to expect the new variable name but it wasn't passing a list, it was passing a var.

This can either be fixed in the Jenkins DSL to pass a list or in ansible-provision to create a list when passing it down.