### PR TITLE
[RetirementJobs] make sure the python io encoding is utf-8 compatible

### DIFF
--- a/platform/jobs/RetirementJobs.groovy
+++ b/platform/jobs/RetirementJobs.groovy
@@ -160,6 +160,14 @@ job('user-retirement-driver') {
         }
     }
 
+    environmentVariables {
+        // Make sure that when we try to write unicode to the console, it
+        // correctly encodes to UTF-8 rather than exiting with a UnicodeEncode
+        // error.
+        env('PYTHONIOENCODING', 'UTF-8')
+        env('LC_CTYPE', 'en_US.UTF-8')
+    }
+
     steps {
         virtualenv {
             name('user-retirement-driver')
@@ -283,6 +291,12 @@ job('user-retirement-collector') {
 
     environmentVariables {
         env('LEARNERS_TO_RETIRE_PROPERTIES_DIR', '${WORKSPACE}/learners-to-retire')
+
+        // Make sure that when we try to write unicode to the console, it
+        // correctly encodes to UTF-8 rather than exiting with a UnicodeEncode
+        // error.
+        env('PYTHONIOENCODING', 'UTF-8')
+        env('LC_CTYPE', 'en_US.UTF-8')
     }
 
     steps {
@@ -441,6 +455,12 @@ job('retirement-partner-reporter') {
 
     environmentVariables {
         env('PARTNER_REPORTS_DIR', '${WORKSPACE}/partner-reports')
+
+        // Make sure that when we try to write unicode to the console, it
+        // correctly encodes to UTF-8 rather than exiting with a UnicodeEncode
+        // error.
+        env('PYTHONIOENCODING', 'UTF-8')
+        env('LC_CTYPE', 'en_US.UTF-8')
     }
 
     steps {

--- a/platform/resources/retirement-partner-reporter.sh
+++ b/platform/resources/retirement-partner-reporter.sh
@@ -2,6 +2,18 @@
 
 set -ex
 
+# Display the environment variables again, this time within the context of a
+# new subshell inside of the job. N.B. this should not print plain credentials
+# because the only credentialsBindings we currently use is of type "file" which
+# just stores a filename in the environment (rather than the content).
+env
+
+# Make sure that when we try to write unicode to the console, it
+# correctly encodes to UTF-8 rather than exiting with a UnicodeEncode
+# error.
+export PYTHONIOENCODING=UTF-8
+export LC_CTYPE=en_US.UTF-8
+
 # prepare credentials
 mkdir -p $WORKSPACE/user-retirement-secure
 cp $USER_RETIREMENT_SECURE_DEFAULT $WORKSPACE/user-retirement-secure/secure-default.yml

--- a/platform/resources/user-retirement-bulk-status.sh
+++ b/platform/resources/user-retirement-bulk-status.sh
@@ -2,6 +2,18 @@
 
 set -ex
 
+# Display the environment variables again, this time within the context of a
+# new subshell inside of the job. N.B. this should not print plain credentials
+# because the only credentialsBindings we currently use is of type "file" which
+# just stores a filename in the environment (rather than the content).
+env
+
+# Make sure that when we try to write unicode to the console, it
+# correctly encodes to UTF-8 rather than exiting with a UnicodeEncode
+# error.
+export PYTHONIOENCODING=UTF-8
+export LC_CTYPE=en_US.UTF-8
+
 # prepare credentials
 mkdir -p $WORKSPACE/user-retirement-secure
 cp $USER_RETIREMENT_SECURE_DEFAULT $WORKSPACE/user-retirement-secure/secure-default.yml

--- a/platform/resources/user-retirement-collector.sh
+++ b/platform/resources/user-retirement-collector.sh
@@ -2,6 +2,18 @@
 
 set -ex
 
+# Display the environment variables again, this time within the context of a
+# new subshell inside of the job. N.B. this should not print plain credentials
+# because the only credentialsBindings we currently use is of type "file" which
+# just stores a filename in the environment (rather than the content).
+env
+
+# Make sure that when we try to write unicode to the console, it
+# correctly encodes to UTF-8 rather than exiting with a UnicodeEncode
+# error.
+export PYTHONIOENCODING=UTF-8
+export LC_CTYPE=en_US.UTF-8
+
 # prepare credentials
 mkdir -p $WORKSPACE/user-retirement-secure
 cp $USER_RETIREMENT_SECURE_DEFAULT $WORKSPACE/user-retirement-secure/secure-default.yml

--- a/platform/resources/user-retirement-driver.sh
+++ b/platform/resources/user-retirement-driver.sh
@@ -2,6 +2,18 @@
 
 set -ex
 
+# Display the environment variables again, this time within the context of a
+# new subshell inside of the job. N.B. this should not print plain credentials
+# because the only credentialsBindings we currently use is of type "file" which
+# just stores a filename in the environment (rather than the content).
+env
+
+# Make sure that when we try to write unicode to the console, it
+# correctly encodes to UTF-8 rather than exiting with a UnicodeEncode
+# error.
+export PYTHONIOENCODING=UTF-8
+export LC_CTYPE=en_US.UTF-8
+
 # prepare credentials
 mkdir -p $WORKSPACE/user-retirement-secure
 cp $USER_RETIREMENT_SECURE_DEFAULT $WORKSPACE/user-retirement-secure/secure-default.yml


### PR DESCRIPTION
This makes sure that both PYTHONIOENCODING and LC_CTYPE are both set to utf-8. Adding these to environmentVariables{} might have been overkill, but I had already written that and decided to keep it.