### PR TITLE
TE-2793 Clear quality reports from prior jobs

### DIFF
--- a/platform/jobs/edxPlatformQualityDiff.groovy
+++ b/platform/jobs/edxPlatformQualityDiff.groovy
@@ -5,6 +5,9 @@ import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SEC
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_ARCHIVE_XUNIT
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 
+String deleteReports = 'reports/**/*,test_root/log/*.log,'
+deleteReports += 'edx-platform*/reports/**/*,edx-platform*/test_root/log/*.log,'
+
 stringParams = [
     [
         name: 'sha1',
@@ -113,6 +116,10 @@ jobConfigs.each { jobConfig ->
             }
             timestamps()
             colorizeOutput('gnome-terminal')
+            preBuildCleanup {
+                includePattern(deleteReports)
+                deleteDirectories()
+            }
             sshAgent('jenkins-worker')
             buildName('#\${BUILD_NUMBER}: \${GIT_REVISION,length=8}')
         }

--- a/platform/jobs/edxPlatformQualityMaster.groovy
+++ b/platform/jobs/edxPlatformQualityMaster.groovy
@@ -147,6 +147,10 @@ jobConfigs.each { jobConfig ->
             }
             timestamps()
             sshAgent('jenkins-worker')
+            preBuildCleanup {
+                includePattern(archiveReports)
+                deleteDirectories()
+            }
             colorizeOutput()
        }
 

--- a/platform/jobs/edxPlatformQualityPr.groovy
+++ b/platform/jobs/edxPlatformQualityPr.groovy
@@ -30,6 +30,9 @@ catch (any) {
     return 1
 }
 
+String archiveReports = 'reports/**/*,test_root/log/*.log,'
+archiveReports += 'edx-platform*/reports/**/*,edx-platform*/test_root/log/*.log,'
+
 String pep8Reports = 'reports/pep8/pep8.report, edx-platform*/reports/pep8/pep8.report'
 String pylintReports = 'reports/**/pylint.report, edx-platform*/reports/**/pylint.report'
 
@@ -175,6 +178,10 @@ jobConfigs.each { jobConfig ->
                 absolute(90)
             }
             timestamps()
+            preBuildCleanup {
+                includePattern(archiveReports)
+                deleteDirectories()
+            }
             colorizeOutput()
         }
 
@@ -182,10 +189,7 @@ jobConfigs.each { jobConfig ->
 
         publishers {
             archiveArtifacts {
-                pattern(
-                    'reports/**/*,test_root/log/*.log,' +
-                    'edx-platform*/reports/**/*,edx-platform*/test_root/log/*.log,'
-                )
+                pattern(archiveReports)
                 defaultExcludes(true)
                 allowEmpty(true)
             }


### PR DESCRIPTION
Quality reports from previous jobs on the same worker were sometimes sticking around and being included in the results for later jobs.  Explicitly delete all these at the start of each quality job run.  The copying of artifacts from other jobs in the quality diff job occurs after this cleanup.