### PR TITLE
Add 20 minute timeout to bokchoy db cache uploader

### DIFF
--- a/testeng/jobs/bokchoyDbCacheUploader.groovy
+++ b/testeng/jobs/bokchoyDbCacheUploader.groovy
@@ -124,6 +124,9 @@ secretMap.each { jobConfigs ->
         }
 
         wrappers {
+            timeout {
+                absolute(20)
+            }
             credentialsBinding {
                 string('GITHUB_TOKEN', 'GITHUB_CACHE_UPLOADER_TOKEN')
             }


### PR DESCRIPTION
A build hung for several days due to a problem with an `npm install` which blocked successive builds, since the job only allows one build at a time. On average these take 5-7 minutes but I wanted to leave some cushion before aborting.