### PR TITLE
[RetirementJobs] add environment to the collector build name

### DIFF
--- a/platform/jobs/RetirementJobs.groovy
+++ b/platform/jobs/RetirementJobs.groovy
@@ -231,7 +231,7 @@ job('user-retirement-collector') {
 
     wrappers {
         buildUserVars() /* gives us access to BUILD_USER_ID, among other things */
-        buildName('#${BUILD_NUMBER}')
+        buildName('#${BUILD_NUMBER}, ${ENV,var="ENVIRONMENT"}')
         timestamps()
         colorizeOutput('xterm')
         credentialsBinding {


### PR DESCRIPTION
This helps use quickly identify which builds were run against prod vs.
ones that were run agaonst stage, etc.