### PR TITLE
[RetirementJobs] Fix the file pattern for the parameterized trigger

### DIFF
--- a/platform/jobs/RetirementJobs.groovy
+++ b/platform/jobs/RetirementJobs.groovy
@@ -273,7 +273,7 @@ job('user-retirement-collector') {
                 parameterFactories {
                     // This is Dynamic DSL magic that I copied from https://issues.jenkins-ci.org/browse/JENKINS-34552
                     fileBuildParameterFactory {
-                       filePattern('${LEARNERS_TO_RETIRE_PROPERTIES_DIR}/*')
+                       filePattern('learners-to-retire/*')
                        encoding('UTF-8')
                        noFilesFoundAction('SKIP')
                     }


### PR DESCRIPTION
The pattern apparently cannot contain environment variables since they
aren't expanded.  I just replace the environment variable with what it
would expand to, since the name is arbitrary anyway.  It just needs to
stay in sync with the name chosen above.

Tested on build jenkins:

* failed build before this change:
https://build.testeng.edx.org/job/user-retirement-collector/1/
* successful build after this change:
https://build.testeng.edx.org/job/user-retirement-collector/2/