### PR TITLE
fix platform view regex

### DIFF
--- a/platform/views/platformViews.groovy
+++ b/platform/views/platformViews.groovy
@@ -21,7 +21,7 @@ branchList.each { branch ->
         }
 
         jobs {
-            regex("${branch}(-django-upgrade)?-(accessibility|bok-choy|js|lettuce|quality|python-unittests)-pr")
+            regex("${branch}(-django-upgrade)?-(accessibility|bok-choy|js|lettuce|quality|python-unittests|unittests)-pr")
         }
         columns DEFAULT_VIEW.call()
 
@@ -40,7 +40,7 @@ branchList.each { branch ->
 
         jobs {
             name('github-build-status')
-            regex("${branch}(-django-upgrade)?-(accessibility|bok-choy|js|lettuce|quality|python-unittests)-master")
+            regex("${branch}(-django-upgrade)?-(accessibility|bok-choy|js|lettuce|quality|python-unittests|unittests)-master")
         }
         columns DEFAULT_VIEW.call()
     }


### PR DESCRIPTION
The new unit test job is named 'edx-platform-django-upgrade-unittests-pr' (no python in the name), and therefore wasn't being picked up by the regex. I have reseeded on test jenkins:
* https://test-jenkins.testeng.edx.org/view/edx-platform-master-tests/
* https://test-jenkins.testeng.edx.org/view/edx-platform-pr-tests/

NOTE: quality is not present in those views, because JZ has temporarily renamed it on test jenkins