### PR TITLE
turn on django 1.11 unit tests for all prs

### DIFF
--- a/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
@@ -108,7 +108,6 @@ Map django111JobConfig = [ open: true,
                            triggerPhrase: 'jenkins run django upgrade python',
                            targetBranch: 'origin/master',
                            defaultTestengBranch: 'master',
-                           commentOnly: true,
                            djangoVersion: '1.11'
                            ]
 


### PR DESCRIPTION
All pull requests to the edx-platform will now run both unittests and django upgrade (1.11) unittests. This pr does not touch the existing django 1.9 and 1.10 jobs. I will remove them in a separate pull request.

This job should be reseeded on Jenkins once the platform team has confirmed that all unit tests are passing for both normal and django 1.11 unit test jobs