### PR TITLE
Revert "On failures also notify individuals with commits in change."

### DIFF
--- a/devops/jobs/AppPermissionsRunner.groovy
+++ b/devops/jobs/AppPermissionsRunner.groovy
@@ -110,7 +110,7 @@ class AppPermissionsRunner {
 
                     if (extraVars.get('NOTIFY_ON_FAILURE')){
                         publishers {
-                            mailer(extraVars.get('NOTIFY_ON_FAILURE'), false, true)
+                            mailer(extraVars.get('NOTIFY_ON_FAILURE'), false, false)
                         }
                     }
 


### PR DESCRIPTION
Reverts edx/jenkins-job-dsl#409

This change is causing PII to leak outside of the org.