### PR TITLE
On failures also notify individuals with commits in change.

### DIFF
--- a/devops/jobs/AppPermissionsRunner.groovy
+++ b/devops/jobs/AppPermissionsRunner.groovy
@@ -110,7 +110,7 @@ class AppPermissionsRunner {
 
                     if (extraVars.get('NOTIFY_ON_FAILURE')){
                         publishers {
-                            mailer(extraVars.get('NOTIFY_ON_FAILURE'), false, false)
+                            mailer(extraVars.get('NOTIFY_ON_FAILURE'), false, true)
                         }
                     }
 


### PR DESCRIPTION
This should hopefully reduce the burden on IT to fix issues introduced by developers.