### PR TITLE
add slack alerts to build packer job

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,9 +76,11 @@ dependencies {
     testCompile 'org.jgrapht:jgrapht-jdk1.5:0.7.3'
     testCompile 'org.jenkins-ci.plugins:cloudbees-folder:5.18@jar'
     testCompile 'org.jvnet.hudson.plugins:hipchat:0.1.9@jar'
+    testCompile 'org.jenkins-ci.plugins:slack:2.2@jar'
 
     // Plugins to install in test instance
     testPlugins 'com.cloudbees.plugins:build-flow-plugin:0.20'
+    testCompile 'org.jenkins-ci.plugins:slack:2.2'
 }
 
 codenarc {

--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -1,9 +1,10 @@
-package devops
+package platform
 
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_SLACK_STATUS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_BASE_URL
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_STATUS_PENDING
@@ -172,6 +173,7 @@ jobConfigs.each { jobConfig ->
             downstreamParameterized JENKINS_PUBLIC_GITHUB_STATUS_UNSTABLE_OR_WORSE.call(predefinedPropsMap)
             mailer('testeng@edx.org')
             hipChatNotifier JENKINS_PUBLIC_HIPCHAT('')
+            configure GENERAL_SLACK_STATUS()
        }
     }
 }

--- a/platform/jobs/edxPlatformBokChoyMaster.groovy
+++ b/platform/jobs/edxPlatformBokChoyMaster.groovy
@@ -1,9 +1,10 @@
-package devops
+package platform
 
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_SLACK_STATUS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_BASE_URL
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_STATUS_SUCCESS
@@ -172,6 +173,7 @@ jobConfigs.each { jobConfig ->
             downstreamParameterized JENKINS_PUBLIC_GITHUB_STATUS_UNSTABLE_OR_WORSE.call(predefinedPropsMap)
             mailer('testeng@edx.org')
             hipChatNotifier JENKINS_PUBLIC_HIPCHAT('')
+            configure GENERAL_SLACK_STATUS()
        }
     }
 }

--- a/platform/jobs/edxPlatformJsMaster.groovy
+++ b/platform/jobs/edxPlatformJsMaster.groovy
@@ -1,9 +1,10 @@
-package devops
+package platform
 
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_SLACK_STATUS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_BASE_URL
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_STATUS_PENDING
@@ -171,6 +172,7 @@ jobConfigs.each { jobConfig ->
             downstreamParameterized JENKINS_PUBLIC_GITHUB_STATUS_UNSTABLE_OR_WORSE.call(predefinedPropsMap)
             mailer('testeng@edx.org')
             hipChatNotifier JENKINS_PUBLIC_HIPCHAT('')
+            configure GENERAL_SLACK_STATUS()
         }
     }
 }

--- a/platform/jobs/edxPlatformLettuceMaster.groovy
+++ b/platform/jobs/edxPlatformLettuceMaster.groovy
@@ -1,9 +1,10 @@
-package devops
+package platform
 
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_SLACK_STATUS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_BASE_URL
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_BASEURL
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
@@ -175,6 +176,7 @@ jobConfigs.each { jobConfig ->
            downstreamParameterized JENKINS_PUBLIC_GITHUB_STATUS_UNSTABLE_OR_WORSE.call(predefinedPropsMap)
            mailer('testeng@edx.org')
            hipChatNotifier JENKINS_PUBLIC_HIPCHAT('')
+           configure GENERAL_SLACK_STATUS()
        }
     }
 }

--- a/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
@@ -5,6 +5,7 @@ import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SEC
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_JUNIT_REPORTS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_SLACK_STATUS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_BASE_URL
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_STATUS_SUCCESS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_STATUS_UNSTABLE_OR_WORSE
@@ -207,6 +208,7 @@ jobConfigs.each { jobConfig ->
             downstreamParameterized JENKINS_PUBLIC_GITHUB_STATUS_UNSTABLE_OR_WORSE.call(predefinedPropsMap)
             mailer('testeng@edx.org')
             hipChatNotifier JENKINS_PUBLIC_HIPCHAT('')
+            configure GENERAL_SLACK_STATUS()
         }
     }
 }

--- a/platform/jobs/edxPlatformQualityMaster.groovy
+++ b/platform/jobs/edxPlatformQualityMaster.groovy
@@ -1,10 +1,11 @@
-package devops
+package platform
 
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_ARCHIVE_XUNIT
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_SLACK_STATUS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_BASE_URL
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_STATUS_PENDING
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_STATUS_SUCCESS
@@ -183,6 +184,7 @@ jobConfigs.each { jobConfig ->
             downstreamParameterized JENKINS_PUBLIC_GITHUB_STATUS_UNSTABLE_OR_WORSE.call(predefinedPropsMap)
             mailer('testeng@edx.org')
             hipChatNotifier JENKINS_PUBLIC_HIPCHAT('')
+            configure GENERAL_SLACK_STATUS()
         }
     }
 }

