### PR TITLE
docker images are all launched into the devstack_default network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ docker.clean:
 # service and launches it into a new container.  If this is used to start
 # jenkins again after stopping it, jenkins jobs and configuration will persist.
 $(DOCKER_SERVICES:%=docker.run.%) : docker.run.% :
+	docker network create devstack_default || echo 'devstack_default may already exist'
 	docker-compose up -d $*
 
 # docker.stop.$service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,8 @@ services:
 volumes:
   jenkins_tools:
   jenkins_build:
+
+networks:
+  default:
+    external:
+      name: devstack_default


### PR DESCRIPTION
This convenience should have no ill-effect on the jenkins containers,
but should aid in cases where jenkins jobs are required to communicate
with devstack (e.g. integration testing, local development, etc.).