### PR TITLE
Add in TEST_SUITE env name in a11y dsl

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -153,7 +153,7 @@ secretMap.each { jobConfigs ->
                                   'job/' + jobConfig['jobName'] + '/${BUILD_NUMBER}/')
         steps { //trigger GitHub-Build-Status and run accessibility tests
             downstreamParameterized JENKINS_PUBLIC_GITHUB_STATUS_PENDING.call(predefinedPropsMap)
-            shell("cd ${jobConfig['repoName']}; bash scripts/accessibility-tests.sh")
+            shell("cd ${jobConfig['repoName']}; TEST_SUITE=a11y bash scripts/accessibility-tests.sh")
         }
         publishers { //publish artifacts and JUnit Test report, trigger GitHub-Build-Status, message on hipchat
            archiveArtifacts {

--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -180,7 +180,7 @@ jobConfigs.each { jobConfig ->
            }
        }
        steps {
-           shell("cd ${jobConfig.repoName}; bash scripts/accessibility-tests.sh")
+           shell("cd ${jobConfig.repoName}; TEST_SUITE=a11y bash scripts/accessibility-tests.sh")
        }
        publishers {
            publishHtml {


### PR DESCRIPTION
To make paver timing log names unique we are now going to use the TEST_SUITE env var. a11y jobs are the only type without this variable (since they call a specific script rather than generic-ci), but let's add it in for this use case.