### PR TITLE
upgrade gradle to output codenarc violations in travis logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ script:
     - pep8 mobile_app/resources
     - nosetests mobile_app/resources -v --with-coverage --cover-package=mobile_app
 
-    # uncomment once we add a groovy project
+    - export CI_SYSTEM='travis'
     - ./gradlew check 

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,12 @@ codenarc {
     configFile = file('config/codenarc/codenarcRules.groovy')
     maxPriority2Violations = 75
     maxPriority3Violations = 99
+
+    // Display codenarc violations in the console for travis builds
+    // otherwise, default to creating an html report
+    if (System.getenv('CI_SYSTEM') == 'travis') {
+        reportFormat = 'console'
+    }
 }
 
 task libs(type: Copy) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
An html report of codenarc violations is not very useful on travis, so this will output the failures to stdout. It requires a substantial bump to the version of gradle used, but we are already using this in https://github.com/edx/jenkins-configuration/blob/master/build.gradle