### PR TITLE
Add analytics_api as optional install for sandboxes

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -160,6 +160,9 @@ class CreateSandbox {
                 booleanParam("certs",false,"")
                 stringParam("certs_version","master","")
 
+                booleanParam("analytics_api",false,"")
+                stringParam("analytics_api_version","master","")
+
                 booleanParam("insights",false,"")
                 stringParam("insights_version","master","")
 


### PR DESCRIPTION
Runway for the analytics_api config changes in https://github.com/edx/configuration/pull/4443