### PR TITLE
PLAT-1676 Add a11y xunit file to xunit files list

### DIFF
--- a/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
@@ -35,7 +35,7 @@ class JenkinsPublicConstants {
     return {
         jUnit {
             pattern("**/nosetests.xml,**/TEST-*.xml,reports/acceptance/*.xml,reports/quality.xml," +
-                    "reports/javascript/javascript_xunit.xml,reports/bok_choy/xunit.xml,reports/bok_choy/**/xunit.xml"
+                    "reports/javascript/javascript_xunit.xml,reports/a11y/xunit.xml,reports/bok_choy/xunit.xml,reports/bok_choy/**/xunit.xml"
                     )
             skipNoTestFiles(true)
             stopProcessingIfError(true)


### PR DESCRIPTION
Our paver configuration tries to put the results from the a11y bok-choy tests in `reports/a11y/xunit.xml`, but it was inadvertently putting them in `nosetests.xml` instead:

* You can see from a [previous job's output](https://build.testeng.edx.org/job/edx-platform-accessibility-pr/37837/consoleFull) that we called nosetests with `--with-xunitmp`, but `--xunit-file` instead of `--xunitmp-file`.  Hence the file parameter was ignored, and the nose default of `nosetests.xml` was used instead.
* I fixed the file parameter in the process of [switching bok-choy and a11y tests from nose to pytest](https://github.com/edx/edx-platform/pull/15712), but that broke test reporting because the configured file path wasn't in the [xunit file search list](https://github.com/edx/jenkins-job-dsl/blob/master/platform/jobs/edxPlatformAccessibilityPr.groovy#L155).

This new files list should work with both the current test configuration and the upcoming pytest-based version.