### PR TITLE
Revert "Make whitelabel options the default for sandbox configuration"

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -142,7 +142,7 @@ class CreateSandbox {
                 booleanParam("forum",true,"")
                 stringParam("forum_version","master","")
 
-                booleanParam("ecommerce",true,"")
+                booleanParam("ecommerce",false,"")
                 stringParam("ecommerce_version","master","")
 
                 booleanParam("notifier",false,"")
@@ -154,7 +154,7 @@ class CreateSandbox {
                 booleanParam("xserver",false,"")
                 stringParam("xserver_version","master","")
 
-                booleanParam("ecommerce_worker",true,"")
+                booleanParam("ecommerce_worker",false,"")
                 stringParam("ecommerce_worker_version","master","")
 
                 booleanParam("certs",false,"")
@@ -172,7 +172,7 @@ class CreateSandbox {
                 booleanParam("credentials",false,"")
                 stringParam("credentials_version","master","")
 
-                booleanParam("set_whitelabel",true,
+                booleanParam("set_whitelabel",false,
                              "Check this in order to create a Sandbox with whitelabel themes automatically set.")
 
                 booleanParam("video_pipeline",false,


### PR DESCRIPTION
Reverts edx/jenkins-job-dsl#330

This is causing sandbox builds to fail:

```
16:58:44 TASK [whitelabel : Create Sites and Themes] ************************************
16:58:44 task path: /edx/var/jenkins/jobs/Sandboxes/jobs/CreateSandbox/workspace/configuration/playbooks/roles/whitelabel/tasks/main.yml:3
16:58:44 fatal: [int.sandbox.edx.org]: FAILED! => {
16:58:44     "failed": true, 
16:58:44     "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'dns_name' is undefined\n\nThe error appears to have been in '/edx/var/jenkins/jobs/Sandboxes/jobs/CreateSandbox/workspace/configuration/playbooks/roles/whitelabel/tasks/main.yml': line 3, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Create Sites and Themes\n  ^ here\n"
16:58:44 }
```