### PR TITLE
Add GHPRB configure block for cancel on update var

### DIFF
--- a/platform/jobs/edxEndToEndTestsJob.groovy
+++ b/platform/jobs/edxEndToEndTestsJob.groovy
@@ -2,7 +2,7 @@ package platform
 
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_WHITELIST_BRANCH
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_CANCEL_BUILDS_ON_UPDATE
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_STATUS_SUCCESS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_STATUS_UNSTABLE_OR_WORSE
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_BASEURL
@@ -260,6 +260,7 @@ jobConfigs.each { jobConfig ->
                     }
                 }
             }
+            configure GHPRB_CANCEL_BUILDS_ON_UPDATE(false)
         }
         // enable triggers for merge jobs
         else if (jobConfig.trigger == 'merge') {

--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -3,7 +3,7 @@ package platform
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_WHITELIST_BRANCH
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_CANCEL_BUILDS_ON_UPDATE
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_EDX_PLATFORM_TEST_NOTIFIER
 
@@ -190,6 +190,7 @@ jobConfigs.each { jobConfig ->
                 }
             }
         }
+        configure GHPRB_CANCEL_BUILDS_ON_UPDATE(false)
 
         wrappers {
            timeout {

--- a/platform/jobs/edxPlatformBokChoyPr.groovy
+++ b/platform/jobs/edxPlatformBokChoyPr.groovy
@@ -3,8 +3,7 @@ package platform
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_BLACKLIST_BRANCH
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_WHITELIST_BRANCH
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_CANCEL_BUILDS_ON_UPDATE
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_EDX_PLATFORM_TEST_NOTIFIER
 
@@ -199,6 +198,7 @@ jobConfigs.each { jobConfig ->
                 }
             }
         }
+        configure GHPRB_CANCEL_BUILDS_ON_UPDATE(false)
 
         wrappers {
             timestamps()

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -3,7 +3,7 @@ package platform
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_WHITELIST_BRANCH
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_CANCEL_BUILDS_ON_UPDATE
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_EDX_PLATFORM_TEST_NOTIFIER
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_STATUS_UNSTABLE_OR_WORSE
@@ -199,7 +199,7 @@ jobConfigs.each { jobConfig ->
                 }
             }
         }
-
+        configure GHPRB_CANCEL_BUILDS_ON_UPDATE(false)
 
         wrappers {
             timeout {

--- a/platform/jobs/edxPlatformLettucePr.groovy
+++ b/platform/jobs/edxPlatformLettucePr.groovy
@@ -3,7 +3,7 @@ package platform
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_WHITELIST_BRANCH
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_CANCEL_BUILDS_ON_UPDATE
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_EDX_PLATFORM_TEST_NOTIFIER
 
@@ -196,6 +196,7 @@ jobConfigs.each { jobConfig ->
                 }
             }
         }
+        configure GHPRB_CANCEL_BUILDS_ON_UPDATE(false)
 
         wrappers {
             timestamps()

--- a/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
@@ -3,7 +3,7 @@ package platform
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_WHITELIST_BRANCH
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_CANCEL_BUILDS_ON_UPDATE
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_EDX_PLATFORM_TEST_NOTIFIER
 
@@ -237,6 +237,7 @@ jobConfigs.each { jobConfig ->
                 }
             }
         }
+        configure GHPRB_CANCEL_BUILDS_ON_UPDATE(false)
 
         wrappers {
             timestamps()

--- a/platform/jobs/edxPlatformQualityPr.groovy
+++ b/platform/jobs/edxPlatformQualityPr.groovy
@@ -3,7 +3,7 @@ package platform
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_BASEURL
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_WHITELIST_BRANCH
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_CANCEL_BUILDS_ON_UPDATE
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_EDX_PLATFORM_TEST_NOTIFIER
 
@@ -143,6 +143,8 @@ jobConfigs.each { jobConfig ->
                 }
             }
         }
+        configure GHPRB_CANCEL_BUILDS_ON_UPDATE(false)
+
         wrappers {
             timeout {
                 absolute(90)

--- a/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
@@ -190,22 +190,10 @@ class JenkinsPublicConstants {
         }
     }
 
-    public static final Closure GHPRB_BLACKLIST_BRANCH(String branchRegex) {
+    public static final Closure GHPRB_CANCEL_BUILDS_ON_UPDATE(boolean override) {
         return {
-            it / triggers / 'org.jenkinsci.plugins.ghprb.GhprbTrigger' << blackListTargetBranches {
-                'org.jenkinsci.plugins.ghprb.GhprbBranch' {
-                    branch branchRegex
-                }
-            }
-        }
-    }
-
-    public static final Closure GHPRB_WHITELIST_BRANCH(String branchRegex) {
-        return {
-            it / triggers / 'org.jenkinsci.plugins.ghprb.GhprbTrigger' << whiteListTargetBranches {
-                'org.jenkinsci.plugins.ghprb.GhprbBranch' {
-                    branch branchRegex
-                }
+            it / 'triggers' / 'org.jenkinsci.plugins.ghprb.GhprbTrigger' / 'extensions' / 'org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate' {
+                overrideGlobal(override)
             }
         }
     }
@@ -221,19 +209,4 @@ class JenkinsPublicConstants {
             buildButton()
         }
     }
-
-    // Reusable closure for configuring a masked password user parameter with a default value
-    // Input must be structured in the following format:
-    // [ name: String x, description: String y, default: String z ]
-    public static final Closure JENKINS_PUBLIC_MASKED_PASSWORD = { param ->
-        return {
-            it / 'properties' / 'hudson.model.ParametersDefinitionProperty' / parameterDefinitions << 'hudson.model.PasswordParameterDefinition' {
-                name param.name
-                defaultValue Secret.fromString(param.default.toString()).getEncryptedValue()
-                description param.description
-            }
-        }
-
-    }
-
 }

--- a/testeng/jobs/buildPackerAMIjob.groovy
+++ b/testeng/jobs/buildPackerAMIjob.groovy
@@ -4,7 +4,6 @@ import hudson.util.Secret
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_TEAM_SECURITY
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_MASKED_PASSWORD
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 
 Map config = [:]


### PR DESCRIPTION
We need overrideGlobal set to false to actually do any deduping. This was actually added in the GHPRB repo as a DSL option a few days ago, there just isn't a version for it yet.

Also I removed some dead code.