### PR TITLE
Remove DSL statements that require ws-cleanup and ansicolor plugins

### DIFF
--- a/src/main/groovy/org/edx/jenkins/dsl/UserRetirementConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/UserRetirementConstants.groovy
@@ -44,7 +44,6 @@ class UserRetirementConstants {
             buildUserVars() /* gives us access to BUILD_USER_ID, among other things */
             buildName('#${BUILD_NUMBER}, ' + extraVars.get('ENVIRONMENT_DEPLOYMENT'))
             timestamps()
-            colorizeOutput('xterm')
         }
     }
 
@@ -93,10 +92,6 @@ class UserRetirementConstants {
 
     public static def common_publishers = { extraVars ->
         return {
-            // After all the build steps have completed, cleanup the workspace in
-            // case this worker instance is re-used for a different job.
-            wsCleanup()
-
             if (extraVars.containsKey('MAILING_LIST')) {
                 // Send an alerting email upon failure.
                 extendedEmail {


### PR DESCRIPTION
The wsCleanup() publisher isn't as important anymore now that we're running these jobs in a more controlled environment (as opposed to the public-facing build jenkins running public jobs).

We don't particularly care about colors in the logging anyway.