### PR TITLE
Create a job to count workers on build jenkins

### DIFF
--- a/testeng/jobs/countWorkers.groovy
+++ b/testeng/jobs/countWorkers.groovy
@@ -1,0 +1,36 @@
+package testeng
+
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
+
+job('count-workers') {
+
+    logRotator JENKINS_PUBLIC_LOG_ROTATOR()
+    label('master')
+    concurrentBuild(false)
+
+    scm {
+        git {
+            remote {
+                url('https://github.com/edx/testeng-ci.git')
+            }
+            branch('*/master')
+            browser()
+        }
+    }
+
+    triggers{
+        cron('*/5 * * * *')
+    }
+
+    wrappers {
+        timestamps()
+    }
+
+    steps {
+        shell(readFileFromWorkspace('testeng/resources/count-workers.sh'))
+    }
+
+    publishers {
+        mailer('testeng@edx.org')
+    }
+}

--- a/testeng/resources/count-workers.sh
+++ b/testeng/resources/count-workers.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+virtualenv workers_venv -q
+source workers_venv/bin/activate
+
+echo "Installing python requirements..."
+pip install -q -r requirements.txt
+
+echo "Counting workers for build jenkins..."
+python jenkins/workers.py -j https://build.testeng.edx.org


### PR DESCRIPTION
We already had a testeng-ci script, but we weren't actively using it.