### PR TITLE
fail quality fast

### DIFF
--- a/platform/jobs/edxPlatformTestSubset.groovy
+++ b/platform/jobs/edxPlatformTestSubset.groovy
@@ -163,6 +163,7 @@ secretMap.each { jobConfigs ->
 
         /* Actual build steps for this job */
         steps {
+            shell(readFileFromWorkspace('platform/resources/quality-fail-fast.sh'))
             shell('bash scripts/all-tests.sh')
         }
 

--- a/platform/resources/quality-fail-fast.sh
+++ b/platform/resources/quality-fail-fast.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Temporary fix
+
+# This script will ensure that pull requests that were open before 
+# https://github.com/edx/edx-platform/pull/17252 was merged into the platform
+# do not report false positives for quality. The thresholds.sh file was introduced
+# in this pull request. If it is not present, fail fast.
+
+# Once all prs have been rebased to contain this fix, remove this script
+
+if [[ $TEST_SUITE == 'quality' ]] && [[ ! -e 'scripts/thresholds.sh' ]]; then
+    echo 'The quality job has been refactored and requires a fix in the platform.'
+    echo 'Please rebase your pr and rerun this test'
+    exit 1
+fi


### PR DESCRIPTION
This is a temporary fix while we roll out the new sharded quality pr job. To make sure that people with existing pull requests that do not yet contain the fix in edx/edx-platform#17252 do not pass quality without actually running anything, this will fail fast on the quality flow job, alerting them that they need to rebase