--- a/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
@@ -75,6 +75,25 @@ class JenkinsPublicConstants {
     }
   }
 
+  public static final Closure GENERAL_SLACK_STATUS = {
+    return {
+        it /
+            publishers /
+            'jenkins.plugins.slack.SlackNotifier' {
+                startNotification false
+                notifySuccess false
+                notifyAborted true
+                notifyNotBuilt false
+                notifyUnstable true
+                notifyRegression false
+                notifyFailure true
+                notifyBackToNormal true
+                notifyRepeatedFailure true
+            }
+    }
+  }
+
+
     /* Parse data out of the Jenkins secret file referenced with env var "secretFileVariable" */
     /* Secret files are in YAML format, so parse their k:v into a a Map */
     public static final Closure JENKINS_PUBLIC_PARSE_SECRET = { secretFileVariable, envVarsMap, out ->

--- a/testeng/jobs/backupJenkins.groovy
+++ b/testeng/jobs/backupJenkins.groovy
@@ -3,6 +3,7 @@ package testeng
 import hudson.util.Secret
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_SLACK_STATUS
 
 Map config = [:]
 Binding bindings = getBinding()
@@ -128,6 +129,9 @@ secretMap.each { jobConfigs ->
             }
             // alert team of failures via hipchat & email
             hipChatNotifier JENKINS_PUBLIC_HIPCHAT(jobConfig['hipchat'])
+            configure GENERAL_SLACK_STATUS()
+
+
             mailer(jobConfig['email'])
             // fail the build if the snapshot command does not correctly trigger a snapshot
             // requires "textFinder plugin"

--- a/testeng/jobs/bokchoyDbCacheUploader.groovy
+++ b/testeng/jobs/bokchoyDbCacheUploader.groovy
@@ -5,6 +5,7 @@ import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_MASKED_PASSWORD
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_SLACK_STATUS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_BASE_URL
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_GITHUB_BASEURL
 
@@ -144,6 +145,7 @@ secretMap.each { jobConfigs ->
         publishers {
             mailer(jobConfig['email'])
             hipChatNotifier JENKINS_PUBLIC_HIPCHAT(jobConfig['hipchat'])
+            configure GENERAL_SLACK_STATUS()
         }
     }
 }

--- a/testeng/jobs/buildPackerAMIjob.groovy
+++ b/testeng/jobs/buildPackerAMIjob.groovy
@@ -3,6 +3,7 @@ package testeng
 import hudson.util.Secret
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_SLACK_STATUS
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_TEAM_SECURITY
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 
@@ -152,6 +153,7 @@ secretMap.each { jobConfigs ->
         publishers {
             // alert team of failures via hipchat & email
             hipChatNotifier JENKINS_PUBLIC_HIPCHAT(jobConfig['hipchat'])
+            configure GENERAL_SLACK_STATUS()
             mailer(jobConfig['email'])
         }
 

--- a/testeng/jobs/edxPlatformTestNotifierJob.groovy
+++ b/testeng/jobs/edxPlatformTestNotifierJob.groovy
@@ -4,6 +4,7 @@ import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SEC
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_MASKED_PASSWORD
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_SLACK_STATUS
 
 job('edx-platform-test-notifier') {
 
@@ -44,5 +45,6 @@ job('edx-platform-test-notifier') {
     publishers {
         mailer('testeng@edx.org')
         hipChatNotifier JENKINS_PUBLIC_HIPCHAT('')
+        configure GENERAL_SLACK_STATUS()
     }
 }

--- a/testeng/jobs/gatherCodecovMetrics.groovy
+++ b/testeng/jobs/gatherCodecovMetrics.groovy
@@ -4,6 +4,7 @@ import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SEC
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_MASKED_PASSWORD
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_SLACK_STATUS
 
 job('gather-codecov-metrics') {
 
@@ -43,6 +44,7 @@ job('gather-codecov-metrics') {
     publishers {
         mailer('testeng@edx.org')
         hipChatNotifier JENKINS_PUBLIC_HIPCHAT('')
+        configure GENERAL_SLACK_STATUS()
         archiveArtifacts {
             pattern('codecov_metrics.json')
         }

--- a/testeng/jobs/scanPluginUpdatesJob.groovy
+++ b/testeng/jobs/scanPluginUpdatesJob.groovy
@@ -2,6 +2,7 @@ package testeng
 
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_HIPCHAT
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_SLACK_STATUS
 
 job('scan-plugin-updates') {
 
@@ -44,6 +45,7 @@ job('scan-plugin-updates') {
     publishers {
         mailer('testeng@edx.org')
         hipChatNotifier JENKINS_PUBLIC_HIPCHAT('')
+        configure GENERAL_SLACK_STATUS()
     }
 
 }


### PR DESCRIPTION
This adds a function for sending basic job statuses from Jenkins to Slack, approximating our basic hipchat alerts, as part of the move from hipchat -> slack. Most job DSL scripts will use this, but there are  few jobs that use custom alerts. I will work on those in a separate PR