### PR TITLE
Delete coverage builds after 1 day

### DIFF
--- a/platform/jobs/edxPlatformUnitCoverage.groovy
+++ b/platform/jobs/edxPlatformUnitCoverage.groovy
@@ -1,7 +1,6 @@
 package platform
 
 import org.yaml.snakeyaml.Yaml
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
 
 stringParams = [
@@ -89,7 +88,12 @@ jobConfigs.each { jobConfig ->
 
     job(jobConfig.jobName) {
 
-        logRotator JENKINS_PUBLIC_LOG_ROTATOR()
+        logRotator{
+            daysToKeep(1)
+            numToKeep(-1)
+            artifactDaysToKeep(-1)
+            artifactNumToKeep(-1)
+        }
         if (!jobConfig.open.toBoolean()) {
             authorization GENERAL_PRIVATE_JOB_SECURITY()
         }


### PR DESCRIPTION
Nobody actually ever looks at those builds. This is a downstream job to the python unittests job, and the results are passed back up to it.
Each build stores ~140M of artifacts.

We probably don't even need to keep them for one day. A more bold move would be to only keep the last 1 result. I'm open to that, or getting this in now and circling back later.