### PR TITLE
edx-east cleanup

### DIFF
--- a/devops/resources/run-app-permissions.sh
+++ b/devops/resources/run-app-permissions.sh
@@ -10,7 +10,7 @@ env
 assume-role ${ROLE_ARN}
 cd $WORKSPACE/configuration/playbooks
 
-INVENTORY=$(../active_instances_in_asg.py --asg ${ENVIRONMENT}-${DEPLOYMENT}-worker)
+INVENTORY=$(./active_instances_in_asg.py --asg ${ENVIRONMENT}-${DEPLOYMENT}-worker)
 if [[ -n ${INVENTORY} ]]; then
     ansible-playbook -i ${INVENTORY} manage_edxapp_users_and_groups.yml -e@$WORKSPACE/app-permissions/${ENVIRONMENT}-${DEPLOYMENT}-edxapp.yml --user ${USER}
 else


### PR DESCRIPTION
See failures on https://tools-edx-jenkins.edx.org/job/User-Management/job/app-permissions-runner-prod-edx/218/console

active_instances_in_asg.py and manage_edxapp_users_and_groups.yml are now in the same directory.