### PR TITLE
add makefile for build jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,79 @@
+SHELL := /usr/bin/env bash
+.DEFAULT_GOAL := help
+
+# List of services defined in docker-compose.yml.  Guard this with a check for
+# the existence of the docker-compose program since we don't want to exit
+# before showing help text.
+ifneq (, $(shell which docker-compose))
+    DOCKER_SERVICES := $(shell docker-compose config --services)
+endif
+
+.PHONY: help clean docker.clean $(DOCKER_SERVICES:%=docker.run.%) $(DOCKER_SERVICES:%=docker.stop.%) $(DOCKER_SERVICES:%=docker.running.%) $(DOCKER_SERVICES:%=docker.configure.%)
+
+help:
+	@echo 'Makefile for launching and configuring edX-related jenkins services.'
+	@echo ''
+	@echo 'These jenkins services are launched via Docker, and are primarily intended for'
+	@echo 'local development of jenkins jobs and features, but may also facilitate with'
+	@echo 'production deploys for the OpenEdX community.'
+	@echo ''
+	@echo 'Available targets:'
+	@echo '    help                       show this information'
+	@echo '    clean                      shutdown and delete running containers, networks, and images specified in docker-compose.yml'
+	@echo '    docker.run.$$service        run the specified jenkins service container'
+	@echo '    docker.stop.$$service       stop the specified jenkins service container'
+	@echo '    docker.running.$$service    check if specified jenkins service container is running'
+	@echo '    docker.configure.$$service  configure the specified jenkins service container'
+	@echo ''
+	@echo '$$service can be one of the services specified in docker-compose.yml'
+
+clean: docker.clean
+
+docker.clean:
+	docker-compose down --rmi all
+	@echo ''
+	@echo 'Service conatiners, networks, and images were successfully removed.'
+	@echo 'If you also wish to remove volumes, deleting all jenkins configuration and jobs,'
+	@echo 'run this command:'
+	@echo ''
+	@echo '    docker-compose down -v'
+
+# docker.run.$service
+# This target fetches the docker image corresponding to the requested jenkins
+# service and launches it into a new container.  If this is used to start
+# jenkins again after stopping it, jenkins jobs and configuration will persist.
+$(DOCKER_SERVICES:%=docker.run.%) : docker.run.% :
+	docker-compose up -d $*
+
+# docker.stop.$service
+# Stop a given jenkins service.  They can be restarted later using
+# docker.run.$service.
+$(DOCKER_SERVICES:%=docker.stop.%) : docker.stop.% :
+	docker-compose stop $*
+
+# docker.running.$service
+# Check if service is running.
+$(DOCKER_SERVICES:%=docker.running.%) : docker.running.% :
+	@docker-compose exec $* /bin/bash -c 'echo "'$*' is running"'
+
+# docker.configure.$service
+# This target picks up any user-specified ansible overrides, then reconfigures
+# and restarts the specified service container.
+docker.configure.jenkins_build : docker.configure.% : ansible_overrides.yml docker.running.%
+	docker cp ansible_overrides.yml $*:/ansible_overrides_extra.yml
+	# The jenkins:local-dev ansible tag is specific to jenkinses that use
+	# the jenkins_common role.
+	docker-compose exec $* /bin/bash -c "PYTHONUNBUFFERED=1 /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook \
+		-v $*.yml \
+		-i '127.0.0.1,' \
+		-c local \
+		-e@/ansible_overrides.yml \
+		-e@/ansible_overrides_extra.yml \
+		-t 'jenkins:local-dev' \
+		-vv"
+	docker-compose restart $*
+
+# Reconfigure jenkins_tools
+docker.configure.jenkins_tools:
+	@echo 'This makefile currently does not support reconfiguring jenkins_tools.'
+	exit 1

--- a/README-Hacking.md
+++ b/README-Hacking.md
@@ -1,28 +1,26 @@
 # Local Development
 
-The simplest way to get started with local development targeted for tools-edx-jenkins is to use our Docker container.
-This container is pre-configured  to run Jenkins. The `docker-compose.yml` file in the root of this repository contains 
-the configuration necessary to  bring a new container online with the proper ports exposed, and volumes shared.
+The simplest way to get started with local development edx-related jenkins services is to use our Docker containers.
+These containers are pre-configured to run Jenkins. The `docker-compose.yml` file in the root of this repository
+contains the configuration necessary to bring a containers online with the proper ports exposed, and volumes shared.
 
 Execute this command from the root of the repository:
 
-    $ docker-compose up
+    $ make docker.run.<name_of_jenkins_service>
 
