### PR TITLE
Set the pylint threshold so that it will not affect the build status

### DIFF
--- a/platform/jobs/edxPlatformQualityMaster.groovy
+++ b/platform/jobs/edxPlatformQualityMaster.groovy
@@ -187,7 +187,7 @@ secretMap.each { jobConfigs ->
                 pep8(1, 2, 3, '**/pep8.report')
                 perlcritic(10, 999, 999)
                 pmd(10, 999, 999)
-                pylint(10, 4500, 4500, '**/*pylint.report')
+                pylint(10, 10000, 10000, '**/*pylint.report')
                 simian(10, 999, 999)
                 stylecop(10, 999, 999)
                 sourceEncoding()


### PR DESCRIPTION
I've already made this change manually to unblock the release pipeline.
This PR is so that the next time we reseed the job we will not lose the change.