### PR TITLE
only run django jobs via trigger phrase

### DIFF
--- a/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
@@ -108,6 +108,7 @@ Map django111JobConfig = [ open: true,
                            triggerPhrase: 'jenkins run django upgrade python',
                            targetBranch: 'origin/master',
                            defaultTestengBranch: 'master',
+                           commentOnly: true,
                            djangoVersion: '1.11'
                            ]
 


### PR DESCRIPTION
While I test out https://github.com/edx/edx-platform/commit/0514e0a9074a4d886abb08a381a620933992efce, I want to enable the django upgrade jobs via trigger phrase only