### PR TITLE
TE-2548 Add jobs to build named release Docker images

### DIFF
--- a/devops/jobs/AppWatcher.groovy
+++ b/devops/jobs/AppWatcher.groovy
@@ -19,13 +19,16 @@
                 app_repo: <GitHub repository name for the IDA>
                 app_repo_branch: <branch of the above repository to checkout>
                 config_branch: <GitHub branch of configuration repository to checkout>
+                tag_name: <tag to use for the built image>
         For example, 
         APPS_TO_CONFIG:
             ecommerce:
                 app_repo: 'ecommerce'
                 app_repo_branch: 'master'
                 config_branch: 'master'
-        Note that the default for app_repo_branch is master, and the default for config_branch is master; therefore, they do not need to be specified unless you are providing overrides.
+                tag_name: 'latest'
+        Note that the default for app_repo_branch is master, the default for config_branch is master, and the default
+        for tag_name is latest; therefore, they do not need to be specified unless you are providing overrides.
         
         For example,
         APPS_TO_CONFIG:
@@ -110,7 +113,7 @@ class AppWatcher {
                     triggers merge_to_master_trigger(app_repo_branch)
 
                     steps {
-                        // trigger image-builder job, passing commit checked out of the applicatio code repository 
+                        // trigger image-builder job, passing commit checked out of the application code repository 
                        downstreamParameterized {
                             trigger('../image-builders/' + app_name + '-image-builder')
                         }

--- a/devops/jobs/ConfigurationWatcher.groovy
+++ b/devops/jobs/ConfigurationWatcher.groovy
@@ -16,13 +16,16 @@
                 app_repo: <GitHub repository name for the IDA>
                 app_repo_branch: <branch of the above repository to checkout>
                 config_branch: <GitHub branch of configuration repository to checkout>
+                tag_name: <tag to use for the built image>
         For example, 
         APPS_TO_CONFIG:
             ecommerce:
                 app_repo: 'ecommerce'
                 app_repo_branch: 'master'
                 config_branch: 'master'
-        Note that the default for app_repo_branch is master, and the default for config_branch is master; therefore, they do not need to be specified unless you are providing overrides.
+                tag_name: 'latest'
+        Note that the default for app_repo_branch is master, the default for config_branch is master, and the default for tag_name is latest;
+        therefore, they do not need to be specified unless you are providing overrides.
         
         For example,
         APPS_TO_CONFIG:

--- a/devops/resources/build-push-app.sh
+++ b/devops/resources/build-push-app.sh
@@ -3,12 +3,13 @@
 # unofficial bash strict mode
 set -euxo pipefail
 
-image_tag=edxops/${APP_NAME}:latest
+openedx_release=${OPENEDX_RELEASE:-master}
+tag_name=${TAG_NAME:-latest}
+image_tag=edxops/${APP_NAME}:${tag_name}
 
 # build the Dockerfile of the IDA defined by APP_NAME and tag it with its name; don't use cache
 cd configuration
-docker build -f docker/build/${APP_NAME}/Dockerfile -t ${image_tag} --no-cache .
+docker build -f docker/build/${APP_NAME}/Dockerfile --build-arg BASE_IMAGE_TAG=${tag_name} --build-arg OPENEDX_RELEASE=${openedx_release} -t ${image_tag} --no-cache .
 
 # push built image to DockerHub
 docker --config $(dirname ${CONFIG_JSON_FILE}) push ${image_tag}
-


### PR DESCRIPTION
These changes let us create additional jobs for building and tagging devstack Docker images for named Open edX releases, and for automatically rebuilding them when commits are pushed to the appropriate branches in configuration and each app repository.  These will be grouped into their own folders (such as `DockerCI/Hawthorn`) to avoid conflicting with the existing jobs.  The newly supported configuration fields are optional, and in their absence the behavior is unchanged from before.

The new `--build-arg` parameters will be utilized by the Dockerfile changes being made in https://github.com/edx/configuration/pull/4499 .