### PR TITLE
Change @channel to @here in slack spigot message

### DIFF
--- a/testeng/jobs/toggleSpigot.groovy
+++ b/testeng/jobs/toggleSpigot.groovy
@@ -118,7 +118,7 @@ secretMap.each { jobConfigs ->
                     notifyBackToNormal false
                     notifyRepeatedFailure false
                     includeCustomMessage true
-                    customMessage '@channel The Spigot is now: $SPIGOT_STATE ($SPIGOT_MESSAGE)'
+                    customMessage '@here The Spigot is now: $SPIGOT_STATE ($SPIGOT_MESSAGE)'
                     room 'TestEngineering'
                 }
             }


### PR DESCRIPTION
We've received feedback that `@channel` is too harsh, switching to `@here` for now. Which will only message all active members of the room.