### PR TITLE
Change bot user in cache uploader job

### DIFF
--- a/testeng/jobs/bokchoyDbCacheUploader.groovy
+++ b/testeng/jobs/bokchoyDbCacheUploader.groovy
@@ -125,7 +125,7 @@ secretMap.each { jobConfigs ->
 
         wrappers {
             credentialsBinding {
-                string('GITHUB_TOKEN', 'GITHUB_STATUS_OAUTH_TOKEN')
+                string('GITHUB_TOKEN', 'GITHUB_CACHE_UPLOADER_TOKEN')
             }
             timestamps()
         }


### PR DESCRIPTION
The job was never updated to use the new bot.