### PR TITLE
Add job to run platform views dsl

### DIFF
--- a/testeng/jobs/seedViews.groovy
+++ b/testeng/jobs/seedViews.groovy
@@ -1,0 +1,21 @@
+package testeng
+
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
+
+job('seed-views') {
+
+    description('Run the platform views dsl on Jenkins startup.')
+
+    logRotator JENKINS_PUBLIC_LOG_ROTATOR()
+    concurrentBuild(false)
+
+    steps {
+        downstreamParameterized {
+            trigger('manually-seed-one-job') {
+                parameters {
+                    predefinedProp('DSL_SCRIPT', 'platform/views/*')
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
We can easily generate the job views by running this when we setup a new instance.