### PR TITLE
Enable hourly retirements on prod-edge.

### DIFF
--- a/platform/jobs/RetirementJobEdxTriggers.groovy
+++ b/platform/jobs/RetirementJobEdxTriggers.groovy
@@ -24,7 +24,7 @@ List jobConfigs = [
         environmentDeployment: 'prod-edge',
         extraMembersCanBuild: [],
         cron: 'H * * * *',  // Hourly at an arbitrary, but consistent minute.
-        disabled: true
+        disabled: false
     ],
     [
         downstreamJobName: 'retirement-partner-reporter',


### PR DESCRIPTION
https://openedx.atlassian.net/browse/PLAT-2296

User retirements of prod-edge users now successfully run. So turn on the hourly triggered runs on prod-edge.