### PR TITLE
Enable the partner reporting weekly trigger for prod-edx

### DIFF
--- a/platform/jobs/RetirementJobEdxTriggers.groovy
+++ b/platform/jobs/RetirementJobEdxTriggers.groovy
@@ -32,7 +32,7 @@ List jobConfigs = [
         environmentDeployment: 'prod-edx',
         extraMembersCanBuild: [],
         cron: '0 8 * * 2',  // 09:00 UTC every Tuesday.
-        disabled: true
+        disabled: false
     ],
     [
         downstreamJobName: 'retirement-partner-reporter',


### PR DESCRIPTION
We should be good to enable this trigger now that we don't expect the job to fail and require manual cleanup (i.e. manually deleting rows from the partner reporting statuses table since the script would error before that step).