### PR TITLE
add creds to a11y jobs for db caching

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -138,6 +138,10 @@ secretMap.each { jobConfigs ->
             if (!jobConfig['open'].toBoolean()) {
                 sshAgent(jobConfig['credential'])
             }
+            credentialsBinding {
+                string('AWS_ACCESS_KEY_ID', 'DB_CACHE_ACCESS_KEY_ID')
+                string('AWS_SECRET_ACCESS_KEY', 'DB_CACHE_SECRET_ACCESS_KEY')
+            }
         }
 
         Map <String, String> predefinedPropsMap  = [:]

--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -174,6 +174,10 @@ jobConfigs.each { jobConfig ->
            if (!jobConfig.open.toBoolean()) {
                sshAgent('jenkins-worker')
            }
+           credentialsBinding {
+               string('AWS_ACCESS_KEY_ID', 'DB_CACHE_ACCESS_KEY_ID')
+               string('AWS_SECRET_ACCESS_KEY', 'DB_CACHE_SECRET_ACCESS_KEY')
+           }
        }
        steps {
            shell("cd ${jobConfig.repoName}; bash scripts/accessibility-tests.sh")


### PR DESCRIPTION
I forgot that a11y jobs will also need to use the credentials for pushing to s3