### PR TITLE
use common log rotator for loadtest jobs

### DIFF
--- a/testeng/jobs/loadtestDriver.groovy
+++ b/testeng/jobs/loadtestDriver.groovy
@@ -1,6 +1,7 @@
 package testeng
 
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_TEAM_SECURITY
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 
 /* loadtestDriver.groovy
  *
@@ -126,6 +127,8 @@ buildFlowJob('run-simple-loadtest') {
 
     concurrentBuild(true)
 
+    logRotator JENKINS_PUBLIC_LOG_ROTATOR()
+
     wrappers {
         buildUserVars() /* gives us access to BUILD_USER_ID, among other things */
         buildName('#${BUILD_NUMBER} by ${ENV,var="BUILD_USER_ID"}')
@@ -168,6 +171,8 @@ job('loadtest-driver') {
      * elsewhere.
      */
     concurrentBuild(true)
+
+    logRotator JENKINS_PUBLIC_LOG_ROTATOR()
 
     /* This worker label corresponds to an AMI built using
      * util/packer/jenkins_worker_loadtest.json from edx/configuration.
@@ -229,6 +234,8 @@ job('loadtest-summary') {
     }
 
     concurrentBuild(true)
+
+    logRotator JENKINS_PUBLIC_LOG_ROTATOR()
 
     /* Build this on a loadtest-driver-worker instead of a generic jenkins worker because the former is likely already
      * online.


### PR DESCRIPTION
This will clean up any loadtest-* job older than 14 days, similar to how we manage the platform testing jobs. If you need to keep a particular build, navigate to the build page and click the 'Keep this build forever' button in the top right corner. For example, see: https://build.testeng.edx.org/view/All/job/edx-platform-lettuce-pr/41299/ (NOTE: you won't see these on the loadtest jobs, because they are currently kept forever :) ).