### PR TITLE
add python3 job configs to platform pr jobs

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -120,6 +120,18 @@ Map privateFicusJobConfig = [
     triggerPhrase: /.*ficus\W+run\W+a11y.*/
 ]
 
+Map python3JobConfig = [
+    open : true,
+    jobName : 'edx-platform-python3-accessibility-pr',
+    repoName : 'edx-platform',
+    workerLabel: 'jenkins-worker',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/python3.5/a11y',
+    triggerPhrase: /.*jenkins\W+run\W+py35-django111\W+a11y.*/,
+    commentOnly: true,
+    toxEnv: 'py35-django111'
+]
+
 List jobConfigs = [
     publicJobConfig,
     privateJobConfig,
@@ -128,7 +140,8 @@ List jobConfigs = [
     publicGinkgoJobConfig,
     privateGinkgoJobConfig,
     publicFicusJobConfig,
-    privateFicusJobConfig
+    privateFicusJobConfig,
+    python3JobConfig
 ]
 
 /* Iterate over the job configurations */
@@ -144,6 +157,9 @@ jobConfigs.each { jobConfig ->
         }
         logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
         concurrentBuild()
+        environmentVariables {
+            env('TOX_ENV', jobConfig.toxEnv)
+        }
         parameters {
             labelParam('WORKER_LABEL') {
                 description('Select a Jenkins worker label for running this job')

--- a/platform/jobs/edxPlatformBokChoyPr.groovy
+++ b/platform/jobs/edxPlatformBokChoyPr.groovy
@@ -134,6 +134,19 @@ Map privateFicusJobConfig = [ open: false,
                               defaultTestengBranch: 'origin/open-release/ficus.master'
                               ]
 
+Map python3JobConfig = [ open : true,
+                         jobName : 'edx-platform-python3-bok-choy-pr',
+                         subsetJob: 'edx-platform-test-subset',
+                         repoName: 'edx-platform',
+                         workerLabel: 'jenkins-worker',
+                         whitelistBranchRegex: /^((?!open-release\/).)*$/,
+                         context: 'jenkins/python3.5/bokchoy',
+                         triggerPhrase: /.*jenkins\W+run\W+py35-django111\W+bokchoy.*/,
+                         defaultTestengBranch: 'master',
+                         commentOnly: true,
+                         toxEnv: 'py35-django111'
+                         ]
+
 List jobConfigs = [ publicJobConfig,
                     privateJobConfig,
                     publicHawthornJobConfig,
@@ -141,7 +154,8 @@ List jobConfigs = [ publicJobConfig,
                     publicGinkgoJobConfig,
                     privateGinkgoJobConfig,
                     publicFicusJobConfig,
-                    privateFicusJobConfig
+                    privateFicusJobConfig,
+                    python3JobConfig
                     ]
 
 /* Iterate over the job configurations */
@@ -162,6 +176,7 @@ jobConfigs.each { jobConfig ->
         environmentVariables {
             env('SUBSET_JOB', jobConfig.subsetJob)
             env('REPO_NAME', jobConfig.repoName)
+            env('TOX_ENV', jobConfig.toxEnv)
         }
         parameters {
             stringParam('WORKER_LABEL', jobConfig.workerLabel, 'Jenkins worker for running the test subset jobs')

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -129,6 +129,18 @@ Map privateFicusJobConfig = [
     triggerPhrase: /.*ficus\W+run\W+js.*/
 ]
 
+Map python3JobConfig = [
+    open : true,
+    jobName : 'edx-platform-python3-js-pr',
+    repoName: 'edx-platform',
+    workerLabel: 'jenkins-worker',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/python3.5/js',
+    triggerPhrase: /.*jenkins\W+run\W+py35-django111\W+js.*/,
+    commentOnly: true,
+    toxEnv: 'py35-django111'
+]
+
 List jobConfigs = [
     publicJobConfig,
     privateJobConfig,
@@ -137,7 +149,8 @@ List jobConfigs = [
     publicGinkgoJobConfig,
     privateGinkgoJobConfig,
     publicFicusJobConfig,
-    privateFicusJobConfig
+    privateFicusJobConfig,
+    python3JobConfig
 ]
 
 /* Iterate over the job configurations */
@@ -154,6 +167,9 @@ jobConfigs.each { jobConfig ->
         }
         logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
         concurrentBuild()
+        environmentVariables {
+            env('TOX_ENV', jobConfig.toxEnv)
+        }
         parameters {
             labelParam('WORKER_LABEL') {
                 description('Select a Jenkins worker label for running this job')

--- a/platform/jobs/edxPlatformLettucePr.groovy
+++ b/platform/jobs/edxPlatformLettucePr.groovy
@@ -132,6 +132,19 @@ Map privateFicusJobConfig = [ open: false,
                               defaultTestengBranch: 'origin/open-release/ficus.master'
                               ]
 
+Map python3JobConfig = [ open : true,
+                        jobName : 'edx-platform-python3-lettuce-pr',
+                        subsetJob: 'edx-platform-test-subset',
+                        repoName: 'edx-platform',
+                        workerLabel: 'jenkins-worker',
+                        whitelistBranchRegex: /^((?!open-release\/).)*$/,
+                        context: 'jenkins/python3.5/lettuce',
+                        triggerPhrase: /.*jenkins\W+run\W+py35-django111\W+lettuce.*/,
+                        defaultTestengBranch: 'master',
+                        commentOnly: true,
+                        toxEnv: 'py35-django111' 
+                        ]
+
 List jobConfigs = [ publicJobConfig,
                     privateJobConfig,
                     publicHawthornJobConfig,
@@ -139,7 +152,8 @@ List jobConfigs = [ publicJobConfig,
                     publicGinkgoJobConfig,
                     privateGinkgoJobConfig,
                     publicFicusJobConfig,
-                    privateFicusJobConfig
+                    privateFicusJobConfig,
+                    python3JobConfig
                     ]
 
 /* Iterate over the job configurations */
@@ -160,6 +174,7 @@ jobConfigs.each { jobConfig ->
         environmentVariables {
             env('SUBSET_JOB', jobConfig.subsetJob)
             env('REPO_NAME', jobConfig.repoName)
+            env('TOX_ENV', jobConfig.toxEnv)
         }
         parameters {
             stringParam('WORKER_LABEL', jobConfig.workerLabel, 'Jenkins worker for running the test subset jobs')

--- a/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
@@ -171,6 +171,23 @@ Map privateFicusJobConfig = [ open: false,
                               defaultTestengBranch: 'origin/open-release/ficus.master'
                               ]
 
+Map python3JobConfig = [ open: true,
+                         jobName: 'edx-platform-python3-unittests-pr',
+                         flowWorkerLabel: 'flow-worker-python',
+                         subsetJob: 'edx-platform-test-subset',
+                         repoName: 'edx-platform',
+                         runCoverage: true,
+                         coverageJob: 'edx-platform-unit-coverage',
+                         workerLabel: 'jenkins-worker',
+                         whitelistBranchRegex: /^((?!open-release\/).)*$/,
+                         context: 'jenkins/python3.5/python',
+                         triggerPhrase: /.*jenkins\W+run\W+py35-django111\W+python.*/,
+                         targetBranch: 'origin/master',
+                         defaultTestengBranch: 'master',
+                         commentOnly: true,
+                         toxEnv: 'py35-django111'
+                         ]
+
 List jobConfigs = [ publicJobConfig,
                     privateJobConfig,
                     publicHawthornJobConfig,
@@ -178,7 +195,8 @@ List jobConfigs = [ publicJobConfig,
                     publicGinkgoJobConfig,
                     privateGinkgoJobConfig,
                     publicFicusJobConfig,
-                    privateFicusJobConfig
+                    privateFicusJobConfig,
+                    python3JobConfig
                     ]
 
 // Iterate over the job configs to create individual build flow jobs
@@ -202,6 +220,7 @@ jobConfigs.each { jobConfig ->
             env('RUN_COVERAGE', jobConfig.runCoverage)
             env('COVERAGE_JOB', jobConfig.coverageJob)
             env('TARGET_BRANCH', jobConfig.targetBranch)
+            env('TOX_ENV', jobConfig.toxEnv)
         }
         parameters {
             stringParam('WORKER_LABEL', jobConfig.workerLabel, 'Jenkins worker for running the test subset jobs')

--- a/platform/jobs/edxPlatformQualityPr.groovy
+++ b/platform/jobs/edxPlatformQualityPr.groovy
@@ -83,10 +83,26 @@ Map hawthornJobConfig = [
     diffJob: 'edx-platform-quality-diff'
 ]
 
+Map python3JobConfig = [
+    open : true,
+    jobName : 'edx-platform-python3-quality-flow-pr',
+    subsetJob: 'edx-platform-test-subset',
+    repoName: 'edx-platform',
+    workerLabel: 'jenkins-worker',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/python3.5/quality',
+    triggerPhrase: /.*jenkins\W+run\W+py35-django111\W+quality.*/,
+    defaultTestengBranch: 'master',
+    diffJob: 'edx-platform-quality-diff',
+    commentOnly: true,
+    toxEnv: 'py35-django111'
+]
+
 List jobConfigs = [
     publicJobConfig,
     privateJobConfig,
-    hawthornJobConfig
+    hawthornJobConfig,
+    python3JobConfig
 ]
 
 jobConfigs.each { jobConfig ->
@@ -108,6 +124,7 @@ jobConfigs.each { jobConfig ->
             env('REPO_NAME', jobConfig.repoName)
             env('DIFF_JOB', jobConfig.diffJob)
             env('TARGET_BRANCH', 'origin/master')
+            env('TOX_ENV', jobConfig.toxEnv)
         }
         parameters {
             stringParam('WORKER_LABEL', jobConfig.workerLabel, 'Jenkins worker for running the test subset jobs')


### PR DESCRIPTION
Finally, this will set up the Jenkins jobs to run w/ the python 3 tox environment. This follows https://github.com/edx/edx-platform/pull/18377 and https://github.com/edx/testeng-ci/pull/152.

There are a couple of things to note here:
1) should we run coverage on the python3 job? I tend to think 'no', but am open to suggestion.
2) this does not include a change to the pipeline job (which I am doing in a separate set of PRs)