### PR TITLE
Add dsl for openedx-release-ci job

### DIFF
--- a/openedx/jobs/openedxReleaseJob.groovy
+++ b/openedx/jobs/openedxReleaseJob.groovy
@@ -1,0 +1,35 @@
+package openedx
+
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
+
+// This is the job DSL responsible for creating the main pipeline job.
+pipelineJob('openedx-release-ci') {
+
+    definition {
+
+        parameters {
+            stringParam('OPENEDX_RELEASE_NAME', 'test-release',
+                        'open-release/${OPENEDX_RELEASE_NAME}')
+            choiceParam('DELETE_OR_KEEP', ['delete', 'keep'],
+                        'What should we do with the new release branches')
+
+        }
+
+        logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
+
+        cpsScm {
+            scm {
+                git {
+                    branch('master')
+                    remote {
+                        credentials('jenkins-worker')
+                        github('edx/repo-tools', 'ssh', 'github.com')
+                        refspec('+refs/heads/master:refs/remotes/origin/master')
+                    }
+                }
+            }
+            scriptPath('Jenkinsfiles/openedx-release-ci')
+        }
+
+    }
+}

--- a/platform/jobs/pipelines/edxPlatformLettucePipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformLettucePipelinePr.groovy
@@ -3,7 +3,6 @@ package platform
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_TEAM_SECURITY
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 
 /* stdout logger */
 Map config = [:]

--- a/platform/jobs/pipelines/edxPlatformPythonPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPythonPipelinePr.groovy
@@ -3,7 +3,6 @@ package platform
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_TEAM_SECURITY
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
 
 /* stdout logger */
 Map config = [:]


### PR DESCRIPTION
Get started on the DSL for the new openedx-release-ci job. For now, it just allows you to specify a release-name and whether you want the created branches to be kept or deleted at the end of the job.

For now, it is only triggered manually. That will change as the job becomes more useful.