### PR TITLE
adjust makefile to account for no overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ hs_err_pid*
 
 # PyCharm files
 *.idea/
+
+# additional configuration overrides for provisioning a local Jenkins sandbox
+ansible_overrides.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
   jenkins_build:
     image: edxops/jenkins_build:latest
     container_name: jenkins_build
-    volumes:
-        - jenkins_build:/var/lib/jenkins
     ports:
       - "127.0.0.1:8081:8080"
 


### PR DESCRIPTION
Sometimes you don't need to add any overrides to the ansible configuration of the jenkins_build container. This will prevent you from needing to rejigger the Makefile each time.