### PR TITLE
TE-2560 Show quality failures on overview, enable Warnings plugin

### DIFF
--- a/platform/jobs/edxPlatformQualityDiff.groovy
+++ b/platform/jobs/edxPlatformQualityDiff.groovy
@@ -2,6 +2,7 @@ package platform
 
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_ARCHIVE_XUNIT
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 
 stringParams = [
@@ -134,9 +135,10 @@ jobConfigs.each { jobConfig ->
         }
         publishers {
             archiveArtifacts {
-                pattern('test_root/log/*.log,reports/*.html,reports/**/*.html')
+                pattern('test_root/log/*.log,reports/*.html,reports/**/*.html,reports/**/*.xml')
                 defaultExcludes(true)
             }
+            archiveXUnit JENKINS_PUBLIC_ARCHIVE_XUNIT()
             publishHtml {
                 report("${jobConfig.repoName}/reports/metrics/") {
                     reportName('Quality Report')

--- a/platform/jobs/edxPlatformQualityMaster.groovy
+++ b/platform/jobs/edxPlatformQualityMaster.groovy
@@ -2,6 +2,7 @@ package devops
 
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_ARCHIVE_XUNIT
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_BASE_URL
@@ -15,6 +16,9 @@ archiveReports += 'edx-platform*/reports/**/*,edx-platform*/test_root/log/*.log,
 
 String htmlReports = 'pylint/*view*/,pep8/*view*/,python_complexity/*view*/,'
 htmlReports += 'xsscommitlint/*view*/,xsslint/*view*/,eslint/*view*/'
+
+String pep8Reports = 'reports/pep8/pep8.report, edx-platform*/reports/pep8/pep8.report'
+String pylintReports = 'reports/**/pylint.report, edx-platform*/reports/**/pylint.report'
 
 /* stdout logger */
 /* use this instead of println, because you can pass it into closures or other scripts. */
@@ -163,6 +167,7 @@ jobConfigs.each { jobConfig ->
                 pattern(archiveReports)
                 defaultExcludes()
             }
+            archiveXUnit JENKINS_PUBLIC_ARCHIVE_XUNIT()
             publishHtml {
                 report(jobConfig.repoName + '/reports/metrics/') {
                     reportFiles(htmlReports)
@@ -171,24 +176,8 @@ jobConfigs.each { jobConfig ->
                     keepAll()
                 }
             }
-            violations(100) {
-                checkstyle(10, 999, 999)
-                codenarc(10, 999, 999)
-                cpd(10, 999, 999)
-                cpplint(10, 999, 999)
-                csslint(10, 999, 999)
-                findbugs(10, 999, 999)
-                fxcop(10, 999, 999)
-                gendarme(10, 999, 999)
-                jcreport(10, 999, 999)
-                jslint(10, 999, 999)
-                pep8(1, 2, 3, '**/pep8.report')
-                perlcritic(10, 999, 999)
-                pmd(10, 999, 999)
-                pylint(10, 10000, 10000, '**/*pylint.report')
-                simian(10, 999, 999)
-                stylecop(10, 999, 999)
-                sourceEncoding()
+            warnings([], ['Pep8': pep8Reports, 'PYLint': pylintReports]) {
+                canRunOnFailed()
             }
             downstreamParameterized JENKINS_PUBLIC_GITHUB_STATUS_SUCCESS.call(predefinedPropsMap)
             downstreamParameterized JENKINS_PUBLIC_GITHUB_STATUS_UNSTABLE_OR_WORSE.call(predefinedPropsMap)

--- a/platform/jobs/edxPlatformQualityPr.groovy
+++ b/platform/jobs/edxPlatformQualityPr.groovy
@@ -1,6 +1,7 @@
 package platform
 
 import org.yaml.snakeyaml.Yaml
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_ARCHIVE_XUNIT
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_BASEURL
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_CANCEL_BUILDS_ON_UPDATE
@@ -28,6 +29,9 @@ catch (any) {
     out.println('Exiting with error code 1')
     return 1
 }
+
+String pep8Reports = 'reports/pep8/pep8.report, edx-platform*/reports/pep8/pep8.report'
+String pylintReports = 'reports/**/pylint.report, edx-platform*/reports/**/pylint.report'
 
 // This script generates a lot of jobs. Here is the breakdown of the configuration options:
 // Map exampleConfig = [
@@ -181,6 +185,7 @@ jobConfigs.each { jobConfig ->
                 defaultExcludes(true)
                 allowEmpty(true)
             }
+            archiveXUnit JENKINS_PUBLIC_ARCHIVE_XUNIT()
             publishHtml {
                 report("reports/metrics/") {
                     reportName('Quality Report')
@@ -197,6 +202,9 @@ jobConfigs.each { jobConfig ->
                     keepAll(true)
                     allowMissing(true)
                 }
+            }
+            warnings([], ['Pep8': pep8Reports, 'PYLint': pylintReports]) {
+                canRunOnFailed()
             }
             if (jobConfig.repoName == "edx-platform") {
                 downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER('${ghprbPullId}')

--- a/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
@@ -36,7 +36,8 @@ class JenkinsPublicConstants {
     return {
         jUnit {
             pattern("**/nosetests.xml,**/TEST-*.xml,reports/acceptance/*.xml,reports/quality.xml," +
-                    "reports/javascript/javascript_xunit.xml,reports/a11y/xunit.xml,reports/bok_choy/xunit.xml,reports/bok_choy/**/xunit.xml"
+                    "reports/javascript/javascript_xunit.xml,reports/a11y/xunit.xml," +
+                    "reports/bok_choy/xunit.xml,reports/bok_choy/**/xunit.xml,reports/quality_junitxml/*.xml"
                     )
             skipNoTestFiles(true)
             stopProcessingIfError(true)


### PR DESCRIPTION
Make a few changes to make the nature of quality job failures more obvious:

* Run xUnit pass/fail checks against the new quality check results files added in https://github.com/edx/edx-platform/pull/18421
* Propagate those results files from the sharded quality jobs to the main quality job
* Replace the unsupported `Violations` plugin with the newer `Warnings` plugin that replaces it
* Enable warnings analysis on pull requests again; [TE-754](https://openedx.atlassian.net/browse/TE-754) notes that we had disabled it because `Violations` didn't work correctly with concurrent builds, but it seems that `Warnings` should

This PR depends on both the edx-platform PR noted above and the configuration PR to add the `Warnings` plugin: https://github.com/edx/configuration/pull/4637