### PR TITLE
Decrease Poll Time for Open Release Master Jobs

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -136,7 +136,7 @@ secretMap.each { jobConfigs ->
             // for all other jobs in this style, poll github for new commits on
             // the 'defaultBranch'
             else {
-                scm("@hourly")
+                scm("H/10 * * * *")
             }
         }
         wrappers { //abort when stuck after 75 minutes, use gnome-terminal coloring, have timestamps at Console

--- a/platform/jobs/edxPlatformBokChoyMaster.groovy
+++ b/platform/jobs/edxPlatformBokChoyMaster.groovy
@@ -162,7 +162,7 @@ secretMap.each { jobConfigs ->
             // for all other jobs in this style, poll github for new commits on
             // the 'defaultBranch'
             else {
-                scm('@hourly')
+                scm('H/10 * * * *')
             }
         }
 

--- a/platform/jobs/edxPlatformJsMaster.groovy
+++ b/platform/jobs/edxPlatformJsMaster.groovy
@@ -142,7 +142,7 @@ secretMap.each { jobConfigs ->
             // for all other jobs in this style, poll github for new commits on
             // the 'defaultBranch'
             else {
-                scm("@hourly")
+                scm("H/10 * * * *")
             }
         }
         wrappers { //abort when stuck, x-mal coloring, timestamps in Console, change build name

--- a/platform/jobs/edxPlatformLettuceMaster.groovy
+++ b/platform/jobs/edxPlatformLettuceMaster.groovy
@@ -161,7 +161,7 @@ secretMap.each { jobConfigs ->
             // for all other jobs in this style, poll github for new commits on
             // the 'defaultBranch'
             else {
-                scm('@hourly')
+                scm('H/10 * * * *')
             }
         }
 

--- a/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
@@ -162,7 +162,7 @@ secretMap.each { jobConfigs ->
             // for all other jobs in this style, poll github for new commits on
             // the 'defaultBranch'
             else {
-                scm('@hourly')
+                scm('H/10 * * * *')
             }
         }
 

--- a/platform/jobs/edxPlatformQualityMaster.groovy
+++ b/platform/jobs/edxPlatformQualityMaster.groovy
@@ -144,7 +144,7 @@ secretMap.each { jobConfigs ->
             // for all other jobs in this style, poll github for new commits on
             // the 'defaultBranch'
             else {
-                scm('@hourly')
+                scm('H/10 * * * *')
             }
         }
         wrappers { //abort when stuck after 90 minutes, x-mal coloring, timestamps at Console, change the build name


### PR DESCRIPTION
Right now, our master jobs for eucalyptus/ficus/gingko all poll GitHub hourly for changes.

This PR is just to reduce that time to every 10 minutes.