### PR TITLE
run toggle spigot on master only

### DIFF
--- a/testeng/jobs/toggleSpigot.groovy
+++ b/testeng/jobs/toggleSpigot.groovy
@@ -62,6 +62,7 @@ secretMap.each { jobConfigs ->
         }
 
         logRotator JENKINS_PUBLIC_LOG_ROTATOR()
+        label('master')
         concurrentBuild(false)
 
         scm {


### PR DESCRIPTION
We should only run the toggle spigot job on master. This should hopefully help when workers are in a problematic state