### PR TITLE
[loadtestDriver.groovy] change default hatch rate to 5

### DIFF
--- a/testeng/jobs/loadtestDriver.groovy
+++ b/testeng/jobs/loadtestDriver.groovy
@@ -68,7 +68,7 @@ stringParams = [
     name: 'HATCH_RATE',
     description: 'Locust clients will be hatched at this rate ' +
                  '(hatches/second).',
-    default: '30'
+    default: '5'
     ],
     [
     name: 'MAX_RUN_TIME',


### PR DESCRIPTION
Values greater than about 5 cause problems with auto_auth and/or
enrollment of locust users.