### PR TITLE
TE-2804 Optimize git usage in unit test pipeline

### DIFF
--- a/platform/jobs/pipelines/edxPlatformPythonPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPythonPipelinePr.groovy
@@ -52,15 +52,29 @@ pipelineJob('edx-platform-python-pipeline-pr') {
         cpsScm {
             scm {
                 git {
+                    extensions {
+                        cloneOptions {
+                            honorRefspec(true)
+                            noTags(true)
+                            shallow(true)
+                        }
+                        sparseCheckoutPaths {
+                            sparseCheckoutPaths {
+                                sparseCheckoutPath {
+                                    path('scripts/Jenkinsfiles')
+                                }
+                            }
+                        }
+                    }
                     remote {
                         credentials('jenkins-worker')
                         github('edx/edx-platform', 'ssh', 'github.com')
-                        refspec('+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/*')
+                        refspec('+refs/heads/master:refs/remotes/origin/master +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*')
                         branch('\${sha1}')
                     }
                 }
             }
-            scriptPath('Jenkinsfile')
+            scriptPath('scripts/Jenkinsfiles/python')
         }
     }
 }


### PR DESCRIPTION
Make a few changes to dramatically speed up retrieval of the Jenkinsfile which defines the pipeline:

* Narrow the refspec to include only `master` and the PR's branch (this alone saves 2+ minutes)
* Don't fetch historical commits, just the current code
* Don't fetch tags
* Do a sparse checkout of just a directory of Jenkinsfiles, instead of needing to fetch the entire repo to get a Jenkinsfile at the project root

Collectively, these changes have reduced the time spent in the Jenkinsfile retrieval step from nearly 4 minutes to about 10 seconds.

Note: This shouldn't be applied to build Jenkins until a while after https://github.com/edx/edx-platform/pull/19249 is merged (since that copies the Jenkinsfile to its new subdirectory).