### PR TITLE
PLAT-1676 Add a11y xunit.xml to correct list

### DIFF
--- a/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
@@ -82,8 +82,8 @@ class JenkinsPublicConstants {
 
     public static final String JENKINS_PUBLIC_JUNIT_REPORTS = 'edx-platform*/**/nosetests.xml,edx-platform*/reports/acceptance/*.xml,' +
                                                               'edx-platform*/reports/quality.xml,edx-platform*/reports/javascript/' +
-                                                              'javascript_xunit*.xml,edx-platform*/reports/bok_choy/xunit.xml,edx-platform*/' +
-                                                              'reports/bok_choy/**/xunit.xml'
+                                                              'javascript_xunit*.xml,edx-platform*/reports/a11y/**/xunit.xml,' +
+                                                              'edx-platform*/reports/bok_choy/**/xunit.xml'
 
     public static final Closure JENKINS_PUBLIC_GITHUB_STATUS_PENDING = { predefinedPropsMap ->
         return {


### PR DESCRIPTION
Two of these constants are confusingly similar; adding the accessibility tests xunit.xml file to the correct one this time.