### PR TITLE
jobDSL for splitting app permissions job so webhooks work

### DIFF
--- a/devops/jobs/AppPermissionsRunner.groovy
+++ b/devops/jobs/AppPermissionsRunner.groovy
@@ -48,14 +48,22 @@ class AppPermissionsRunner {
                         maxTotal(0)
                     }
 
+                    assert extraVars.containsKey('APP_PERMISSIONS_REPO') : 'Make sure you define the app permissions repository'
+
+                    def gitCredentialId = extraVars.get('SECURE_GIT_CREDENTIALS','')
+
                     parameters{
                         stringParam('CONFIGURATION_REPO', extraVars.get('CONFIGURATION_REPO', 'https://github.com/edx/configuration.git'),
                                 'Git repo containing edX configuration.')
                         stringParam('CONFIGURATION_BRANCH', extraVars.get('CONFIGURATION_BRANCH', 'master'),
                                 'e.g. tagname or origin/branchname')
+                        stringParam('APP_PERMISSIONS_REPO', extraVars.get('APP_PERMISSIONS_REPO'),
+                                'Git repo containing edx app permissions')
+                        stringParam('APP_PERMISSIONS_BRANCH', extraVars.get('APP_PERMISSIONS_BRANCH', 'master'),
+                                'e.g. tagname or origin/branchname')
                     }
                     
