### PR TITLE
add timestamps to all tools jobs

### DIFF
--- a/platform/jobs/edxPlatformBokChoyMaster.groovy
+++ b/platform/jobs/edxPlatformBokChoyMaster.groovy
@@ -156,6 +156,10 @@ secretMap.each { jobConfigs ->
             githubPush()
         }
 
+        wrappers {
+            timestamps()
+        }
+
         Map <String, String> predefinedPropsMap  = [:]
         predefinedPropsMap.put('GIT_SHA', '${GIT_COMMIT}')
         predefinedPropsMap.put('GITHUB_ORG', 'edx')

--- a/platform/jobs/edxPlatformBokChoyPr.groovy
+++ b/platform/jobs/edxPlatformBokChoyPr.groovy
@@ -148,6 +148,10 @@ secretMap.each { jobConfigs ->
             }
         }
 
+        wrappers {
+            timestamps()
+        }
+
         configure GHPRB_WHITELIST_BRANCH(jobConfig['whitelistBranchRegex'])
 
         dslFile('testeng-ci/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy')

--- a/platform/jobs/edxPlatformLettuceMaster.groovy
+++ b/platform/jobs/edxPlatformLettuceMaster.groovy
@@ -155,6 +155,10 @@ secretMap.each { jobConfigs ->
             githubPush()
         }
 
+        wrappers {
+            timestamps()
+        }
+
         Map <String, String> predefinedPropsMap  = [:]
         predefinedPropsMap.put('GIT_SHA', '${GIT_COMMIT}')
         predefinedPropsMap.put('GITHUB_ORG', 'edx')

--- a/platform/jobs/edxPlatformLettucePr.groovy
+++ b/platform/jobs/edxPlatformLettucePr.groovy
@@ -146,6 +146,10 @@ secretMap.each { jobConfigs ->
             }
         }
 
+        wrappers {
+            timestamps()
+        }
+
         configure GHPRB_WHITELIST_BRANCH(jobConfig['whitelistBranchRegex'])
 
         dslFile('testeng-ci/jenkins/flow/pr/edx-platform-lettuce-pr.groovy')

--- a/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
@@ -156,6 +156,10 @@ secretMap.each { jobConfigs ->
             githubPush()
         }
 
+        wrappers {
+            timestamps()
+        }
+
         Map <String, String> predefinedPropsMap  = [:]
         predefinedPropsMap.put('GIT_SHA', '${GIT_COMMIT}')
         predefinedPropsMap.put('GITHUB_ORG', 'edx')

--- a/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
@@ -147,6 +147,10 @@ secretMap.each { jobConfigs ->
             }
         }
 
+        wrappers {
+            timestamps()
+        }
+
         configure GHPRB_WHITELIST_BRANCH(jobConfig['whitelistBranchRegex'])
 
         dslFile('testeng-ci/jenkins/flow/pr/edx-platform-python-unittests-pr.groovy')

--- a/testeng/jobs/cleanUpWorkers.groovy
+++ b/testeng/jobs/cleanUpWorkers.groovy
@@ -23,6 +23,10 @@ job('clean-up-workers') {
         cron('H H/6 * * *')
     }
 
+    wrappers {
+        timestamps()
+    }
+
     steps {
         systemGroovyScriptFile('jenkins/admin-scripts/delete-old-workers.groovy')
     }

--- a/testeng/jobs/toggleSpigot.groovy
+++ b/testeng/jobs/toggleSpigot.groovy
@@ -94,6 +94,10 @@ secretMap.each { jobConfigs ->
             env('AWS_DEFAULT_REGION', jobConfig['region'])
         }
 
+        wrappers {
+            timestamps()
+        }
+
         steps {
             shell(readFileFromWorkspace('testeng/resources/toggle-spigot.sh'))
         }

--- a/testeng/jobs/travisCounts.groovy
+++ b/testeng/jobs/travisCounts.groovy
@@ -21,6 +21,10 @@ job('travis-counts') {
         cron("H/10 * * * *")
     }
 
+    wrappers {
+        timestamps()
+    }
+
     steps {
        shell(readFileFromWorkspace('testeng/resources/travis-counts.sh'))
      }

--- a/testeng/jobs/travisJobCounts.groovy
+++ b/testeng/jobs/travisJobCounts.groovy
@@ -21,6 +21,10 @@ job('travis-job-counts') {
         cron("H/10 * * * *")
     }
 
+    wrappers {
+        timestamps()
+    }
+
     steps {
        shell(readFileFromWorkspace('testeng/resources/travis-job-counts.sh'))
      }


### PR DESCRIPTION
Some of our jobs are not timestamped, which is making splunk reporting difficult. The build flows do not allow you to add timestamps via the gui, so it will appear as though this is not possible, but I have tested locally