### PR TITLE
Remove django/ firefox jobs from DSL

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -69,28 +69,16 @@ Map ficusJobConfig = [
     defaultBranch : 'refs/heads/open-release/ficus.master'
 ]
 
-Map firefox57JobConfig = [
-    open : true,
-    jobName : 'edx-platform-firefox-upgrade-accessibility-master',
-    repoName: 'edx-platform',
-    workerLabel: 'ff-59-jenkins-worker',
-    context: 'jenkins/ff-59-a11y',
-    refSpec : '+refs/heads/estute/jenkins-ff-57-b:refs/remotes/origin/estute/jenkins-ff-57-b',
-    defaultBranch : 'estute/jenkins-ff-57-b'
-]
-
 List jobConfigs = [
     publicJobConfig,
     privateJobConfig,
     ginkgoJobConfig,
-    ficusJobConfig,
-    firefox57JobConfig
+    ficusJobConfig
 ]
 
 jobConfigs.each { jobConfig ->
 
     job(jobConfig.jobName) {
-
 
         if (!jobConfig.open.toBoolean()) {
             authorization GENERAL_PRIVATE_JOB_SECURITY()

--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -50,45 +50,6 @@ Map publicJobConfig = [
     triggerPhrase: /.*jenkins\W+run\W+a11y.*/
 ]
 
-Map django19JobConfig = [
-    open : true,
-    jobName : 'edx-platform-django-1.9-accessibility-pr',
-    repoName: 'edx-platform',
-    workerLabel: 'django-upgrade-worker',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-1.9/a11y',
-    triggerPhrase: /.*jenkins\W+run\W+django19\W+a11y.*/,
-    defaultTestengBranch: 'master',
-    commentOnly: true,
-    djangoVersion: '1.9'
-]
-
-Map django110JobConfig = [
-    open : true,
-    jobName : 'edx-platform-django-1.10-accessibility-pr',
-    repoName: 'edx-platform',
-    workerLabel: 'django-upgrade-worker',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-1.10/a11y',
-    triggerPhrase: /.*jenkins\W+run\W+django110\W+a11y.*/,
-    defaultTestengBranch: 'master',
-    commentOnly: true,
-    djangoVersion: '1.10'
-]
-
-Map django111JobConfig = [
-    open : true,
-    jobName : 'edx-platform-django-upgrade-accessibility-pr',
-    repoName: 'edx-platform',
-    workerLabel: 'django-upgrade-worker',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-upgrade/a11y',
-    triggerPhrase: /.*jenkins\W+run\W+django\W+upgrade\W+a11y.*/,
-    defaultTestengBranch: 'master',
-    commentOnly: true,
-    djangoVersion: '1.11'
-]
-
 Map privateJobConfig = [
     open: false,
     jobName: 'edx-platform-accessibility-pr_private',
@@ -139,27 +100,13 @@ Map privateFicusJobConfig = [
     triggerPhrase: /.*ficus\W+run\W+a11y.*/
 ]
 
-Map firefox57JobConfig = [
-    open : true,
-    jobName : 'edx-platform-firefox-upgrade-accessibility-pr',
-    repoName: 'edx-platform',
-    workerLabel: 'ff-59-jenkins-worker',
-    whitelistBranchRegex: /estute\/jenkins-ff-57-b/,
-    context: 'jenkins/ff-59-a11y',
-    triggerPhrase: /.*jenkins\W+run\W+firefox\W+upgrade\W+a11y.*/
-]
-
 List jobConfigs = [
     publicJobConfig,
     privateJobConfig,
-    django19JobConfig,
-    django110JobConfig,
-    django111JobConfig,
     publicGinkgoJobConfig,
     privateGinkgoJobConfig,
     publicFicusJobConfig,
-    privateFicusJobConfig,
-    firefox57JobConfig
+    privateFicusJobConfig
 ]
 
 /* Iterate over the job configurations */
@@ -175,13 +122,6 @@ jobConfigs.each { jobConfig ->
         }
         logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
         concurrentBuild()
-        environmentVariables {
-            // Only define the Django version if explicitly defined in a config.
-            // Otherwise, the default version will be used
-            if (jobConfig.containsKey('djangoVersion')) {
-                env('DJANGO_VERSION', jobConfig.djangoVersion)
-            }
-        }
         parameters {
             labelParam('WORKER_LABEL') {
                 description('Select a Jenkins worker label for running this job')

--- a/platform/jobs/edxPlatformBokChoyMaster.groovy
+++ b/platform/jobs/edxPlatformBokChoyMaster.groovy
@@ -77,24 +77,11 @@ Map publicFicusJobConfig = [
     defaultBranch : 'refs/heads/open-release/ficus.master'
 ]
 
-Map firefox57JobConfig = [
-    open : true,
-    jobName : 'edx-platform-firefox-upgrade-bok-choy-master',
-    subsetJob: 'edx-platform-test-subset',
-    repoName: 'edx-platform',
-    workerLabel: 'ff-59-jenkins-worker',
-    context: 'jenkins/ff-59-bokchoy',
-    defaultTestengBranch: 'master',
-    refSpec : '+refs/heads/estute/jenkins-ff-57-b:refs/remotes/origin/estute/jenkins-ff-57-b',
-    defaultBranch : 'estute/jenkins-ff-57-b'
-]
-
 List jobConfigs = [
     publicJobConfig,
     privateJobConfig,
     publicGinkgoJobConfig,
-    publicFicusJobConfig,
-    firefox57JobConfig
+    publicFicusJobConfig
 ]
 
 /* Iterate over the job configurations */

--- a/platform/jobs/edxPlatformBokChoyPr.groovy
+++ b/platform/jobs/edxPlatformBokChoyPr.groovy
@@ -45,7 +45,6 @@ catch (any) {
 //                       defaultTestengbranch: default branch of the testeng-ci repo for this job
 //                       commentOnly: true/false if this job should only be triggered by explicit comments on
 //                       github. Default behavior: triggered by comments AND pull request updates
-//                       djangoVersion: version of django to run tests with (via tox)
 //                       ]
 
 Map publicJobConfig = [ open : true,
@@ -59,45 +58,6 @@ Map publicJobConfig = [ open : true,
                         triggerPhrase: /.*jenkins\W+run\W+bokchoy.*/,
                         defaultTestengBranch: 'master'
                         ]
-
-Map django19JobConfig = [ open : true,
-                          jobName : 'edx-platform-django-1.9-bok-choy-pr',
-                          subsetJob: 'edx-platform-test-subset',
-                          repoName: 'edx-platform',
-                          workerLabel: 'django-upgrade-worker',
-                          whitelistBranchRegex: /^((?!open-release\/).)*$/,
-                          context: 'jenkins/django-1.9/bokchoy',
-                          triggerPhrase: /.*jenkins\W+run\W+django19\W+bokchoy.*/,
-                          defaultTestengBranch: 'master',
-                          commentOnly: true,
-                          djangoVersion: '1.9'
-                          ]
-
-Map django110JobConfig = [ open : true,
-                           jobName : 'edx-platform-django-1.10-bok-choy-pr',
-                           subsetJob: 'edx-platform-test-subset',
-                           repoName: 'edx-platform',
-                           workerLabel: 'django-upgrade-worker',
-                           whitelistBranchRegex: /^((?!open-release\/).)*$/,
-                           context: 'jenkins/django-1.10/bokchoy',
-                           triggerPhrase: /.*jenkins\W+run\W+django110\W+bokchoy.*/,
-                           defaultTestengBranch: 'master',
-                           commentOnly: true,
-                           djangoVersion: '1.10'
-                           ]
-
-Map django111JobConfig = [ open : true,
-                           jobName : 'edx-platform-django-upgrade-bok-choy-pr',
-                           subsetJob: 'edx-platform-test-subset',
-                           repoName: 'edx-platform',
-                           workerLabel: 'django-upgrade-worker',
-                           whitelistBranchRegex: /^((?!open-release\/).)*$/,
-                           context: 'jenkins/django-upgrade/bokchoy',
-                           triggerPhrase: /.*jenkins\W+run\W+django\W+upgrade\W+bokchoy.*/,
-                           defaultTestengBranch: 'master',
-                           commentOnly: true,
-                           djangoVersion: '1.11'
-                           ]
 
 Map privateJobConfig = [ open: false,
                          jobName: 'edx-platform-bok-choy-pr_private',
@@ -154,27 +114,12 @@ Map privateFicusJobConfig = [ open: false,
                               defaultTestengBranch: 'origin/open-release/ficus.master'
                               ]
 
-Map firefox57JobConfig = [ open : true,
-                        jobName : 'edx-platform-firefox-upgrade-bok-choy-pr',
-                        subsetJob: 'edx-platform-test-subset',
-                        repoName: 'edx-platform',
-                        workerLabel: 'ff-59-jenkins-worker',
-                        whitelistBranchRegex: /estute\/jenkins-ff-57-b/,
-                        context: 'jenkins/ff-59-bokchoy',
-                        triggerPhrase: /.*jenkins\W+run\W+firefox\W+upgrade\W+bokchoy.*/,
-                        defaultTestengBranch: 'master'
-                        ]
-
 List jobConfigs = [ publicJobConfig,
-                    django19JobConfig,
-                    django110JobConfig,
-                    django111JobConfig,
                     privateJobConfig,
                     publicGinkgoJobConfig,
                     privateGinkgoJobConfig,
                     publicFicusJobConfig,
-                    privateFicusJobConfig,
-                    firefox57JobConfig
+                    privateFicusJobConfig
                     ]
 
 /* Iterate over the job configurations */
@@ -195,11 +140,6 @@ jobConfigs.each { jobConfig ->
         environmentVariables {
             env('SUBSET_JOB', jobConfig.subsetJob)
             env('REPO_NAME', jobConfig.repoName)
-            // Only define the Django version if explicitly defined in a config.
-            // Otherwise, the default version will be used
-            if (jobConfig.containsKey('djangoVersion')) {
-                env('DJANGO_VERSION', jobConfig.djangoVersion)
-            }
         }
         parameters {
             stringParam('WORKER_LABEL', jobConfig.workerLabel, 'Jenkins worker for running the test subset jobs')

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -59,45 +59,6 @@ Map publicJobConfig = [
     triggerPhrase: /.*jenkins\W+run\W+js.*/
 ]
 
-Map django19JobConfig = [
-    open : true,
-    jobName : 'edx-platform-django-1.9-js-pr',
-    repoName: 'edx-platform',
-    workerLabel: 'django-upgrade-worker',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-1.9/js',
-    triggerPhrase: /.*jenkins\W+run\W+django19\W+js.*/,
-    defaultTestengBranch: 'master',
-    commentOnly: true,
-    djangoVersion: '1.9'
-]
-
-Map django110JobConfig = [
-    open : true,
-    jobName : 'edx-platform-django-1.10-js-pr',
-    repoName: 'edx-platform',
-    workerLabel: 'django-upgrade-worker',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-1.10/js',
-    triggerPhrase: /.*jenkins\W+run\W+django110\W+js.*/,
-    defaultTestengBranch: 'master',
-    commentOnly: true,
-    djangoVersion: '1.10'
-]
-
-Map django111JobConfig = [
-    open : true,
-    jobName : 'edx-platform-django-upgrade-js-pr',
-    repoName: 'edx-platform',
-    workerLabel: 'django-upgrade-worker',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-upgrade/js',
-    triggerPhrase: /.*jenkins\W+run\W+django\W+upgrade\W+js.*/,
-    defaultTestengBranch: 'master',
-    commentOnly: true,
-    djangoVersion: '1.11'
-]
-
 Map privateJobConfig = [
     open: false,
     jobName: 'edx-platform-js-pr_private',
@@ -151,9 +112,6 @@ Map privateFicusJobConfig = [
 List jobConfigs = [
     publicJobConfig,
     privateJobConfig,
-    django19JobConfig,
-    django110JobConfig,
-    django111JobConfig,
     publicGinkgoJobConfig,
     privateGinkgoJobConfig,
     publicFicusJobConfig,
@@ -174,13 +132,6 @@ jobConfigs.each { jobConfig ->
         }
         logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
         concurrentBuild()
-        environmentVariables {
-            // Only define the Django version if explicitly defined in a config.
-            // Otherwise, the default version will be used
-            if (jobConfig.containsKey('djangoVersion')) {
-                env('DJANGO_VERSION', jobConfig.djangoVersion)
-            }
-        }
         parameters {
             labelParam('WORKER_LABEL') {
                 description('Select a Jenkins worker label for running this job')

--- a/platform/jobs/edxPlatformLettucePr.groovy
+++ b/platform/jobs/edxPlatformLettucePr.groovy
@@ -42,7 +42,6 @@ catch (any) {
 //                       defaultTestengbranch: default branch of the testeng-ci repo for this job
 //                       commentOnly: true/false if this job should only be triggered by explicit comments on
 //                       github. Default behavior: triggered by comments AND pull request updates
-//                       djangoVersion: version of django to run tests with (via tox)
 //                       ]
 
 Map publicJobConfig = [ open : true,
@@ -55,45 +54,6 @@ Map publicJobConfig = [ open : true,
                         triggerPhrase: /.*jenkins\W+run\W+lettuce.*/,
                         defaultTestengBranch: 'master'
                         ]
-
-Map django19JobConfig = [ open : true,
-                          jobName : 'edx-platform-django-1.9-lettuce-pr',
-                          subsetJob: 'edx-platform-test-subset',
-                          repoName: 'edx-platform',
-                          workerLabel: 'django-upgrade-worker',
-                          whitelistBranchRegex: /^((?!open-release\/).)*$/,
-                          context: 'jenkins/django-1.9/lettuce',
-                          triggerPhrase: /.*jenkins\W+run\W+django19\W+lettuce.*/,
-                          defaultTestengBranch: 'master',
-                          commentOnly: true,
-                          djangoVersion: '1.9'
-                          ]
-
-Map django110JobConfig = [ open : true,
-                           jobName : 'edx-platform-django-1.10-lettuce-pr',
-                           subsetJob: 'edx-platform-test-subset',
-                           repoName: 'edx-platform',
-                           workerLabel: 'django-upgrade-worker',
-                           whitelistBranchRegex: /^((?!open-release\/).)*$/,
-                           context: 'jenkins/django-1.10/lettuce',
-                           triggerPhrase: /.*jenkins\W+run\W+django110\W+lettuce.*/,
-                           defaultTestengBranch: 'master',
-                           commentOnly: true,
-                           djangoVersion: '1.10'
-                           ]
-
-Map django111JobConfig = [ open : true,
-                           jobName : 'edx-platform-django-upgrade-lettuce-pr',
-                           subsetJob: 'edx-platform-test-subset',
-                           repoName: 'edx-platform',
-                           workerLabel: 'django-upgrade-worker',
-                           whitelistBranchRegex: /^((?!open-release\/).)*$/,
-                           context: 'jenkins/django-upgrade/lettuce',
-                           triggerPhrase: /.*jenkins\W+run\W+django\W+upgrade\W+lettuce.*/,
-                           defaultTestengBranch: 'master',
-                           commentOnly: true,
-                           djangoVersion: '1.11'
-                           ]
 
 Map privateJobConfig = [ open: false,
                          jobName: 'edx-platform-lettuce-pr_private',
@@ -151,9 +111,6 @@ Map privateFicusJobConfig = [ open: false,
                               ]
 
 List jobConfigs = [ publicJobConfig,
-                    django19JobConfig,
-                    django110JobConfig,
-                    django111JobConfig,
                     privateJobConfig,
                     publicGinkgoJobConfig,
                     privateGinkgoJobConfig,
@@ -179,11 +136,6 @@ jobConfigs.each { jobConfig ->
         environmentVariables {
             env('SUBSET_JOB', jobConfig.subsetJob)
             env('REPO_NAME', jobConfig.repoName)
-            // Only define the Django version if explicitly defined in a config.
-            // Otherwise, the default version will be used
-            if (jobConfig.containsKey('djangoVersion')) {
-                env('DJANGO_VERSION', jobConfig.djangoVersion)
-            }
         }
         parameters {
             stringParam('WORKER_LABEL', jobConfig.workerLabel, 'Jenkins worker for running the test subset jobs')

--- a/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
@@ -34,7 +34,6 @@ PrintStream out = config['out']
 //     defaultTestengBranch: default branch of the testeng-ci repo for this job
 //     refSpec: refspec for branches to build
 //     defaultBranch: branch to build
-//     djangoVersion: version of django to run tests with (via tox)
 // ]
 
 Map publicJobConfig = [
@@ -51,23 +50,6 @@ Map publicJobConfig = [
     defaultTestengBranch: 'master',
     refSpec : '+refs/heads/master:refs/remotes/origin/master',
     defaultBranch : 'master'
-]
-
-Map django111JobConfig = [
-    open: true,
-    jobName: 'edx-platform-django-upgrade-unittests-master',
-    flowWorkerLabel: 'flow-worker-django-upgrade-python',
-    subsetJob: 'edx-platform-test-subset',
-    repoName: 'edx-platform',
-    runCoverage: false,
-    coverageJob: 'edx-platform-unit-coverage',
-    workerLabel: 'django-upgrade-worker',
-    context: 'jenkins/django-upgrade/python',
-    targetBranch: 'origin/master',
-    defaultTestengBranch: 'master',
-    refSpec : '+refs/heads/master:refs/remotes/origin/master',
-    defaultBranch : 'master',
-    djangoVersion: '1.11'
 ]
 
 Map privateJobConfig = [
@@ -120,7 +102,6 @@ Map ficusJobConfig = [
 
 List jobConfigs = [
     publicJobConfig,
-    django111JobConfig,
     privateJobConfig,
     ginkgoJobConfig,
     ficusJobConfig
@@ -146,11 +127,6 @@ jobConfigs.each { jobConfig ->
             env('RUN_COVERAGE', jobConfig.runCoverage)
             env('COVERAGE_JOB', jobConfig.coverageJob)
             env('TARGET_BRANCH', jobConfig.targetBranch)
-            // Only define the Django version if explicitly defined in a config.
-            // Otherwise, the default version will be used
-            if (jobConfig.containsKey('djangoVersion')) {
-                env('DJANGO_VERSION', jobConfig.djangoVersion)
-            }
         }
         parameters {
             stringParam('WORKER_LABEL', jobConfig.workerLabel, 'Jenkins worker for running the test subset jobs')

--- a/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
@@ -48,7 +48,6 @@ catch (any) {
 //                       defaultTestengbranch: default branch of the testeng-ci repo for this job
 //                       commentOnly: true/false if this job should only be triggered by explicit comments on
 //                       github. Default behavior: triggered by comments AND pull request updates
-//                       djangoVersion: version of django to run tests with (via tox)
 //                       ]
 
 // Individual Job Configurations
@@ -66,56 +65,6 @@ Map publicJobConfig = [ open: true,
                         targetBranch: 'origin/master',
                         defaultTestengBranch: 'master'
                         ]
-
-Map django19JobConfig = [ open: true,
-                          jobName: 'edx-platform-django-1.9-unittests-pr',
-                          flowWorkerLabel: 'flow-worker-django-upgrade-python',
-                          subsetJob: 'edx-platform-test-subset',
-                          repoName: 'edx-platform',
-                          runCoverage: false,
-                          coverageJob: 'edx-platform-unit-coverage',
-                          workerLabel: 'django-upgrade-worker',
-                          whitelistBranchRegex: /^((?!open-release\/).)*$/,
-                          context: 'jenkins/django-1.9/python',
-                          triggerPhrase: /.*jenkins\W+run\W+django19\W+python.*/,
-                          targetBranch: 'origin/master',
-                          defaultTestengBranch: 'master',
-                          commentOnly: true,
-                          djangoVersion: '1.9'
-                          ]
-
-Map django110JobConfig = [ open: true,
-                           jobName: 'edx-platform-django-1.10-unittests-pr',
-                           flowWorkerLabel: 'flow-worker-django-upgrade-python',
-                           subsetJob: 'edx-platform-test-subset',
-                           repoName: 'edx-platform',
-                           runCoverage: false,
-                           coverageJob: 'edx-platform-unit-coverage',
-                           workerLabel: 'django-upgrade-worker',
-                           whitelistBranchRegex: /^((?!open-release\/).)*$/,
-                           context: 'jenkins/django-1.10/python',
-                           triggerPhrase: /.*jenkins\W+run\W+django110\W+python.*/,
-                           targetBranch: 'origin/master',
-                           defaultTestengBranch: 'master',
-                           commentOnly: true,
-                           djangoVersion: '1.10'
-                           ]
-
-Map django111JobConfig = [ open: true,
-                           jobName: 'edx-platform-django-upgrade-unittests-pr',
-                           flowWorkerLabel: 'flow-worker-django-upgrade-python',
-                           subsetJob: 'edx-platform-test-subset',
-                           repoName: 'edx-platform',
-                           runCoverage: false,
-                           coverageJob: 'edx-platform-unit-coverage',
-                           workerLabel: 'django-upgrade-worker',
-                           whitelistBranchRegex: /^((?!open-release\/).)*$/,
-                           context: 'jenkins/django-upgrade/python',
-                           triggerPhrase: /.*jenkins\W+run\W+django\W+upgrade\W+python.*/,
-                           targetBranch: 'origin/master',
-                           defaultTestengBranch: 'master',
-                           djangoVersion: '1.11'
-                           ]
 
 Map privateJobConfig = [ open: false,
                          jobName: 'edx-platform-python-unittests-pr_private',
@@ -193,9 +142,6 @@ Map privateFicusJobConfig = [ open: false,
                               ]
 
 List jobConfigs = [ publicJobConfig,
-                    django19JobConfig,
-                    django110JobConfig,
-                    django111JobConfig,
                     privateJobConfig,
                     publicGinkgoJobConfig,
                     privateGinkgoJobConfig,
@@ -224,11 +170,6 @@ jobConfigs.each { jobConfig ->
             env('RUN_COVERAGE', jobConfig.runCoverage)
             env('COVERAGE_JOB', jobConfig.coverageJob)
             env('TARGET_BRANCH', jobConfig.targetBranch)
-            // Only define the Django version if explicitly defined in a config.
-            // Otherwise, the default version will be used
-            if (jobConfig.containsKey('djangoVersion')) {
-                env('DJANGO_VERSION', jobConfig.djangoVersion)
-            }
         }
         parameters {
             stringParam('WORKER_LABEL', jobConfig.workerLabel, 'Jenkins worker for running the test subset jobs')

--- a/platform/jobs/edxPlatformQualityPr.groovy
+++ b/platform/jobs/edxPlatformQualityPr.groovy
@@ -57,48 +57,6 @@ Map publicJobConfig = [
     diffJob: 'edx-platform-quality-diff'
 ]
 
-Map django19JobConfig = [
-    open : true,
-    jobName : 'edx-platform-django-1.9-quality-flow-pr',
-    subsetJob: 'edx-platform-test-subset',
-    repoName: 'edx-platform',
-    workerLabel: 'django-upgrade-worker',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-1.9/quality',
-    triggerPhrase: /.*jenkins\W+run\W+django19\W+quality.*/,
-    defaultTestengBranch: 'master',
-    commentOnly: true,
-    djangoVersion: '1.9'
-]
-
-Map django110JobConfig = [
-    open : true,
-    jobName : 'edx-platform-django-1.10-quality-flow-pr',
-    subsetJob: 'edx-platform-test-subset',
-    repoName: 'edx-platform',
-    workerLabel: 'django-upgrade-worker',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-1.10/quality',
-    triggerPhrase: /.*jenkins\W+run\W+django110\W+quality.*/,
-    defaultTestengBranch: 'master',
-    commentOnly: true,
-    djangoVersion: '1.10'
-]
-
-Map django111JobConfig = [
-    open : true,
-    jobName : 'edx-platform-django-upgrade-quality-flow-pr',
-    subsetJob: 'edx-platform-test-subset',
-    repoName: 'edx-platform',
-    workerLabel: 'django-upgrade-worker',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-upgrade/quality',
-    triggerPhrase: /.*jenkins\W+run\W+django\W+upgrade\W+quality.*/,
-    defaultTestengBranch: 'master',
-    commentOnly: true,
-    djangoVersion: '1.11'
-]
-
 Map privateJobConfig = [
     open: false,
     jobName: 'edx-platform-quality-flow-pr_private',
@@ -108,16 +66,12 @@ Map privateJobConfig = [
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/quality',
     triggerPhrase: /.*jenkins\W+run\W+quality.*/,
-    defaultTestengBranch: 'master',
-    diffJob: 'edx-platform-quality-diff_private'
+    defaultTestengBranch: 'master'
 ]
 
 List jobConfigs = [
     publicJobConfig,
-    privateJobConfig,
-    django19JobConfig,
-    django110JobConfig,
-    django111JobConfig,
+    privateJobConfig
 ]
 
 jobConfigs.each { jobConfig ->
@@ -139,11 +93,6 @@ jobConfigs.each { jobConfig ->
             env('REPO_NAME', jobConfig.repoName)
             env('DIFF_JOB', jobConfig.diffJob)
             env('TARGET_BRANCH', 'origin/master')
-            // Only define the Django version if explicitly defined in a config.
-            // Otherwise, the default version will be used
-            if (jobConfig.containsKey('djangoVersion')) {
-                env('DJANGO_VERSION', jobConfig.djangoVersion)
-            }
         }
         parameters {
             stringParam('WORKER_LABEL', jobConfig.workerLabel, 'Jenkins worker for running the test subset jobs')

--- a/platform/views/platformViews.groovy
+++ b/platform/views/platformViews.groovy
@@ -21,7 +21,7 @@ branchList.each { branch ->
         }
 
         jobs {
-            regex("${branch}(-django-upgrade)?-(accessibility|bok-choy|js|lettuce|quality|quality-flow|python-unittests)-pr")
+            regex("${branch}-.*-pr")
         }
         columns DEFAULT_VIEW.call()
 
@@ -40,27 +40,9 @@ branchList.each { branch ->
 
         jobs {
             name('github-build-status')
-            regex("${branch}(-django-upgrade)?-(accessibility|bok-choy|js|lettuce|quality|quality-flow|python-unittests)-master")
+            regex("${branch}-.*-master")
         }
         columns DEFAULT_VIEW.call()
     }
 
-}
-
-listView('django-upgrade-pr-tests') {
-    description('jobs used to run tests on pull requests against various ' +
-                'versions of django during the upgrade process')
-    jobs {
-        regex('edx-platform-django-.*-pr')
-    }
-    columns DEFAULT_VIEW.call()
-}
-
-listView('django-upgrade-master-tests') {
-    description('jobs used to run tests on merges to master against various ' +
-                'versions of django during the upgrade process')
-    jobs {
-        regex('edx-platform-django-.*-master')
-    }
-    columns DEFAULT_VIEW.call()
 }

--- a/src/test/groovy/platform/edxPlatformPrJobSpec.groovy
+++ b/src/test/groovy/platform/edxPlatformPrJobSpec.groovy
@@ -55,12 +55,12 @@ class edxPlatformPrJobSpec extends Specification {
 
         where:
         dslFile                               | numJobs
-        'edxPlatformAccessibilityPr.groovy'   | 10
-        'edxPlatformBokChoyPr.groovy'         | 10
-        'edxPlatformJsPr.groovy'              | 9
-        'edxPlatformLettucePr.groovy'         | 9
-        'edxPlatformPythonUnitTestsPr.groovy' | 9
-        'edxPlatformQualityPr.groovy'         | 5
+        'edxPlatformAccessibilityPr.groovy'   | 6
+        'edxPlatformBokChoyPr.groovy'         | 6
+        'edxPlatformJsPr.groovy'              | 6
+        'edxPlatformLettucePr.groovy'         | 6
+        'edxPlatformPythonUnitTestsPr.groovy' | 6
+        'edxPlatformQualityPr.groovy'         | 2
         'edxPlatformQualityDiff.groovy'       | 2
         'edxPlatformUnitCoverage.groovy'      | 2
     }


### PR DESCRIPTION
The django upgrade to edx-platform is rolling out today, so we can get rid of the upgrade testing jobs we created.

We also upgraded firefox earlier in the week, so I'm removing those temp jobs as well.