### PR TITLE
fix syntax

### DIFF
--- a/platform/jobs/pipelines/edxPlatformPythonPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPythonPipelinePr.groovy
@@ -34,7 +34,7 @@ pipelineJob('edx-platform-python-pipeline-pr') {
         logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
 
         triggers {
-            pullRequest {
+            githubPullRequest {
                 admins(ghprbMap['admin'])
                 useGitHubHooks()
                 triggerPhrase(/.*jenkins\W+run\W+pipeline\W+python.*/)


### PR DESCRIPTION
Native support for configuring the GHPRB was moved out of the DSL plugin and into the GHPRB plugin itself, as an extension point. This move included a couple of syntax changes (see: https://github.com/jenkinsci/ghprb-plugin#job-dsl-support and https://github.com/jenkinsci/job-dsl-plugin/wiki/Migration#github-pull-request-builder). We had fixed this for the regular pull request jobs, but the pipeline job was still being written at the time and so missed it. Here is the commit to fix the other pr jobs: https://github.com/edx/jenkins-job-dsl/commit/288cef33048c3be468071fc91a6703e9fd0ca9ed

Pipeline job has been successfully reseeded here: https://test-jenkins.testeng.edx.org/job/edx-platform-python-pipeline-pr/