### PR TITLE
Give learner and educator some access to retirement jobs

### DIFF
--- a/platform/jobs/RetirementJobEdxTriggers.groovy
+++ b/platform/jobs/RetirementJobEdxTriggers.groovy
@@ -12,18 +12,22 @@ import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTA
 List jobConfigs = [
     [
         environmentDeployment: 'prod-edx',
+        extraMembersCanBuild: [],
         disabled: true
     ],
     [
         environmentDeployment: 'stage-edx',
+        extraMembersCanBuild: ['edx*educator-all', 'edx*learner'],
         disabled: true
     ],
     [
         environmentDeployment: 'loadtest-edx',
+        extraMembersCanBuild: ['edx*educator-all', 'edx*learner'],
         disabled: true
     ],
     [
         environmentDeployment: 'prod-edge',
+        extraMembersCanBuild: [],
         disabled: true
     ]
 ]
@@ -45,6 +49,12 @@ jobConfigs.each { jobConfig ->
             List membersWithFullControl = ['edx*platform-team', 'edx*testeng', 'edx*devops']
             membersWithFullControl.each { emp ->
                 permissionAll(emp)
+            }
+            jobConfig.extraMembersCanBuild.each { emp ->
+                permission('hudson.model.Item.Read', emp)
+                permission('hudson.model.Item.Discover', emp)
+                permission('hudson.model.Item.Build', emp)
+                permission('hudson.model.Item.Cancel', emp)
             }
             // TODO PLAT-2036: uncomment the following two lines when we add the
             // appropriate github group.

--- a/platform/jobs/RetirementJobs.groovy
+++ b/platform/jobs/RetirementJobs.groovy
@@ -32,6 +32,11 @@ job('user-retirement-driver') {
         membersWithFullControl.each { emp ->
             permissionAll(emp)
         }
+        List extraMembersCanView = ['edx*educator-all', 'edx*learner']
+        extraMembersCanView.each { emp ->
+            permission('hudson.model.Item.Read', emp)
+            permission('hudson.model.Item.Discover', emp)
+        }
         // TODO PLAT-2036: uncomment the following two lines when we add the
         // appropriate github group.
         //permission('hudson.model.Item.Read', 'edx/customer-support')
@@ -147,6 +152,11 @@ job('user-retirement-collector') {
         List membersWithFullControl = ['edx*platform-team', 'edx*testeng', 'edx*devops']
         membersWithFullControl.each { emp ->
             permissionAll(emp)
+        }
+        List extraMembersCanView = ['edx*educator-all', 'edx*learner']
+        extraMembersCanView.each { emp ->
+            permission('hudson.model.Item.Read', emp)
+            permission('hudson.model.Item.Discover', emp)
         }
         // TODO PLAT-2036: uncomment the following two lines when we add the
         // appropriate github group.


### PR DESCRIPTION
This gives read access for the retirement collector and driver jobs, and
trigger access to the stage and loadtest retirement trigger jobs.  This
means that they can trigger retirement in stage and loadtest, and follow
their progress, but cannot trigger retirement in prod.  They can,
however, view prod retirement logs (which they could have gotten from
splunk anyway.