-If you opt not to use `docker-compose`, the following command will achieve the same results
+Where `<name_of_jenkins_service>` corresponds to services specified in docker-compose.yml.
 
-    $ docker run -it --rm -p 127.0.0.1:8080:8080 -v jenkinsjobdsl_jenkins:/edx/var/jenkins edxops/tools_jenkins:latest
+A volume will be created for the container, which contains all of the configuration for Jenkins and will persist between
+container stops and starts.  For the `jenkins_tools` container, however, plugin updates or installs will cause the
+volume to become recreated (see WIP: Updating the Docker Image below).
 
-
-In both instances port 8080 will be exposed only to the host system, and a volume will be created on the 
-container. This volume contains all of the configuration for Jenkins, and will be preserved between container
-stops and starts, except in the case of plugin updates or installs (see WIP: Updating the Docker Image below).
-
-Once the container is running, you can connect to Jenkins at `http://localhost:8080`.
+Once the container is running, you can connect to Jenkins at `http://localhost:<port>`.  Ports are also configured in
+`docker-compose.yml`.
 
 In order to bootstrap Jenkins in a container you will need to do two things:
 
 1. Set up any credentials required for pulling private repositories.
-2. Set up a seed job to process the job DSL.
+2. Set up a seed job to process the job DSL (this job is automatically created in jenkins_build).
 
 ### Credentials
 
@@ -35,11 +33,11 @@ You create a username/password combination where the password is your token, thi
 Note that if using a personal access token, you can only clone https://github.com/ URLs, and ssh keys only work on git@github.com:edx
 URLs.  We use git@github.com URLs on tools-edx-jenkins with deployment keys, but you can use whatever is simpler in testing.
 
-### Testing DSL
+### Creating the Seed Job
 
-You will need to create a new Jenkins job that executes the DSL, and creates other jobs. This can be done with the steps
-below.  Note that these instructions are for a simple DSL, your seed job documentation may specify cloning multiple DSL/configuration
-repos, or running Gradle.
+You will need to create a new Jenkins job that executes the DSL, and creates other jobs. This is referred to as the
+"seed job".  Note that these instructions are for a simple DSL, your seed job documentation may specify cloning multiple
+DSL/configuration repos, or running Gradle.
 
 1. Use the Jenkins UI to create a new **Freestyle project** job named **Job Creator**.
 2. Configure the job to use **Multiple SCMs** for *Source Control Management*, and add a Git repository. (Note that we 
@@ -134,7 +132,7 @@ Manage Jenkins -> Configure System -> Python installations
 
     Check Install automatically
 
-## WIP: Updating the Docker Image
+## WIP: Updating the Tools Jenkins Docker Image
 
 The [edxops/tools_jenkins](https://hub.docker.com/r/edxops/tools_jenkins/) image is used in the Docker steps above. The required plugins have been pre-installed on the container. Feel free to install additional plugins. If you'd like to add or modify Jenkins plugins, follow the steps below.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,21 @@
 version: "3"
 services:
-  edxops-jenkins:
+  jenkins_tools:
     image: edxops/tools_jenkins:latest
-    container_name: tools_jenkins
+    container_name: jenkins_tools
     volumes:
-        - jenkins:/edx/var/jenkins
+        - jenkins_tools:/edx/var/jenkins
         - /var/run/docker.sock:/var/run/docker.sock
     ports:
       - "127.0.0.1:8080:8080"
+  jenkins_build:
+    image: edxops/jenkins_build:latest
+    container_name: jenkins_build
+    volumes:
+        - jenkins_build:/var/lib/jenkins
+    ports:
+      - "127.0.0.1:8081:8080"
 
 volumes:
-  jenkins:
+  jenkins_tools:
+  jenkins_build:


### PR DESCRIPTION
This adds a Makefile for starting and configuring the build_jenkins docker image for local development or for the openedx community.  I tried my best to make it generic enough to be applicable to both tools and build jenkins, but in many ways the two are still quite different.

The changes in this PR have enabled me to build a pipeline job for retirement (https://github.com/edx/jenkins-job-dsl/pull/337) currently by running:

1. `make docker.run.jenkins_build`
2. create ansible_overrides.yml and bump the version of the job-dsl plugin
3. `make docker.configure.jenkins_build`
4. open the manually_seed_one_job job and manually build the retirement job

At least step 2 will be eliminated via https://github.com/edx/jenkins-configuration/pull/83.

I was hoping to automate step 4, but I already spent too much time figuring that out so I'll skip for now.