### PR TITLE
Include db cache credentials in packer job

### DIFF
--- a/src/test/resources/testeng/secrets/build-packer-ami-secret.yml
+++ b/src/test/resources/testeng/secrets/build-packer-ami-secret.yml
@@ -2,6 +2,8 @@ BuildPackerAMIConfig:
     awsAccessKeyId: ABC123
     awsSecretAccessKey: qwerty123
     awsSecurityGroup: abc123
+    DBCacheAccessKeyId: ABC123
+    DBCacheSecretAccessKey: qwerty123
     jenkinsWorkerAMI: ami-12345
     newRelicKey: aabbccdd1122
     webPageTestBaseAMI: ami-67890

--- a/testeng/jobs/buildPackerAMIjob.groovy
+++ b/testeng/jobs/buildPackerAMIjob.groovy
@@ -31,6 +31,8 @@ catch (any) {
         awsAccessKeyId: 123abc
         awsSecretAccessKey: 123abc
         awsSecurityGroup: 123
+        DBCacheAccessKeyId: 123abc
+        DBCacheSecretAccessKey: 123abc
         newRelicKey: 123abc
         webPageTestBaseAMI: ami-123
         toolsTeam: [ 'users1', 'users2' ]
@@ -45,6 +47,8 @@ secretMap.each { jobConfigs ->
     assert jobConfig.containsKey('awsAccessKeyId')
     assert jobConfig.containsKey('awsSecretAccessKey')
     assert jobConfig.containsKey('awsSecurityGroup')
+    assert jobConfig.containsKey('DBCacheAccessKeyId')
+    assert jobConfig.containsKey('DBCacheSecretAccessKey')
     assert jobConfig.containsKey('newRelicKey')
     assert jobConfig.containsKey('webPageTestBaseAMI')
     assert jobConfig.containsKey('toolsTeam')
@@ -141,6 +145,14 @@ secretMap.each { jobConfigs ->
                     EnvInjectPasswordEntry {
                         name 'WEBPAGE_TEST_BASE_AMI'
                         value Secret.fromString(jobConfig['webPageTestBaseAMI']).getEncryptedValue()
+                    }
+                    EnvInjectPasswordEntry {
+                        name 'DB_CACHE_ACCESS_KEY_ID'
+                        value Secret.fromString(jobConfig['DBCacheAccessKeyId']).getEncryptedValue()
+                    }
+                    EnvInjectPasswordEntry {
+                        name 'DB_CACHE_SECRET_ACCESS_KEY'
+                        value Secret.fromString(jobConfig['DBCacheSecretAccessKey']).getEncryptedValue()
                     }
                 }
             }

--- a/testeng/resources/build-packer-ami.sh
+++ b/testeng/resources/build-packer-ami.sh
@@ -10,6 +10,10 @@ export DELETE_OR_KEEP_AMI=${DELETE_OR_KEEP}
 # Variable is used for installing and setting NewRelic agent on workers
 export NEW_RELIC_KEY=${NEW_RELIC_KEY}
 
+# Variables for boto to connect with the testeng db cache bucket
+export DB_CACHE_ACCESS_KEY_ID=${DB_CACHE_ACCESS_KEY_ID}
+export DB_CACHE_SECRET_ACCESS_KEY=${DB_CACHE_SECRET_ACCESS_KEY}
+
 # Activate the Python virtualenv
 . $HOME/edx-venv/bin/activate
 


### PR DESCRIPTION
Using the credentials binding plugin results in these secrets getting leaked when packer calls ansible, but the existing pattern for injecting secrets as env vars results in them being hidden by the Mask Passwords plugin.