### PR TITLE
Fix generate-warehouse-docs to use a virtualenv

### DIFF
--- a/dataeng/jobs/analytics/GenerateWarehouseDocs.groovy
+++ b/dataeng/jobs/analytics/GenerateWarehouseDocs.groovy
@@ -36,7 +36,12 @@ class GenerateWarehouseDocs {
                 timestamps()
             }
             steps {
-                shell(dslFactory.readFileFromWorkspace("dataeng/resources/generate-warehouse-docs.sh"))
+                virtualenv {
+                    nature("shell")
+                    command(
+                        dslFactory.readFileFromWorkspace("dataeng/resources/generate-warehouse-docs.sh")
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
This should fix current failures in the generate-warehouse-docs job, e.g.: http://jenkins.analytics.edx.org/view/all/job/generate-warehouse-docs/4/console

Already seeded, see http://jenkins.analytics.edx.org/view/all/job/generate-warehouse-docs/configure