### PR TITLE
Reduce the number of builds we keep for tasks that run once per minute.

### DIFF
--- a/devops/jobs/CheckCeleryProgress.groovy
+++ b/devops/jobs/CheckCeleryProgress.groovy
@@ -39,7 +39,12 @@ class CheckCeleryProgress {
                 dslFactory.job(extraVars.get("FOLDER_NAME","Monitoring") + "/check-celery-progress-${environment}-${deployment}") {
 
                     wrappers common_wrappers
-                    logRotator common_logrotator
+                    /* Only keep the builds for one day since it runs every minute.
+                       Reduce number of builds kept from ~10,000 to ~1000
+                    */
+                    logRotator {
+                        daysToKeep(1)
+                    }
 
                     wrappers {
                         credentialsBinding {

--- a/devops/jobs/UpdateCeleryMonitoring.groovy
+++ b/devops/jobs/UpdateCeleryMonitoring.groovy
@@ -39,7 +39,12 @@ class UpdateCeleryMonitoring {
                 dslFactory.job(extraVars.get("FOLDER_NAME","Monitoring") + "/update-celery-monitoring-${environment}-${deployment}") {
 
                     wrappers common_wrappers
-                    logRotator common_logrotator
+                    /* Only keep the builds for one day since it runs every minute.
+                       Reduce number of builds kept from ~10,000 to ~1000
+                    */
+                    logRotator {
+                        daysToKeep(1)
+                    }
 
                     wrappers {
                         credentialsBinding {


### PR DESCRIPTION
Having 10,000+ builds isn't super useful and slows down the UI.