### PR TITLE
TE-2607 Update Hawthorn edx-platform jobs to use hawthorn.master

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -55,8 +55,8 @@ Map hawthornJobConfig = [
     repoName: 'edx-platform',
     workerLabel: 'hawthorn-jenkins-worker',
     context: 'jenkins/hawthorn/a11y',
-    refSpec : '+refs/heads/open-release/hawthorn.beta1:refs/remotes/origin/open-release/hawthorn.beta1',
-    defaultBranch : 'refs/heads/open-release/hawthorn.beta1'
+    refSpec : '+refs/heads/open-release/hawthorn.master:refs/remotes/origin/open-release/hawthorn.master',
+    defaultBranch : 'refs/heads/open-release/hawthorn.master'
 ]
 
 Map ginkgoJobConfig = [

--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -65,7 +65,7 @@ Map publicHawthornJobConfig = [
     jobName: 'hawthorn-accessibility-pr',
     repoName: 'edx-platform',
     workerLabel: 'hawthorn-jenkins-worker',
-    whitelistBranchRegex: /open-release\/hawthorn.beta1/,
+    whitelistBranchRegex: /open-release\/hawthorn.master/,
     context: 'jenkins/hawthorn/a11y',
     triggerPhrase: /.*hawthorn\W+run\W+a11y.*/
 ]
@@ -75,7 +75,7 @@ Map privateHawthornJobConfig = [
     jobName: 'hawthorn-accessibility-pr_private',
     repoName: 'edx-platform-private',
     workerLabel: 'hawthorn-jenkins-worker',
-    whitelistBranchRegex: /open-release\/hawthorn.beta1/,
+    whitelistBranchRegex: /open-release\/hawthorn.master/,
     context: 'jenkins/hawthorn/a11y',
     triggerPhrase: /.*hawthorn\W+run\W+a11y.*/
 ]

--- a/platform/jobs/edxPlatformBokChoyMaster.groovy
+++ b/platform/jobs/edxPlatformBokChoyMaster.groovy
@@ -60,9 +60,9 @@ Map publicHawthornJobConfig = [
     repoName: 'edx-platform',
     workerLabel: 'hawthorn-jenkins-worker',
     context: 'jenkins/hawthorn/bokchoy',
-    defaultTestengBranch: 'origin/open-release/hawthorn.beta1',
-    refSpec : '+refs/heads/open-release/hawthorn.beta1:refs/remotes/origin/open-release/hawthorn.beta1',
-    defaultBranch : 'refs/heads/open-release/hawthorn.beta1'
+    defaultTestengBranch: 'origin/open-release/hawthorn.master',
+    refSpec : '+refs/heads/open-release/hawthorn.master:refs/remotes/origin/open-release/hawthorn.master',
+    defaultBranch : 'refs/heads/open-release/hawthorn.master'
 ]
 
 Map publicGinkgoJobConfig = [

--- a/platform/jobs/edxPlatformBokChoyPr.groovy
+++ b/platform/jobs/edxPlatformBokChoyPr.groovy
@@ -72,10 +72,10 @@ Map publicHawthornJobConfig = [ open: true,
                                subsetJob: 'edx-platform-test-subset',
                                repoName: 'edx-platform',
                                workerLabel: 'hawthorn-jenkins-worker',
-                               whitelistBranchRegex: /open-release\/hawthorn.beta1/,
+                               whitelistBranchRegex: /open-release\/hawthorn.master/,
                                context: 'jenkins/hawthorn/bokchoy',
                                triggerPhrase: /.*hawthorn\W+run\W+bokchoy.*/,
-                               defaultTestengBranch: 'origin/open-release/hawthorn.beta1'
+                               defaultTestengBranch: 'origin/open-release/hawthorn.master'
                                ]
 
 Map privateHawthornJobConfig = [ open: false,
@@ -83,10 +83,10 @@ Map privateHawthornJobConfig = [ open: false,
                                 subsetJob: 'edx-platform-test-subset_private',
                                 repoName: 'edx-platform-private',
                                 workerLabel: 'hawthorn-jenkins-worker',
-                                whitelistBranchRegex: /open-release\/hawthorn.beta1/,
+                                whitelistBranchRegex: /open-release\/hawthorn.master/,
                                 context: 'jenkins/hawthorn/bokchoy',
                                 triggerPhrase: /.*hawthorn\W+run\W+bokchoy.*/,
-                                defaultTestengBranch: 'origin/open-release/hawthorn.beta1'
+                                defaultTestengBranch: 'origin/open-release/hawthorn.master'
                                 ]
 
 Map publicGinkgoJobConfig = [ open: true,

--- a/platform/jobs/edxPlatformJsMaster.groovy
+++ b/platform/jobs/edxPlatformJsMaster.groovy
@@ -58,8 +58,8 @@ Map hawthornJobConfig = [
     repoName: 'edx-platform',
     workerLabel: 'jenkins-worker',
     context: 'jenkins/hawthorn/js',
-    refSpec : '+refs/heads/open-release/hawthorn.beta1:refs/remotes/origin/open-release/hawthorn.beta1',
-    defaultBranch : 'refs/heads/open-release/hawthorn.beta1'
+    refSpec : '+refs/heads/open-release/hawthorn.master:refs/remotes/origin/open-release/hawthorn.master',
+    defaultBranch : 'refs/heads/open-release/hawthorn.master'
 ]
 
 Map ginkgoJobConfig = [

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -74,7 +74,7 @@ Map publicHawthornJobConfig = [
     jobName: 'hawthorn-js-pr',
     repoName: 'edx-platform',
     workerLabel: 'hawthorn-jenkins-worker',
-    whitelistBranchRegex: /open-release\/hawthorn.beta1/,
+    whitelistBranchRegex: /open-release\/hawthorn.master/,
     context: 'jenkins/hawthorn/js',
     triggerPhrase: /.*hawthorn\W+run\W+js.*/
 ]
@@ -84,7 +84,7 @@ Map privateHawthornJobConfig = [
     jobName: 'hawthorn-js-pr_private',
     repoName: 'edx-platform-private',
     workerLabel: 'hawthorn-jenkins-worker',
-    whitelistBranchRegex: /open-release\/hawthorn.beta1/,
+    whitelistBranchRegex: /open-release\/hawthorn.master/,
     context: 'jenkins/hawthorn/js',
     triggerPhrase: /.*hawthorn\W+run\W+js.*/
 ]

--- a/platform/jobs/edxPlatformLettuceMaster.groovy
+++ b/platform/jobs/edxPlatformLettuceMaster.groovy
@@ -62,9 +62,9 @@ Map hawthornJobConfig = [
     repoName: 'edx-platform',
     workerLabel: 'hawthorn-jenkins-worker',
     context: 'jenkins/hawthorn/lettuce',
-    defaultTestengBranch : 'refs/heads/open-release/hawthorn.beta1',
-    refSpec : '+refs/heads/open-release/hawthorn.beta1:refs/remotes/origin/open-release/hawthorn.beta1',
-    defaultBranch : 'refs/heads/open-release/hawthorn.beta1'
+    defaultTestengBranch : 'refs/heads/open-release/hawthorn.master',
+    refSpec : '+refs/heads/open-release/hawthorn.master:refs/remotes/origin/open-release/hawthorn.master',
+    defaultBranch : 'refs/heads/open-release/hawthorn.master'
 ]
 
 Map ginkgoJobConfig = [

--- a/platform/jobs/edxPlatformLettucePr.groovy
+++ b/platform/jobs/edxPlatformLettucePr.groovy
@@ -71,10 +71,10 @@ Map publicHawthornJobConfig = [ open: true,
                                subsetJob: 'edx-platform-test-subset',
                                repoName: 'edx-platform',
                                workerLabel: 'hawthorn-jenkins-worker',
-                               whitelistBranchRegex: /open-release\/hawthorn.beta1/,
+                               whitelistBranchRegex: /open-release\/hawthorn.master/,
                                context: 'jenkins/hawthorn/lettuce',
                                triggerPhrase: /.*hawthorn\W+run\W+lettuce.*/,
-                               defaultTestengBranch: 'origin/open-release/hawthorn.beta1'
+                               defaultTestengBranch: 'origin/open-release/hawthorn.master'
                                ]
 
 Map privateHawthornJobConfig = [ open: false,
@@ -82,10 +82,10 @@ Map privateHawthornJobConfig = [ open: false,
                                 subsetJob: 'edx-platform-test-subset_private',
                                 repoName: 'edx-platform-private',
                                 workerLabel: 'hawthorn-jenkins-worker',
-                                whitelistBranchRegex: /open-release\/hawthorn.beta1/,
+                                whitelistBranchRegex: /open-release\/hawthorn.master/,
                                 context: 'jenkins/hawthorn/lettuce',
                                 triggerPhrase: /.*jenkins\W+run\W+lettuce.*/,
-                                defaultTestengBranch: 'origin/open-release/hawthorn.beta1'
+                                defaultTestengBranch: 'origin/open-release/hawthorn.master'
                                 ]
 
 Map publicGinkgoJobConfig = [ open: true,

--- a/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
@@ -78,10 +78,10 @@ Map hawthornJobConfig = [
     coverageJob: 'edx-platform-unit-coverage',
     workerLabel: 'hawthorn-jenkins-worker',
     context: 'jenkins/hawthorn/python',
-    targetBranch: 'origin/open-release/hawthorn.beta1',
-    defaultTestengBranch : 'refs/heads/open-release/hawthorn.beta1',
-    refSpec : '+refs/heads/open-release/hawthorn.beta1:refs/remotes/origin/open-release/hawthorn.beta1',
-    defaultBranch : 'refs/heads/open-release/hawthorn.beta1'
+    targetBranch: 'origin/open-release/hawthorn.master',
+    defaultTestengBranch : 'refs/heads/open-release/hawthorn.master',
+    refSpec : '+refs/heads/open-release/hawthorn.master:refs/remotes/origin/open-release/hawthorn.master',
+    defaultBranch : 'refs/heads/open-release/hawthorn.master'
 ]
 
 Map ginkgoJobConfig = [

--- a/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
@@ -89,11 +89,11 @@ Map publicHawthornJobConfig = [ open: true,
                                runCoverage: true,
                                coverageJob: 'edx-platform-unit-coverage',
                                workerLabel: 'hawthorn-jenkins-worker',
-                               whitelistBranchRegex: /open-release\/hawthorn.beta1/,
+                               whitelistBranchRegex: /open-release\/hawthorn.master/,
                                context: 'jenkins/hawthorn/python',
                                triggerPhrase: /.*hawthorn\W+run\W+python.*/,
-                               targetBranch: 'origin/open-release/hawthorn.beta1',
-                               defaultTestengBranch: 'origin/open-release/hawthorn.beta1'
+                               targetBranch: 'origin/open-release/hawthorn.master',
+                               defaultTestengBranch: 'origin/open-release/hawthorn.master'
                                ]
 
 Map privateHawthornJobConfig = [ open: false,
@@ -104,11 +104,11 @@ Map privateHawthornJobConfig = [ open: false,
                                 runCoverage: true,
                                 coverageJob: 'edx-platform-unit-coverage_private',
                                 workerLabel: 'hawthorn-jenkins-worker',
-                                whitelistBranchRegex: /open-release\/hawthorn.beta1/,
+                                whitelistBranchRegex: /open-release\/hawthorn.master/,
                                 context: 'jenkins/hawthorn/python',
                                 triggerPhrase: /.*hawthorn\W+run\W+python.*/,
                                 targetBranch: 'origin/security/release',
-                                defaultTestengBranch: 'origin/open-release/hawthorn.beta1'
+                                defaultTestengBranch: 'origin/open-release/hawthorn.master'
                                 ]
 
 Map publicGinkgoJobConfig = [ open: true,

--- a/platform/jobs/edxPlatformQualityMaster.groovy
+++ b/platform/jobs/edxPlatformQualityMaster.groovy
@@ -72,9 +72,9 @@ Map hawthornJobConfig = [
     repoName: 'edx-platform',
     workerLabel: 'hawthorn-jenkins-worker',
     context: 'jenkins/hawthorn/quality',
-    defaultTestengBranch : 'refs/heads/open-release/hawthorn.beta1',
-    refSpec : '+refs/heads/open-release/hawthorn.beta1:refs/remotes/origin/open-release/hawthorn.beta1',
-    defaultBranch : 'refs/heads/open-release/hawthorn.beta1'
+    defaultTestengBranch : 'refs/heads/open-release/hawthorn.master',
+    refSpec : '+refs/heads/open-release/hawthorn.master:refs/remotes/origin/open-release/hawthorn.master',
+    defaultBranch : 'refs/heads/open-release/hawthorn.master'
 ]
 
 List jobConfigs = [

--- a/platform/jobs/edxPlatformQualityPr.groovy
+++ b/platform/jobs/edxPlatformQualityPr.groovy
@@ -80,10 +80,10 @@ Map hawthornJobConfig = [
     subsetJob: 'edx-platform-test-subset',
     repoName: 'edx-platform',
     workerLabel: 'hawthorn-jenkins-worker',
-    whitelistBranchRegex: /open-release\/hawthorn.beta1/,
+    whitelistBranchRegex: /open-release\/hawthorn.master/,
     context: 'jenkins/hawthorn/quality',
     triggerPhrase: /.*hawthorn\W+run\W+quality.*/,
-    defaultTestengBranch: 'origin/open-release/hawthorn.beta1',
+    defaultTestengBranch: 'origin/open-release/hawthorn.master',
     diffJob: 'edx-platform-quality-diff'
 ]
 


### PR DESCRIPTION
Now that the hawthorn.master branches have been created, switch the edx-platform Jenkins jobs to use those instead of hawthorn.beta1.