-                    scm{ 
+                    multiscm{ 
                         git {
                             remote {
                                 url('$CONFIGURATION_REPO')
@@ -65,6 +73,20 @@ class AppPermissionsRunner {
                                 cleanAfterCheckout()
                                 pruneBranches()
                                 relativeTargetDirectory('configuration')
+                            }
+                        }
+                        git {
+                            remote {
+                                url('$APP_PERMISSIONS_REPO')
+                                branch('$APP_PERMISSIONS_BRANCH')
+                                    if (gitCredentialId) {
+                                        credentials(gitCredentialId)
+                                    }
+                            }
+                            extensions {
+                                cleanAfterCheckout()
+                                pruneBranches()
+                                relativeTargetDirectory('app-permissions')
                             }
                         }
                     }

--- a/devops/jobs/AppPermissionsRunner.groovy
+++ b/devops/jobs/AppPermissionsRunner.groovy
@@ -1,39 +1,25 @@
 /*
- 
- Variables without defaults are marked (required) 
- 
- Variables consumed for this job:
-    * SECURE_GIT_CREDENTIALS: secure-bot-user (required)
-    * NOTIFY_ON_FAILURE: alert@example.com
-    * FOLER_NAME: folder, default is User-Mananagement
-    * DEPLOYMENTS: (required)
-        environments:
-          - environment (required)
-    * ACCESS_CONTROL: list of users to give access to
-        - user
-    * USER: user to run ansible (required)
-    * DEPLOYMENT_KEY: ssh key that should be defined on the folder (required)
- 
- This job expects the following credentials to be defined on the folder
+
+ This job runs the script with the ansible to update app permissions. It is triggered by the app-permissions-watcher job.
+ It consumes the same variables as the app-permissions-watcher job.
+    
+ Additionally, this job expects the following credentials to be defined on the folder
     tools-edx-jenkins-aws-credentials: file with key/secret in boto config format
     find-active-instances-${deployment}-role-arn: the role to aws sts assume-role
 
 */
-
-
 package devops.jobs
 import static org.edx.jenkins.dsl.Constants.common_wrappers
 import static org.edx.jenkins.dsl.Constants.common_logrotator
 import static org.edx.jenkins.dsl.DevopsConstants.common_read_permissions
 
-class AppPermissions{
+class AppPermissionsRunner {
     public static def job = { dslFactory, extraVars ->
         assert extraVars.containsKey('DEPLOYMENTS') : "Please define DEPLOYMENTS. It should be a list of strings."
         assert !(extraVars.get('DEPLOYMENTS') instanceof String) : "Make sure DEPLOYMENTS is a list and not a string"
         extraVars.get('DEPLOYMENTS').each { deployment, configuration ->
             configuration.environments.each { environment ->
-
-                dslFactory.job(extraVars.get("FOLDER_NAME","User-Management") + "/app-permissions-${environment}-${deployment}") {
+                dslFactory.job(extraVars.get("FOLDER_NAME","User-Management") + "/app-permissions-runner-${environment}-${deployment}") {
 
                     wrappers common_wrappers
                     logRotator common_logrotator
@@ -44,10 +30,11 @@ class AppPermissions{
                             string('ROLE_ARN', "find-active-instances-${deployment}-role-arn")
                         }
                         assert extraVars.containsKey('DEPLOYMENT_KEY_NAME') : "Make sure you define the deployment key name"
-                        sshAgent(extraVars.get('DEPLOYMENT_KEY_NAME'))
-                      }
 
-                    def access_control = extraVars.get('ACCESS_CONTROL',[])
+                        sshAgent(extraVars.get('DEPLOYMENT_KEY_NAME'))
+                    }
+
+                    def access_control = extraVars.get('ACCESS_CONTROL', [])
                     access_control.each { acl ->
                         common_read_permissions.each { perm ->
                             authorization {
@@ -61,45 +48,23 @@ class AppPermissions{
                         maxTotal(0)
                     }
 
-                    properties {
-                        githubProjectUrl("https://github.com/edx/app-permissions/")
+                    parameters{
+                        stringParam('CONFIGURATION_REPO', extraVars.get('CONFIGURATION_REPO', 'https://github.com/edx/configuration.git'),
+                                'Git repo containing edX configuration.')
+                        stringParam('CONFIGURATION_BRANCH', extraVars.get('CONFIGURATION_BRANCH', 'master'),
+                                'e.g. tagname or origin/branchname')
                     }
-
-                    triggers {
-                        githubPush()
-                    }
-
-
-                    def gitCredentialId = extraVars.get('SECURE_GIT_CREDENTIALS','')
                     
-                    // The urls for the repos as well as the branch names have to be hardcoded in order for webhooks to work. 
-                    // If they are parameterized, they are not defined until run time so the webhook cannot find them.
-                    // To make the job more configurable, you can add back in parameters for repos and branches, but you have to change the trigger back to polling.
-                    multiscm{
+                    scm{ 
                         git {
                             remote {
-                                url('https://github.com/edx/configuration.git')
-                                branch('master')
+                                url('$CONFIGURATION_REPO')
+                                branch('$CONFIGURATION_BRANCH')
                             }
                             extensions {
                                 cleanAfterCheckout()
                                 pruneBranches()
                                 relativeTargetDirectory('configuration')
-                            }
-                        } 
-
-                        git {
-                            remote {
-                                url('git@github.com:edx/app-permissions.git')
-                                branch('master')
-                                    if (gitCredentialId) {
-                                        credentials(gitCredentialId)
-                                    }
-                            }
-                            extensions {
-                                cleanAfterCheckout()
-                                pruneBranches()
-                                relativeTargetDirectory('app-permissions')
                             }
                         }
                     }
@@ -107,8 +72,8 @@ class AppPermissions{
                     environmentVariables {
                         env('ENVIRONMENT', environment)
                         env('DEPLOYMENT', deployment)
-                        env('USER', extraVars.get('USER', 'ubuntu'))
                     }
+
                     steps {
                         virtualenv {
                             nature("shell")
@@ -117,9 +82,7 @@ class AppPermissions{
                             command(
                                 dslFactory.readFileFromWorkspace("devops/resources/run-app-permissions.sh")
                             )
-
                         }
-
                     }
 
                     if (extraVars.get('NOTIFY_ON_FAILURE')){
@@ -132,5 +95,4 @@ class AppPermissions{
             }
         }
     }
-
 }

--- a/devops/jobs/AppPermissionsRunner.groovy
+++ b/devops/jobs/AppPermissionsRunner.groovy
@@ -94,6 +94,7 @@ class AppPermissionsRunner {
                     environmentVariables {
                         env('ENVIRONMENT', environment)
                         env('DEPLOYMENT', deployment)
+                        env('USER', extraVars.get('USER', 'ubuntu'))
                     }
 
                     steps {

--- a/devops/jobs/AppPermissionsWatcher.groovy
+++ b/devops/jobs/AppPermissionsWatcher.groovy
@@ -1,0 +1,97 @@
+/*
+
+ This job checks out the app permissions repository and checks for merges to master with github webhooks. Upon a merge to master, 
+ it will trigger a build of the app-permissions-runner job (below). The app-permissions-runner job is what actually calls the script 
+ to run the ansible.
+ 
+ Variables without defaults are marked (required) 
+ 
+ Variables consumed for this job and for the app-permission-runner job:
+    * SECURE_GIT_CREDENTIALS: secure-bot-user (required)
+    * FOLER_NAME: folder, default is User-Mananagement
+    * DEPLOYMENTS: (required)
+        environments:
+          - environment (required)
+    * ACCESS_CONTROL: list of users to give access to
+        - user
+    * USER: user to run ansible (required)
+    * DEPLOYMENT_KEY: ssh key that should be defined on the folder (required)
+    * NOTIFY_ON_FAILURE: alert@example.com
+    * APP_PERMISSION_BRANCH: branch of app permissions for the webhook to watch, default is master
+
+
+*/
+
+
+package devops.jobs
+import static org.edx.jenkins.dsl.Constants.common_wrappers
+import static org.edx.jenkins.dsl.Constants.common_logrotator
+import static org.edx.jenkins.dsl.DevopsConstants.common_read_permissions
+import static org.edx.jenkins.dsl.DevopsConstants.merge_to_master_trigger
+
+class AppPermissionsWatcher{ 
+    public static def job = { dslFactory, extraVars ->
+        dslFactory.job(extraVars.get("FOLDER_NAME","User-Management") + "/app-permissions-watcher") {
+
+            description("Job to watch the app-permissions repo to determine when to trigger the app-permissions-runner jobs.")
+
+            wrappers common_wrappers
+            logRotator common_logrotator
+
+            def access_control = extraVars.get('ACCESS_CONTROL',[])
+            access_control.each { acl ->
+                common_read_permissions.each { perm ->
+                    authorization {
+                        permission(perm,acl)
+                    }
+                }
+            }
+
+            throttleConcurrentBuilds {
+                maxPerNode(0)
+                maxTotal(0)
+            }
+
+            def gitCredentialId = extraVars.get('SECURE_GIT_CREDENTIALS','')
+            def repo_branch = extraVars.get('APP_PERMISSIONS_BRANCH', 'master')
+            
+            // The urls for the repos and the branch names cannot be variables that are defined in the scm checkout because 
+            // they are not defined until run time so the webhook cannot find them.
+            // If you want to parameterize them, define them as variables within the job prior to the scm checkout (as done above)
+            scm{ 
+                git {
+                    remote {
+                        url('git@github.com:edx/app-permissions.git')
+                        branch(repo_branch)
+                            if (gitCredentialId) {
+                                credentials(gitCredentialId)
+                            }
+                    }
+                    extensions {
+                        cleanAfterCheckout()
+                        pruneBranches()
+                        relativeTargetDirectory('app-permissions')
+                    }
+                }
+            }
+
+            properties {
+                githubProjectUrl("https://github.com/edx/app-permissions/")
+            }
+
+            triggers merge_to_master_trigger(repo_branch)
+
+            steps{
+                extraVars.get('DEPLOYMENTS').each { deployment, configuration ->
+                    configuration.environments.each { environment ->
+                        downstreamParameterized {
+                            trigger("app-permissions-runner-${environment}-${deployment}")
+                        }
+                    }
+                }  
+            }
+              
+        }
+    }
+}
+

--- a/devops/jobs/AppPermissionsWatcher.groovy
+++ b/devops/jobs/AppPermissionsWatcher.groovy
@@ -17,8 +17,8 @@
     * USER: user to run ansible (required)
     * DEPLOYMENT_KEY: ssh key that should be defined on the folder (required)
     * NOTIFY_ON_FAILURE: alert@example.com
+    * APP_PERMISSION_REPO: app permissions git repository (required)
     * APP_PERMISSION_BRANCH: branch of app permissions for the webhook to watch, default is master
-
 
 */
 
@@ -90,7 +90,7 @@ class AppPermissionsWatcher{
                     }
                 }  
             }
-              
+
         }
     }
 }


### PR DESCRIPTION
The app-permissions job's webhook was triggering the job to build both on merges to master on the configuration and app-permissions repos. 
The job had to be split up into a watcher and runner job so that the job with the webhook only checks out the app-permissions repo. This first job then triggers the builds of the runner jobs which run the ansible command.