### PR TITLE
Add user-retirement-bulk-status job and shell script

### DIFF
--- a/platform/resources/user-retirement-bulk-status.sh
+++ b/platform/resources/user-retirement-bulk-status.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# prepare credentials
+mkdir -p $WORKSPACE/user-retirement-secure
+cp $USER_RETIREMENT_SECURE_DEFAULT $WORKSPACE/user-retirement-secure/secure-default.yml
+
+# prepare tubular
+cd $WORKSPACE/tubular
+pip install -r requirements.txt
+
+# Call the script to collect the list of learners that are to be retired.
+python scripts/retirement_bulk_status_update.py \
+    --config_file=$WORKSPACE/user-retirement-secure/$ENVIRONMENT.yml \
+    --start_date=$START_DATE \
+    --end_date=$END_DATE \
+    --initial_state=$INITIAL_STATE_NAME \
+    --new_state=$NEW_STATE_NAME


### PR DESCRIPTION
This PR creates a Jenkins job that allows us to move learners who are in the retirement process from one retirement state to another in bulk. Use cases for this are things like: bugs or connectivity issues causing numerous learners to end up in the ERRORED state or adding a new step to the process and needing to re-run users in COMPLETE. It also requires a date range that is used to limit the number of learners acted upon to those whose retirements were created within those dates.

Like the other retirement jobs, this one calls a Tubular Python script via a shell script. The Tubular side of this is here: https://github.com/edx/tubular/pull/254