### PR TITLE
[WIP] Fix overzealous parameter-based throttling

### DIFF
--- a/platform/jobs/RetirementJobs.groovy
+++ b/platform/jobs/RetirementJobs.groovy
@@ -77,7 +77,7 @@ job('user-retirement-driver') {
     }
     configure { project ->
         project / 'properties' / 'hudson.plugins.throttleconcurrents.ThrottleJobProperty' <<
-            'paramsToUseForLimit'('ENVIRONMENT,RETIREMENT_USERNAME')
+            'paramsToUseForLimit'('')  // blank string implies all parameters must match
         project / 'properties' / 'hudson.plugins.throttleconcurrents.ThrottleJobProperty' <<
             'limitOneJobWithMatchingParams'('true')
     }
@@ -197,7 +197,7 @@ job('user-retirement-collector') {
     }
     configure { project ->
         project / 'properties' / 'hudson.plugins.throttleconcurrents.ThrottleJobProperty' <<
-            'paramsToUseForLimit'('ENVIRONMENT')
+            'paramsToUseForLimit'('')  // blank string implies all parameters must match
         project / 'properties' / 'hudson.plugins.throttleconcurrents.ThrottleJobProperty' <<
             'limitOneJobWithMatchingParams'('true')
     }


### PR DESCRIPTION
The intention was to prevent the same exact user in the same environment
to have retirement driven concurrently by multiple different retirement
driver jobs in order to prevent race conditions.  This plugin
functionality is clearly broken according to tests, since subsequent
consecutive jobs with DIFFERENT parameters were pending with this
message:

"(pending—A build with matching parameters is already running)"

Replacing the comma separated list with an empty string implies the
matching criteria is all parameters.  This isn't perfect, but it's
better than nothing.

---

In this case, user J...n has a job running, but user J...4 has a job pending on J...n on the basis of having the same set of parameters (false!):

![2018-05-22-135635_1366x768_scrot](https://user-images.githubusercontent.com/85151/40388505-be1dac8e-5ddd-11e8-8398-361b65a05963.png)