### PR TITLE
Github teams syntax uses an asterisk instead of slash as delimiter

### DIFF
--- a/platform/jobs/RetirementJobEdxTriggers.groovy
+++ b/platform/jobs/RetirementJobEdxTriggers.groovy
@@ -42,7 +42,7 @@ jobConfigs.each { jobConfig ->
         // but customer support can read and discover.
         authorization {
             blocksInheritance(true)
-            List membersWithFullControl = ['edx/platform-team', 'edx/testeng', 'edx/devops']
+            List membersWithFullControl = ['edx*platform-team', 'edx*testeng', 'edx*devops']
             membersWithFullControl.each { emp ->
                 permissionAll(emp)
             }

--- a/platform/jobs/RetirementJobs.groovy
+++ b/platform/jobs/RetirementJobs.groovy
@@ -28,7 +28,7 @@ job('user-retirement-driver') {
     // but customer support can read and discover.
     authorization {
         blocksInheritance(true)
-        List membersWithFullControl = ['edx/platform-team', 'edx/testeng', 'edx/devops']
+        List membersWithFullControl = ['edx*platform-team', 'edx*testeng', 'edx*devops']
         membersWithFullControl.each { emp ->
             permissionAll(emp)
         }
@@ -144,7 +144,7 @@ job('user-retirement-collector') {
     // but customer support can read and discover.
     authorization {
         blocksInheritance(true)
-        List membersWithFullControl = ['edx/platform-team', 'edx/testeng', 'edx/devops']
+        List membersWithFullControl = ['edx*platform-team', 'edx*testeng', 'edx*devops']
         membersWithFullControl.each { emp ->
             permissionAll(emp)
         }


### PR DESCRIPTION
See <https://wiki.jenkins.io/display/JENKINS/GitHub+OAuth+Plugin#GitHubOAuthPlugin-AuthorizationinGlobalSecurity.>

I just seeded the retirement jobs on test jenkins, but even as administrator I cannot view or discover the jobs, even if I type the url directly: https://test-jenkins.testeng.edx.org/job/user-retirement-collector/

I think I fixed the bug in the PR, but I can't test this locally because I don't use github oauth locally.