### PR TITLE
Fix watching non-master branches for Docker builds

### DIFF
--- a/devops/jobs/ConfigurationWatcher.groovy
+++ b/devops/jobs/ConfigurationWatcher.groovy
@@ -1,9 +1,12 @@
 /*
-    This job serves to watch https://github.com/edx/configuration for changes pushed to master. Upon a push to master, the job is 
+    This job serves to watch https://github.com/edx/configuration for changes pushed to a particular branch. Upon a push to that branch, the job is
     triggered via a webhook, at which point it runs the parsefiles.py script with the files changed between the old commit and the new commit. 
     This resolves which Docker images need to be rebuilt as a result of the aforementioned changes to the configuration repository. For each 
     Docker image that needs rebuilding, this job triggers the respective <app>-watcher downstream job, which then calls the image-builder job 
     to build and push up the respective image to DockerHub.
+
+    Branches other than master should be prefixed with "refs/heads/" for the Jenkins Git plugin to match them
+    correctly when a webhook is received.  For example, "refs/heads/open-release/hawthorn.master".
 
     Variables consumed from the EXTRA_VARS input to your seed job in addition
     to those listed in the seed job.
@@ -48,7 +51,6 @@ import static org.edx.jenkins.dsl.YAMLHelpers.parseYaml
 import org.yaml.snakeyaml.error.YAMLException
 
 import static org.edx.jenkins.dsl.DevopsConstants.common_read_permissions
-import static org.edx.jenkins.dsl.DevopsConstants.merge_to_master_trigger
 import static org.edx.jenkins.dsl.Constants.common_logrotator
 import static org.edx.jenkins.dsl.Constants.common_wrappers
 
@@ -105,7 +107,7 @@ class ConfigurationWatcher {
                 }
             }
             
-            triggers merge_to_master_trigger(config_branch)
+            triggers { githubPush() }
 
             // run the trigger-builds shell script in a virtual environment called venv
             steps {

--- a/devops/jobs/ImageBuilder.groovy
+++ b/devops/jobs/ImageBuilder.groovy
@@ -3,6 +3,9 @@
     various <app>-watcher jobs and does not run on its own. This job receives the name of an application as a build parameter. 
     This application's Docker image is then built and pushed to DockerHub.
 
+    Branches other than master should be prefixed with "refs/heads/" for the Jenkins Git plugin to match them
+    correctly when a webhook is received.  For example, "refs/heads/open-release/hawthorn.master".
+
     Variables are consumed from the EXTRA_VARS input to your seed job in addition
     to those listed in the seed job.
 
@@ -64,11 +67,12 @@ class ImageBuilder {
                 def app_repo_branch = app_config.get('app_repo_branch', 'master')
                 def config_branch = app_config.get('config_branch', 'master')
                 def tag_name = app_config.get('tag_name', 'latest')
+                def openedx_release = app_repo_branch.replace('refs/heads/', '')
 
                 // inject APP_NAME, OPENEDX_RELEASE, and TAG_NAME as environment variables for use by build-push-app.sh
                 environmentVariables {
                     env("APP_NAME", app_name)
-                    env('OPENEDX_RELEASE', app_repo_branch)
+                    env('OPENEDX_RELEASE', openedx_release)
                     env('TAG_NAME', tag_name)
                 }
 


### PR DESCRIPTION
The `merge_to_master` trigger was originally a workaround for an issue which [ultimately turned out](https://openedx.atlassian.net/browse/TE-1921?focusedCommentId=274673&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-274673) to be due to specifying branches in a way that resulted in the Jenkins Git plugin not matching them up to incoming webhooks correctly.  Go back to using the `githubPush` trigger directly for the Docker-related repo watchers and document the correct branch formatting.