### PR TITLE
Revert "only run django jobs via trigger phrase"

### DIFF
--- a/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
@@ -108,7 +108,6 @@ Map django111JobConfig = [ open: true,
                            triggerPhrase: 'jenkins run django upgrade python',
                            targetBranch: 'origin/master',
                            defaultTestengBranch: 'master',
-                           commentOnly: true,
                            djangoVersion: '1.11'
                            ]
 


### PR DESCRIPTION
Reverts edx/jenkins-job-dsl#301. Now that https://github.com/edx/edx-platform/pull/17361 has landed on the platform, we can remove this.