### PR TITLE
add job DSL for user-location-by-course jobs

### DIFF
--- a/dataeng/jobs/analytics/UserActivity.groovy
+++ b/dataeng/jobs/analytics/UserActivity.groovy
@@ -1,7 +1,7 @@
 package analytics
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_multiscm
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_parameters
-import static org.edx.jenkins.dsl.AnalyticsConstants.date_interval_parameters
+import static org.edx.jenkins.dsl.AnalyticsConstants.to_date_interval_parameter
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_log_rotator
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_wrappers
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_publishers
@@ -11,9 +11,9 @@ class UserActivity {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("user-activity-$environment") {
-                logRotator common_log_rotator(allVars)
+                logRotator common_log_rotator(allVars, env_config)
                 parameters common_parameters(allVars, env_config)
-                parameters date_interval_parameters(allVars)
+                parameters to_date_interval_parameter(allVars)
                 multiscm common_multiscm(allVars)
                 triggers common_triggers(allVars, env_config)
                 wrappers common_wrappers(allVars)

--- a/dataeng/jobs/analytics/UserLocationByCourse.groovy
+++ b/dataeng/jobs/analytics/UserLocationByCourse.groovy
@@ -1,27 +1,25 @@
 package analytics
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_multiscm
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_parameters
-import static org.edx.jenkins.dsl.AnalyticsConstants.from_date_interval_parameter
 import static org.edx.jenkins.dsl.AnalyticsConstants.to_date_interval_parameter
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_log_rotator
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_wrappers
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_publishers
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_triggers
 
-class VideoTimeline {
+class UserLocationByCourse {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
-            dslFactory.job("video-timeline-$environment") {
+            dslFactory.job("user-location-by-course-$environment") {
                 logRotator common_log_rotator(allVars, env_config)
                 parameters common_parameters(allVars, env_config)
-                parameters from_date_interval_parameter(allVars)
                 parameters to_date_interval_parameter(allVars)
                 multiscm common_multiscm(allVars)
                 triggers common_triggers(allVars, env_config)
                 wrappers common_wrappers(allVars)
                 publishers common_publishers(allVars)
                 steps {
-                    shell(dslFactory.readFileFromWorkspace('dataeng/resources/video-timeline.sh'))
+                    shell(dslFactory.readFileFromWorkspace('dataeng/resources/user-location-by-course.sh'))
                     if (env_config.get('SNITCH')) {
                         shell('curl https://nosnch.in/' + env_config.get('SNITCH'))
                     }

--- a/dataeng/jobs/createJobs.groovy
+++ b/dataeng/jobs/createJobs.groovy
@@ -2,6 +2,7 @@ import static analytics.AnalyticsEmailOptin.job as AnalyticsEmailOptinJob
 import static analytics.AnalyticsExporter.job as AnalyticsExporterJob
 import static analytics.UserActivity.job as UserActivityJob
 import static analytics.VideoTimeline.job as VideoTimelineJob
+import static analytics.UserLocationByCourse.job as UserLocationByCourse
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.error.YAMLException
 
@@ -24,8 +25,9 @@ try {
 def taskMap = [
     ANALYTICS_EMAIL_OPTIN_JOB: AnalyticsEmailOptinJob,
     ANALYTICS_EXPORTER_JOB: AnalyticsExporterJob,
-    VIDEO_TIMELINE_JOB: VideoTimelineJob,
     USER_ACTIVITY_JOB: UserActivityJob,
+    VIDEO_TIMELINE_JOB: VideoTimelineJob,
+    USER_LOCATION_BY_COURSE: UserLocationByCourse,
 ]
 
 for (task in taskMap) {

--- a/dataeng/resources/user-location-by-course.sh
+++ b/dataeng/resources/user-location-by-course.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+END_DATE=$(date +%Y-%m-%d -d "$TO_DATE")
+
+if [ -z "$NUM_REDUCE_TASKS" ]; then
+    NUM_REDUCE_TASKS=$(( $NUM_TASK_CAPACITY * 2 ))
+fi
+
+env
+
+${WORKSPACE}/analytics-configuration/automation/run-automated-task.sh \
+  ImportCountryWorkflow --local-scheduler \
+  --interval-end $END_DATE \
+  --n-reduce-tasks $NUM_REDUCE_TASKS \
+  --overwrite

--- a/src/main/groovy/org/edx/jenkins/dsl/AnalyticsConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/AnalyticsConstants.groovy
@@ -2,9 +2,12 @@ package org.edx.jenkins.dsl
 
 class AnalyticsConstants {
 
-    public static def common_log_rotator = { allVars ->
-        return {
-            daysToKeep(30)
+    public static def common_log_rotator = { allVars, env=[:] ->
+        def job_frequency = env.get('DAYS_TO_KEEP_BUILD', allVars.get('DAYS_TO_KEEP_BUILD'))
+        if (job_frequency) {
+            return {
+                daysToKeep(job_frequency.toInteger())
+            }
         }
     }
 
@@ -61,7 +64,7 @@ This text may reference other parameters in the task as shell variables, e.g.  $
         }
     }
 
-    public static def date_interval_parameters = { allVars ->
+    public static def from_date_interval_parameter = { allVars ->
       return {
         stringParam('FROM_DATE', allVars.get('FROM_DATE', '2013-11-01'),
           'The first date to export data for. Data for this date and all days before the "TO_DATE" parameter' +
@@ -75,6 +78,11 @@ This text may reference other parameters in the task as shell variables, e.g.  $
   * 1 week ago
   * 2013-11-01
   /$)
+      }
+    }
+
+    public static def to_date_interval_parameter = { allVars ->
+      return {
         stringParam('TO_DATE', allVars.get('TO_DATE', 'today'),
           'The day after the last date to export data for. Data from the "FROM_DATE" parameter to 11:59:59' +
           ' on the date before this date will be included.' + $/


### PR DESCRIPTION
This also makes the common_log_rotator configurable to allow a different
number of days to keep the build for each different job and environment.

DE-910

---

see also https://github.com/edx-ops/analytics-secure/pull/177