### PR TITLE
enable the prod-edx retirement job hourly trigger

### DIFF
--- a/platform/jobs/RetirementJobEdxTriggers.groovy
+++ b/platform/jobs/RetirementJobEdxTriggers.groovy
@@ -13,7 +13,7 @@ List jobConfigs = [
     [
         environmentDeployment: 'prod-edx',
         extraMembersCanBuild: [],
-        disabled: true
+        disabled: false
     ],
     [
         environmentDeployment: 'stage-edx',


### PR DESCRIPTION
Deploying this change will cause the user-reitrement-collector job to
run against prod-edx HOURLY.  The only thing blocking us from
implementing this was not having automated failure notifications, but
now #393 has been merged which enables email notification.