### PR TITLE
[RetirementJobs] give educator build access to retirement driver jobs

### DIFF
--- a/platform/jobs/RetirementJobs.groovy
+++ b/platform/jobs/RetirementJobs.groovy
@@ -28,11 +28,23 @@ job('user-retirement-driver') {
     // but customer support can read and discover.
     authorization {
         blocksInheritance(true)
+        // Only core teams have full control of the retirement driver.
         List membersWithFullControl = ['edx*platform-team', 'edx*testeng', 'edx*devops']
         membersWithFullControl.each { emp ->
             permissionAll(emp)
         }
-        List extraMembersCanView = ['edx*educator-all', 'edx*learner']
+        // Educator is assisting with integration testing and validation, so
+        // they need build access to run the retirement driver against one user
+        // at a time.
+        List extraMembersCanBuild = ['edx*educator-all']
+        extraMembersCanBuild.each { emp ->
+            permission('hudson.model.Item.Build', emp)
+            permission('hudson.model.Item.Cancel', emp)
+            permission('hudson.model.Item.Read', emp)
+            permission('hudson.model.Item.Discover', emp)
+        }
+        // Other engineering teams can view.
+        List extraMembersCanView = ['edx*learner']
         extraMembersCanView.each { emp ->
             permission('hudson.model.Item.Read', emp)
             permission('hudson.model.Item.Discover', emp)
@@ -149,10 +161,12 @@ job('user-retirement-collector') {
     // but customer support can read and discover.
     authorization {
         blocksInheritance(true)
+        // Only core teams can run the retirement collector directly.
         List membersWithFullControl = ['edx*platform-team', 'edx*testeng', 'edx*devops']
         membersWithFullControl.each { emp ->
             permissionAll(emp)
         }
+        // Other engineering teams can view.
         List extraMembersCanView = ['edx*educator-all', 'edx*learner']
         extraMembersCanView.each { emp ->
             permission('hudson.model.Item.Read', emp)


### PR DESCRIPTION
This is done primarily for allowing anyone in educator to conveniently run user-retirement-driver against stage, but this implicitly gives prod access as well.

Pinging @schenedx and @macdiesel since this expands job privileges to a wider set of users.  Alternatively, I could just give @sandroroux alone the build privileges to the job if educator seems too broad.