### PR TITLE
Zub/ent 641 additional command options for dsl jobs

### DIFF
--- a/devops/jobs/RunAnsible.groovy
+++ b/devops/jobs/RunAnsible.groovy
@@ -106,7 +106,7 @@ class RunAnsible {
             def module_args = extraVars.get('MODULE_ARGS')
 
             if (extraVars.get('MANAGEMENT_COMMAND_EXTRA')) {
-                module_args = module_args + ""
+                module_args = module_args + extraVars.get('MANAGEMENT_COMMAND_EXTRA')
             }
 
             // Parameters from the seed job that you don't override, they're just part of

--- a/devops/jobs/RunAnsible.groovy
+++ b/devops/jobs/RunAnsible.groovy
@@ -67,6 +67,8 @@ class RunAnsible {
                             'Git repo containing the analytics pipeline configuration automation.')
                 stringParam('CONFIGURATION_BRANCH', extraVars.get('CONFIGURATION_BRANCH', 'master'),
                             'e.g. tagname or origin/branchname')
+                stringParam('MANAGEMENT_COMMAND_EXTRA', extraVars.get('MANAGEMENT_COMMAND_EXTRA', ''),
+                            'Extra options for the current management command, e.g. "--extra_option_1 true')
             }
 
             def access_control = extraVars.get('ACCESS_CONTROL',[])
@@ -101,6 +103,12 @@ class RunAnsible {
                 maxPerNode(1)
             }
 
+            def module_args = extraVars.get('MODULE_ARGS')
+
+            if (extraVars.get('MANAGEMENT_COMMAND_EXTRA')) {
+                module_args = module_args + ""
+            }
+
             // Parameters from the seed job that you don't override, they're just part of
             // the run.  We need to load different ssh keys per env anyway.
             environmentVariables {
@@ -111,7 +119,7 @@ class RunAnsible {
                 env("CLUSTER", extraVars.get('CLUSTER'))
                 env("BECOME_USER", extraVars.get('BECOME_USER',''))
                 env('ANSIBLE_MODULE_NAME', extraVars.get('MODULE_NAME','shell'))
-                env('ANSIBLE_MODULE_ARGS', extraVars.get('MODULE_ARGS'))
+                env('ANSIBLE_MODULE_ARGS', module_args)
                 env('PATTERN', extraVars.get('PATTERN',''))
                 env('INVENTORY', extraVars.get('INVENTORY',''))
                 env('CUSTOM_INVENTORY', extraVars.get('CUSTOM_INVENTORY',''))


### PR DESCRIPTION
@asadiqbal08 @saleem-latif  @georgebabey @jibsheet @fredsmith 
This is an example PR for  adding a new generic field `MANAGEMENT_COMMAND_EXTRA` for all jenkins dsl jobs. This way we can dynamically provide additional parameter to django management commands by providing parameter like `--additional_parameter true`.

If additional parameter is provided by user then we can append the value of field `MANAGEMENT_COMMAND_EXTRA` to the management commands declared in edx-internal.

**Jenkins "Build with Parameters" page:**
<img width="1401" alt="screen shot 2018-02-07 at 6 01 05 pm" src="https://user-images.githubusercontent.com/5072991/35917754-1242133a-0c31-11e8-8401-eee2d1f2805a.png">
