### PR TITLE
Increase current exporter builds from 4 to 6.

### DIFF
--- a/dataeng/jobs/analytics/AnalyticsExporter.groovy
+++ b/dataeng/jobs/analytics/AnalyticsExporter.groovy
@@ -93,8 +93,8 @@ class AnalyticsExporter {
             }
 
             throttleConcurrentBuilds {
-                maxPerNode(4)
-                maxTotal(4)
+                maxPerNode(6)
+                maxTotal(6)
             }
 
             concurrentBuild()


### PR DESCRIPTION
This should be enough to get started on exporting MIT sooner. 