### PR TITLE
add log rotator to testeng jobs

### DIFF
--- a/testeng/jobs/buildPackerAMIjob.groovy
+++ b/testeng/jobs/buildPackerAMIjob.groovy
@@ -5,6 +5,7 @@ import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_TEAM_SECURITY
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_MASKED_PASSWORD
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 
 Map config = [:]
 Binding bindings = getBinding()
@@ -89,6 +90,7 @@ secretMap.each { jobConfigs ->
                         'Base ami on which to run the Packer script')
         }
 
+        logRotator JENKINS_PUBLIC_LOG_ROTATOR()
         concurrentBuild(true)
         label('coverage-worker')
 

--- a/testeng/jobs/oep2Report.groovy
+++ b/testeng/jobs/oep2Report.groovy
@@ -1,5 +1,7 @@
 package testeng
 
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
+
 job('oep2-report') {
 
     description('Generate a report describing OEP-2 compliance accross edX repos')
@@ -8,6 +10,7 @@ job('oep2-report') {
         permissionAll('edx')
         permission('hudson.model.Item.Discover', 'anonymous')
     }
+    logRotator JENKINS_PUBLIC_LOG_ROTATOR()
     concurrentBuild(false)
     label('jenkins-worker')
     scm {

--- a/testeng/jobs/toggleSpigot.groovy
+++ b/testeng/jobs/toggleSpigot.groovy
@@ -3,6 +3,7 @@ package testeng
 import hudson.util.Secret
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_MASKED_PASSWORD
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 
 Map config = [:]
 Binding bindings = getBinding()
@@ -60,6 +61,7 @@ secretMap.each { jobConfigs ->
                         'Whether the spigot should be ON or OFF')
         }
 
+        logRotator JENKINS_PUBLIC_LOG_ROTATOR()
         concurrentBuild(false)
 
         scm {


### PR DESCRIPTION
These jobs didn't have log rotation set up. this will use the common pattern of keeping only the last 14 days of builds 