### PR TITLE
Add a test notifier job

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -5,6 +5,7 @@ import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTA
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_WHITELIST_BRANCH
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_EDX_PLATFORM_TEST_NOTIFIER
 
 /* stdout logger */
 Map config = [:]
@@ -199,6 +200,9 @@ jobConfigs.each { jobConfig ->
                defaultExcludes()
            }
            archiveJunit(JENKINS_PUBLIC_JUNIT_REPORTS)
+           if (jobConfig.repoName == "edx-platform") {
+               downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER.call('${ghprbPullId}')
+           }
        }
     }
 }

--- a/platform/jobs/edxPlatformBokChoyPr.groovy
+++ b/platform/jobs/edxPlatformBokChoyPr.groovy
@@ -6,6 +6,7 @@ import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_RE
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_BLACKLIST_BRANCH
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_WHITELIST_BRANCH
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_EDX_PLATFORM_TEST_NOTIFIER
 
 /* stdout logger */
 /* use this instead of println, because you can pass it into closures or other scripts. */
@@ -269,6 +270,9 @@ jobConfigs.each { jobConfig ->
         dslFile('testeng-ci/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy')
         publishers { //publish JUnit Test report
             archiveJunit(JENKINS_PUBLIC_JUNIT_REPORTS)
+            if (jobConfig.repoName == "edx-platform") {
+                downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER('${ghprbPullId}')
+            }
         }
     }
 }

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -5,6 +5,8 @@ import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTA
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_WHITELIST_BRANCH
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_EDX_PLATFORM_TEST_NOTIFIER
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_STATUS_UNSTABLE_OR_WORSE
 
 String archiveReports = 'edx-platform*/reports/**/*,edx-platform*/test_root/log/*.png,'
 archiveReports += 'edx-platform*/test_root/log/*.log,'
@@ -209,6 +211,9 @@ jobConfigs.each { jobConfig ->
                 }
             }
             archiveJunit(JENKINS_PUBLIC_JUNIT_REPORTS)
+            if (jobConfig.repoName == "edx-platform") {
+                downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER.call('${ghprbPullId}')
+            }
         }
     }
 }

--- a/platform/jobs/edxPlatformLettucePr.groovy
+++ b/platform/jobs/edxPlatformLettucePr.groovy
@@ -5,6 +5,7 @@ import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTA
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_WHITELIST_BRANCH
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_EDX_PLATFORM_TEST_NOTIFIER
 
 /* stdout logger */
 /* use this instead of println, because you can pass it into closures or other scripts. */
@@ -249,6 +250,9 @@ jobConfigs.each { jobConfig ->
         dslFile('testeng-ci/jenkins/flow/pr/edx-platform-lettuce-pr.groovy')
         publishers {
             archiveJunit(JENKINS_PUBLIC_JUNIT_REPORTS)
+            if (jobConfig.repoName == "edx-platform") {
+                downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER('${ghprbPullId}')
+            }
         }
     }
 }

--- a/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
@@ -5,6 +5,7 @@ import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTA
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_WHITELIST_BRANCH
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_EDX_PLATFORM_TEST_NOTIFIER
 
 /* stdout logger */
 Map config = [:]
@@ -308,6 +309,9 @@ jobConfigs.each { jobConfig ->
                     node / publishers << 'jenkins.plugins.shiningpanda.publishers.CoveragePublisher' {
                     }
                 }
+            }
+            if (jobConfig.repoName == "edx-platform") {
+                downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER('${ghprbPullId}')
             }
         }
     }

--- a/platform/jobs/edxPlatformQualityPr.groovy
+++ b/platform/jobs/edxPlatformQualityPr.groovy
@@ -5,6 +5,7 @@ import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTA
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_BASEURL
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_WHITELIST_BRANCH
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_EDX_PLATFORM_TEST_NOTIFIER
 
 /* stdout logger */
 /* use this instead of println, because you can pass it into closures or other scripts. */
@@ -180,6 +181,9 @@ jobConfigs.each { jobConfig ->
                     keepAll(true)
                     allowMissing(true)
                 }
+            }
+            if (jobConfig.repoName == "edx-platform") {
+                downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER('${ghprbPullId}')
             }
         }
     }

--- a/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
@@ -58,7 +58,7 @@ class JenkinsPublicConstants {
     }
   }
 
-  public static final Closure JENKINS_PUBLIC_HIPCHAT = {authToken ->
+  public static final Closure JENKINS_PUBLIC_HIPCHAT = { authToken ->
     return {
             token(authToken)
             rooms('new-jenkins-chatter')
@@ -85,6 +85,17 @@ class JenkinsPublicConstants {
                                                               'edx-platform*/reports/quality.xml,edx-platform*/reports/javascript/' +
                                                               'javascript_xunit*.xml,edx-platform*/reports/a11y/**/xunit.xml,' +
                                                               'edx-platform*/reports/bok_choy/**/xunit.xml'
+
+    public static final Closure JENKINS_EDX_PLATFORM_TEST_NOTIFIER = { prNumber ->
+        return {
+            trigger('edx-platform-test-notifier') {
+                condition('ALWAYS')
+                parameters {
+                    predefinedProp('PR_NUMBER', prNumber)
+                }
+            }
+        }
+    }
 
     public static final Closure JENKINS_PUBLIC_GITHUB_STATUS_PENDING = { predefinedPropsMap ->
         return {

--- a/testeng/jobs/edxPlatformTestNotifierJob.groovy
+++ b/testeng/jobs/edxPlatformTestNotifierJob.groovy
@@ -1,0 +1,48 @@
+package testeng
+
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_MASKED_PASSWORD
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
+
+job('edx-platform-test-notifier') {
+
+    description('Alert developers when edx-platform PR tests are completed.')
+
+    authorization GENERAL_PRIVATE_JOB_SECURITY()
+
+    parameters {
+        stringParam('PR_NUMBER', null,
+                    'edx-platform PR number to comment')
+    }
+
+    logRotator JENKINS_PUBLIC_LOG_ROTATOR()
+    label('flow-worker-bokchoy || flow-worker-python || flow-worker-quality || flow-worker-lettuce')
+    concurrentBuild()
+
+    scm {
+        git {
+            remote {
+                url('https://github.com/edx/testeng-ci.git')
+            }
+            branch('youngstrom/test-notifier')
+            browser()
+        }
+    }
+
+    wrappers {
+        timestamps()
+        credentialsBinding {
+            string('GITHUB_TOKEN', 'GITHUB_STATUS_OAUTH_TOKEN')
+        }
+    }
+
+    steps {
+        shell(readFileFromWorkspace('testeng/resources/edx-platform-test-notifier.sh'))
+    }
+
+    publishers {
+        mailer('testeng@edx.org')
+        hipChat JENKINS_PUBLIC_HIPCHAT.call('') // Use the token specified in the global configuration
+    }
+}

--- a/testeng/resources/edx-platform-test-notifier.sh
+++ b/testeng/resources/edx-platform-test-notifier.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+virtualenv test_notifier_venv -q
+source test_notifier_venv/bin/activate
+
+echo "Installing python requirements..."
+pip install -q -r requirements.txt
+
+echo "Running test notifier script..."
+python jenkins/edx-platform-test-notifier.py --pr_number $PR_NUMBER


### PR DESCRIPTION
Adds a job that comments on edx-platform PR's to inform developers that their tests are complete. This will help prevent developers from staring at their PR until they see a green check, and will avoid any lost time between when their tests actually finish and when they realize they are done.