### PR TITLE
Add the retirement-partner-report-cleanup job

### DIFF
--- a/platform/resources/retirement-partner-report-cleanup.sh
+++ b/platform/resources/retirement-partner-report-cleanup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# prepare credentials
+mkdir -p $WORKSPACE/user-retirement-secure
+cp $USER_RETIREMENT_SECURE_DEFAULT $WORKSPACE/user-retirement-secure/secure-default.yml
+
+# prepare tubular
+cd $WORKSPACE/tubular
+pip install -r requirements.txt
+
+# Call the script to cleanup the reports
+python scripts/delete_expired_partner_gdpr_reports.py \
+    --config_file=$WORKSPACE/user-retirement-secure/$ENVIRONMENT.yml \
+    --google_secrets_file=$WORKSPACE/user-retirement-secure/google-service-accounts/service-account-$ENVIRONMENT.json \
+    --age_in_days=$AGE_IN_DAYS


### PR DESCRIPTION
Also add all missing corresponding trigger jobs for retirement jobs.  In
particular, this adds the following new jobs:

* retirement-partner-reporter-trigger-prod-edx
* retirement-partner-reporter-trigger-prod-edge
* retirement-partner-report-cleanup-trigger-prod-edx
* retirement-partner-report-cleanup-trigger-prod-edge

PLAT-2187

---

Tested seeding successfully in https://test-jenkins.testeng.edx.org/job/manually-seed-one-job/478/ and https://test-jenkins.testeng.edx.org/job/manually-seed-one-job/479/.  Manually verified configuration by looking at the job configuration pages.