### PR TITLE
Default this off

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -173,7 +173,7 @@ class CreateSandbox {
                 booleanParam("credentials",false,"")
                 stringParam("credentials_version","master","")
 
-                booleanParam("set_whitelabel",true,
+                booleanParam("set_whitelabel",false,
                              "Check this in order to create a Sandbox with whitelabel themes automatically set.")
 
                 booleanParam("video_pipeline",false,


### PR DESCRIPTION
It causes issues when we build a new scratch image to live under the sandbox build.  Because whitelabel is run on new scratch AMIs, it already has all the rows in ecommerce.core_siteconfiguration and the management command breaks.

Example of failure
https://tools-edx-jenkins.edx.org/job/Sandboxes/job/CreateSandbox/10705/console

Passing while building on the new base AMI with this unchecked
https://tools-edx-jenkins.edx.org/job/Sandboxes/job/CreateSandbox/10714/console