### PR TITLE
use db cache creds in subet job

### DIFF
--- a/platform/jobs/edxPlatformTestSubset.groovy
+++ b/platform/jobs/edxPlatformTestSubset.groovy
@@ -155,6 +155,10 @@ secretMap.each { jobConfigs ->
                 sshAgent(jobConfig['credential'])
             }
             buildName('#\${BUILD_NUMBER}: \${ENV,var=\"TEST_SUITE\"} \${ENV,var=\"SHARD\"}')
+            credentialsBinding {
+                string('AWS_ACCESS_KEY_ID', 'DB_CACHE_ACCESS_KEY_ID')
+                string('AWS_SECRET_ACCESS_KEY', 'DB_CACHE_SECRET_ACCESS_KEY')
+            }
         }
 
         /* Actual build steps for this job */


### PR DESCRIPTION
Related to https://github.com/edx/edx-platform/pull/17062. This will allow the jenkins job that runs the tests to access the s3 bucket where the cache files are stored