### PR TITLE
Add two more dataeng jobs

### DIFF
--- a/dataeng/jobs/analytics/AnswerDistribution.groovy
+++ b/dataeng/jobs/analytics/AnswerDistribution.groovy
@@ -1,0 +1,35 @@
+package analytics
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_multiscm
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_parameters
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_log_rotator
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_wrappers
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_publishers
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_triggers
+
+class AnswerDistribution {
+    public static def job = { dslFactory, allVars ->
+        allVars.get('ENVIRONMENTS').each { environment, env_config ->
+            dslFactory.job("answer-distribution-$environment") {
+                logRotator common_log_rotator(allVars, env_config)
+                parameters {
+                    stringParam('SOURCES', env_config.get('SOURCES', allVars.get('SOURCES')), '')
+                    stringParam('DESTINATION_PREFIX', env_config.get('DESTINATION_PREFIX', allVars.get('DESTINATION_PREFIX')), '')
+                    stringParam('OUTPUT_URL', env_config.get('OUTPUT_URL', allVars.get('OUTPUT_URL')), '')
+                    stringParam('CREDENTIALS', env_config.get('CREDENTIALS', allVars.get('CREDENTIALS')), '')
+                    stringParam('LIB_JAR', env_config.get('LIB_JAR', allVars.get('LIB_JAR')), '')
+                }
+                parameters common_parameters(allVars, env_config)
+                multiscm common_multiscm(allVars)
+                triggers common_triggers(allVars, env_config)
+                wrappers common_wrappers(allVars)
+                publishers common_publishers(allVars)
+                steps {
+                    shell(dslFactory.readFileFromWorkspace('dataeng/resources/answer-distribution.sh'))
+                    if (env_config.get('SNITCH')) {
+                        shell('curl https://nosnch.in/' + env_config.get('SNITCH'))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dataeng/jobs/analytics/DatabaseExportCoursewareStudentmodule.groovy
+++ b/dataeng/jobs/analytics/DatabaseExportCoursewareStudentmodule.groovy
@@ -1,0 +1,34 @@
+package analytics
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_multiscm
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_parameters
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_log_rotator
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_wrappers
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_publishers
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_triggers
+
+class DatabaseExportCoursewareStudentmodule {
+    public static def job = { dslFactory, allVars ->
+        allVars.get('ENVIRONMENTS').each { environment, env_config ->
+            dslFactory.job("database-export-courseware-studentmodule-$environment") {
+                logRotator common_log_rotator(allVars, env_config)
+                parameters {
+                    stringParam('BASE_OUTPUT_URL', env_config.get('BASE_OUTPUT_URL', allVars.get('BASE_OUTPUT_URL')), '')
+                    stringParam('OUTPUT_DIR', env_config.get('OUTPUT_DIR', allVars.get('OUTPUT_DIR')), '')
+                    stringParam('OUTPUT_SUFFIX', env_config.get('OUTPUT_SUFFIX', allVars.get('OUTPUT_SUFFIX')), '')
+                    stringParam('CREDENTIALS', env_config.get('CREDENTIALS', allVars.get('CREDENTIALS')), '')
+                }
+                parameters common_parameters(allVars, env_config)
+                multiscm common_multiscm(allVars)
+                triggers common_triggers(allVars, env_config)
+                wrappers common_wrappers(allVars)
+                publishers common_publishers(allVars)
+                steps {
+                    shell(dslFactory.readFileFromWorkspace('dataeng/resources/database-export-courseware-studentmodule.sh'))
+                    if (env_config.get('SNITCH')) {
+                        shell('curl https://nosnch.in/' + env_config.get('SNITCH'))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dataeng/jobs/createJobs.groovy
+++ b/dataeng/jobs/createJobs.groovy
@@ -5,6 +5,8 @@ import static analytics.VideoTimeline.job as VideoTimelineJob
 import static analytics.UserLocationByCourse.job as UserLocationByCourseJob
 import static analytics.Enrollment.job as EnrollmentJob
 import static analytics.ModuleEngagement.job as ModuleEngagementJob
+import static analytics.DatabaseExportCoursewareStudentmodule.job as DatabaseExportCoursewareStudentmoduleJob
+import static analytics.AnswerDistribution.job as AnswerDistributionJob
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.error.YAMLException
 
@@ -32,6 +34,8 @@ def taskMap = [
     USER_LOCATION_BY_COURSE_JOB: UserLocationByCourseJob,
     ENROLLMENT_JOB: EnrollmentJob,
     MODULE_ENGAGEMENT_JOB: ModuleEngagementJob,
+    DATABASE_EXPORT_COURSEWARE_STUDENTMODULE_JOB: DatabaseExportCoursewareStudentmoduleJob,
+    ANSWER_DISTRIBUTION_JOB: AnswerDistributionJob,
 ]
 
 for (task in taskMap) {

--- a/dataeng/resources/answer-distribution.sh
+++ b/dataeng/resources/answer-distribution.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+if [ -z "$NUM_REDUCE_TASKS" ]; then
+    NUM_REDUCE_TASKS=$(( $NUM_TASK_CAPACITY * 2 ))
+fi
+NUM_REDUCE_TASKS=$(( $NUM_REDUCE_TASKS * 2 ))
+
+now=$(date +%H)
+
+name=hourly
+src="$SOURCES"
+dest=${DESTINATION_PREFIX}/$now
+manifest=${DESTINATION_PREFIX}/$now/manifest.txt
+
+# Remove any previous intermediate output for this hour
+pip install awscli
+aws s3 rm --recursive $dest || true
+
+${WORKSPACE}/analytics-configuration/automation/run-automated-task.sh \
+  AnswerDistributionWorkflow --local-scheduler \
+  --src $src --dest $dest --name $name --output-root $OUTPUT_URL \
+  --include '[\"*tracking.log*20131*.gz\",\"*tracking.log*2014*.gz\",\"*tracking.log*2015*.gz\",\"*tracking.log*2016*.gz\",\"*tracking.log*2017*.gz\",\"*tracking.log*2018*.gz\"]' \
+  --manifest "$manifest" --base-input-format "org.edx.hadoop.input.ManifestTextInputFormat" --lib-jar $LIB_JAR \
+  --n-reduce-tasks $NUM_REDUCE_TASKS \
+  --marker $dest/marker \
+  --credentials $CREDENTIALS

--- a/dataeng/resources/database-export-courseware-studentmodule.sh
+++ b/dataeng/resources/database-export-courseware-studentmodule.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+env
+
+DAY_OF_MONTH=$(date +%d)
+OUTPUT_URL=$BASE_OUTPUT_URL/$DAY_OF_MONTH/$OUTPUT_DIR
+NUM_REDUCE_TASKS=$(( $NUM_TASK_CAPACITY + 1 ))
+
+${WORKSPACE}/analytics-configuration/automation/run-automated-task.sh \
+  StudentModulePerCourseAfterImportWorkflow --local-scheduler \
+  --credentials $CREDENTIALS \
+  --dump-root $OUTPUT_URL/raw/ \
+  --output-root $OUTPUT_URL/ \
+  --delete-output-root \
+  --output-suffix $OUTPUT_SUFFIX \
+  --num-mappers $(( ($NUM_TASK_CAPACITY + 1) * 2 )) \
+  --n-reduce-tasks $NUM_REDUCE_TASKS \
+  --verbose


### PR DESCRIPTION
Added the following jobs:

* answer-distribution
* database-export-courseware-studentmodule

DE-914
DE-916

---

See also the corresponding analytics-secure PR: https://github.com/edx-ops/analytics-secure/pull/181

So far, I tested seeding the jobs:

http://jenkins.analytics.edx.org/view/all/job/answer-distribution-production/
http://jenkins.analytics.edx.org/view/all/job/answer-distribution-edge/
http://jenkins.analytics.edx.org/view/all/job/answer-distribution-release/

http://jenkins.analytics.edx.org/view/all/job/database-export-courseware-studentmodule-production/
http://jenkins.analytics.edx.org/view/all/job/database-export-courseware-studentmodule-edge/
