### PR TITLE
TE-2669 Switch unit and lettuce tests to pipelines by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,38 +49,60 @@ dependencies {
     libs 'org.yaml:snakeyaml:1.17'
 
     compile 'org.yaml:snakeyaml:1.17'
-    compile 'org.codehaus.groovy:groovy:2.4.11'
+    compile 'org.codehaus.groovy:groovy-all:2.4.11'
+    compile "org.jenkins-ci.plugins:job-dsl-core:${jobDslVersion}"
     compile "org.jenkins-ci.main:jenkins-war:${jenkinsVersion}"
 
     testCompile 'org.codehaus.groovy:groovy:2.4.11'
-    testCompile('org.spockframework:spock-core:0.7-groovy-2.0') {
-        exclude module: 'groovy-all'
-    }
-    testCompile('org.spockframework:spock-core:0.7-groovy-2.0') {
-        exclude module: 'groovy-all'
-    }
+    testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
 
     // Needed for mocking in tests
     testCompile 'cglib:cglib:3.1'
 
     // Jenkins test harness dependencies
-    testCompile 'org.jenkins-ci.main:jenkins-test-harness:2.8'
+    testCompile 'org.jenkins-ci.main:jenkins-test-harness:2.44'
     testCompile "org.jenkins-ci.main:jenkins-war:${jenkinsVersion}"
-    testCompile "org.jenkins-ci.main:jenkins-war:${jenkinsVersion}:war-for-test@jar"
 
     // Jenkins plugins needed for tests
     testCompile "org.jenkins-ci.plugins:job-dsl:${jobDslVersion}"
     testCompile "org.jenkins-ci.plugins:job-dsl:${jobDslVersion}@jar"
-    testCompile 'org.jenkins-ci.plugins:structs:1.6@jar'
+    testCompile 'org.jenkins-ci.plugins:structs:1.14@jar'
     testCompile 'com.cloudbees.plugins:build-flow-plugin:0.20@jar'
     testCompile 'org.jgrapht:jgrapht-jdk1.5:0.7.3'
     testCompile 'org.jenkins-ci.plugins:cloudbees-folder:5.18@jar'
     testCompile 'org.jvnet.hudson.plugins:hipchat:0.1.9@jar'
-    testCompile 'org.jenkins-ci.plugins:slack:2.2@jar'
 
     // Plugins to install in test instance
     testPlugins 'com.cloudbees.plugins:build-flow-plugin:0.20'
-    testCompile 'org.jenkins-ci.plugins:slack:2.2'
+    testPlugins 'org.jenkins-ci.plugins:build-user-vars-plugin:1.5'
+    testPlugins 'org.jenkins-ci.plugins:build-timeout:1.19'
+    testPlugins 'org.jenkins-ci.plugins:cobertura:1.12.1'
+    testPlugins 'org.jenkins-ci.plugins:copyartifact:1.39'
+    testPlugins 'org.jenkins-ci.plugins:credentials:2.1.18'
+    testPlugins 'org.jenkins-ci.plugins:junit:1.26'
+    testPlugins 'org.jenkins-ci.plugins:matrix-auth:1.5'
+    testPlugins 'org.jenkins-ci.plugins:multiple-scms:0.6'
+    testPlugins 'org.jenkins-ci.plugins.workflow:workflow-job:2.11'
+    testPlugins 'org.jenkins-ci.plugins.workflow:workflow-aggregator:2.5'
+    testPlugins 'org.jenkins-ci.plugins.workflow:workflow-cps:2.46'
+    testPlugins 'org.jenkins-ci.plugins:ws-cleanup:0.34'
+    testPlugins 'org.jenkins-ci.plugins:xunit:1.93'
+    testPlugins 'org.jenkins-ci.plugins:ansicolor:0.5.2'
+    testPlugins 'org.jenkins-ci.plugins:parameterized-trigger:2.35.2'
+    testPlugins 'org.jenkins-ci.plugins:slack:2.2'
+    testPlugins 'org.jenkins-ci.plugins:ssh-agent:1.17'
+    testPlugins 'org.jenkins-ci.plugins:timestamper:1.8.9'
+    testPlugins 'org.jenkins-ci.plugins:token-macro:2.3'
+    testPlugins 'org.jenkins-ci.plugins:build-name-setter:1.3'
+    testPlugins 'org.jenkins-ci.plugins:email-ext:2.62'
+    testPlugins 'org.jenkins-ci.plugins:envinject:2.1.5'
+    testPlugins 'org.jenkins-ci.plugins:flexible-publish:0.15.2'
+    testPlugins 'org.jenkins-ci.plugins:git:3.9.1'
+    testPlugins 'com.coravy.hudson.plugins.github:github:1.29.2'
+    testPlugins 'org.jenkins-ci.plugins:htmlpublisher:1.16'
+    testPlugins 'org.jenkins-ci.plugins:nodelabelparameter:1.7.2'
+    testPlugins 'org.jenkins-ci.plugins:shiningpanda:0.23'
+    testPlugins 'org.jenkins-ci.plugins:text-finder:1.10'
 }
 
 codenarc {
@@ -106,9 +128,17 @@ task resolveTestPlugins(type: Copy) {
     into new File(sourceSets.test.output.resourcesDir, 'test-dependencies')
     include '*.hpi'
     include '*.jpi'
+    def mapping = [:]
+
+    doFirst {
+        configurations.testPlugins.resolvedConfiguration.resolvedArtifacts.each {
+            mapping[it.file.name] = "${it.name}.${it.extension}"
+        }
+    }
+    rename { mapping[it] }
 
     doLast {
-        def baseNames = source.collect { it.name[0..it.name.lastIndexOf('.')-1] }
+        List<String> baseNames = source*.name.collect { mapping[it] }.collect { it[0..it.lastIndexOf('.') - 1] }
         new File(destinationDir, 'index').setText(baseNames.join('\n'), 'UTF-8')
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 jobDslVersion=1.67
-jenkinsVersion=2.50
+jenkinsVersion=2.89.4

--- a/platform/jobs/edxPlatformLettuceMaster.groovy
+++ b/platform/jobs/edxPlatformLettuceMaster.groovy
@@ -31,18 +31,6 @@ PrintStream out = config['out']
 //     defaultBranch: branch to build
 // ]
 
-Map publicJobConfig = [
-    open: true,
-    jobName: 'edx-platform-lettuce-master',
-    subsetJob: 'edx-platform-test-subset',
-    repoName: 'edx-platform',
-    workerLabel: 'jenkins-worker',
-    context: 'jenkins/lettuce',
-    defaultTestengBranch: 'master',
-    refSpec : '+refs/heads/master:refs/remotes/origin/master',
-    defaultBranch : 'master'
-]
-
 Map privateJobConfig = [
     open: false,
     jobName: 'edx-platform-lettuce-master_private',
@@ -67,36 +55,9 @@ Map hawthornJobConfig = [
     defaultBranch : 'refs/heads/open-release/hawthorn.master'
 ]
 
-Map ginkgoJobConfig = [
-    open: true,
-    jobName: 'ginkgo-lettuce-master',
-    subsetJob: 'edx-platform-test-subset',
-    repoName: 'edx-platform',
-    workerLabel: 'ginkgo-jenkins-worker',
-    context: 'jenkins/ginkgo/lettuce',
-    defaultTestengBranch : 'refs/heads/open-release/ginkgo.master',
-    refSpec : '+refs/heads/open-release/ginkgo.master:refs/remotes/origin/open-release/ginkgo.master',
-    defaultBranch : 'refs/heads/open-release/ginkgo.master'
-]
-
-Map ficusJobConfig = [
-    open: true,
-    jobName: 'ficus-lettuce-master',
-    subsetJob: 'edx-platform-test-subset',
-    repoName: 'edx-platform',
-    workerLabel: 'ficus-jenkins-worker',
-    context: 'jenkins/ficus/lettuce',
-    defaultTestengBranch : 'refs/heads/open-release/ficus.master',
-    refSpec : '+refs/heads/open-release/ficus.master:refs/remotes/origin/open-release/ficus.master',
-    defaultBranch : 'refs/heads/open-release/ficus.master'
-]
-
 List jobConfigs = [
-    publicJobConfig,
     privateJobConfig,
-    hawthornJobConfig,
-    ginkgoJobConfig,
-    ficusJobConfig
+    hawthornJobConfig
 ]
 
 /* Iterate over the job configurations */

--- a/platform/jobs/edxPlatformLettucePr.groovy
+++ b/platform/jobs/edxPlatformLettucePr.groovy
@@ -44,17 +44,6 @@ catch (any) {
 //                       github. Default behavior: triggered by comments AND pull request updates
 //                       ]
 
-Map publicJobConfig = [ open : true,
-                        jobName : 'edx-platform-lettuce-pr',
-                        subsetJob: 'edx-platform-test-subset',
-                        repoName: 'edx-platform',
-                        workerLabel: 'jenkins-worker',
-                        whitelistBranchRegex: /^((?!open-release\/).)*$/,
-                        context: 'jenkins/lettuce',
-                        triggerPhrase: /.*jenkins\W+run\W+lettuce.*/,
-                        defaultTestengBranch: 'master'
-                        ]
-
 Map privateJobConfig = [ open: false,
                          jobName: 'edx-platform-lettuce-pr_private',
                          subsetJob: 'edx-platform-test-subset_private',
@@ -88,50 +77,6 @@ Map privateHawthornJobConfig = [ open: false,
                                 defaultTestengBranch: 'origin/open-release/hawthorn.master'
                                 ]
 
-Map publicGinkgoJobConfig = [ open: true,
-                              jobName: 'ginkgo-lettuce-pr',
-                              subsetJob: 'edx-platform-test-subset',
-                              repoName: 'edx-platform',
-                              workerLabel: 'ginkgo-jenkins-worker',
-                              whitelistBranchRegex: /open-release\/ginkgo.master/,
-                              context: 'jenkins/ginkgo/lettuce',
-                              triggerPhrase: /.*ginkgo\W+run\W+lettuce.*/,
-                              defaultTestengBranch: 'origin/open-release/ginkgo.master'
-                              ]
-
-Map privateGinkgoJobConfig = [ open: false,
-                               jobName: 'ginkgo-lettuce-pr_private',
-                               subsetJob: 'edx-platform-test-subset_private',
-                               repoName: 'edx-platform-private',
-                               workerLabel: 'ginkgo-jenkins-worker',
-                               whitelistBranchRegex: /open-release\/ginkgo.master/,
-                               context: 'jenkins/ginkgo/lettuce',
-                               triggerPhrase: /.*jenkins\W+run\W+lettuce.*/,
-                               defaultTestengBranch: 'origin/open-release/ginkgo.master'
-                               ]
-
-Map publicFicusJobConfig = [ open: true,
-                             jobName: 'ficus-lettuce-pr',
-                             subsetJob: 'edx-platform-test-subset',
-                             repoName: 'edx-platform',
-                             workerLabel: 'ficus-jenkins-worker',
-                             whitelistBranchRegex: /open-release\/ficus.master/,
-                             context: 'jenkins/ficus/lettuce',
-                             triggerPhrase: /.*ficus\W+run\W+lettuce.*/,
-                             defaultTestengBranch: 'origin/open-release/ficus.master'
-                             ]
-
-Map privateFicusJobConfig = [ open: false,
-                              jobName: 'ficus-lettuce-pr_private',
-                              subsetJob: 'edx-platform-test-subset_private',
-                              repoName: 'edx-platform-private',
-                              workerLabel: 'ficus-jenkins-worker',
-                              whitelistBranchRegex: /open-release\/ficus.master/,
-                              context: 'jenkins/ficus/lettuce',
-                              triggerPhrase: /.*ficus\W+run\W+lettuce.*/,
-                              defaultTestengBranch: 'origin/open-release/ficus.master'
-                              ]
-
 Map python3JobConfig = [ open : true,
                         jobName : 'edx-platform-python3-lettuce-pr',
                         subsetJob: 'edx-platform-test-subset',
@@ -145,14 +90,9 @@ Map python3JobConfig = [ open : true,
                         toxEnv: 'py35-django111' 
                         ]
 
-List jobConfigs = [ publicJobConfig,
-                    privateJobConfig,
+List jobConfigs = [ privateJobConfig,
                     publicHawthornJobConfig,
                     privateHawthornJobConfig,
-                    publicGinkgoJobConfig,
-                    privateGinkgoJobConfig,
-                    publicFicusJobConfig,
-                    privateFicusJobConfig,
                     python3JobConfig
                     ]
 

--- a/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
@@ -36,22 +36,6 @@ PrintStream out = config['out']
 //     defaultBranch: branch to build
 // ]
 
-Map publicJobConfig = [
-    open: true,
-    jobName: 'edx-platform-python-unittests-master',
-    flowWorkerLabel: 'flow-worker-python',
-    subsetJob: 'edx-platform-test-subset',
-    repoName: 'edx-platform',
-    runCoverage: true,
-    coverageJob: 'edx-platform-unit-coverage',
-    workerLabel: 'jenkins-worker',
-    context: 'jenkins/python',
-    targetBranch: 'origin/master',
-    defaultTestengBranch: 'master',
-    refSpec : '+refs/heads/master:refs/remotes/origin/master',
-    defaultBranch : 'master'
-]
-
 Map privateJobConfig = [
     open: false,
     jobName: 'edx-platform-python-unittests-master_private',
@@ -84,44 +68,9 @@ Map hawthornJobConfig = [
     defaultBranch : 'refs/heads/open-release/hawthorn.master'
 ]
 
-Map ginkgoJobConfig = [
-    open: true,
-    jobName: 'ginkgo-python-unittests-master',
-    flowWorkerLabel: 'flow-worker-python',
-    subsetJob: 'edx-platform-test-subset',
-    repoName: 'edx-platform',
-    runCoverage: true,
-    coverageJob: 'edx-platform-unit-coverage',
-    workerLabel: 'ginkgo-jenkins-worker',
-    context: 'jenkins/ginkgo/python',
-    targetBranch: 'origin/open-release/ginkgo.master',
-    defaultTestengBranch : 'refs/heads/open-release/ginkgo.master',
-    refSpec : '+refs/heads/open-release/ginkgo.master:refs/remotes/origin/open-release/ginkgo.master',
-    defaultBranch : 'refs/heads/open-release/ginkgo.master'
-]
-
-Map ficusJobConfig = [
-    open: true,
-    jobName: 'ficus-python-unittests-master',
-    flowWorkerLabel: 'flow-worker-python',
-    subsetJob: 'edx-platform-test-subset',
-    repoName: 'edx-platform',
-    runCoverage: true,
-    coverageJob: 'edx-platform-unit-coverage',
-    workerLabel: 'ficus-jenkins-worker',
-    context: 'jenkins/ficus/python',
-    targetBranch: 'origin/open-release/ficus.master',
-    defaultTestengBranch : 'refs/heads/open-release/ficus.master',
-    refSpec : '+refs/heads/open-release/ficus.master:refs/remotes/origin/open-release/ficus.master',
-    defaultBranch : 'refs/heads/open-release/ficus.master'
-]
-
 List jobConfigs = [
-    publicJobConfig,
     privateJobConfig,
-    hawthornJobConfig,
-    ginkgoJobConfig,
-    ficusJobConfig
+    hawthornJobConfig
 ]
 
 jobConfigs.each { jobConfig ->

--- a/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsPr.groovy
@@ -50,22 +50,6 @@ catch (any) {
 //                       github. Default behavior: triggered by comments AND pull request updates
 //                       ]
 
-// Individual Job Configurations
-Map publicJobConfig = [ open: true,
-                        jobName: 'edx-platform-python-unittests-pr',
-                        flowWorkerLabel: 'flow-worker-python',
-                        subsetJob: 'edx-platform-test-subset',
-                        repoName: 'edx-platform',
-                        runCoverage: true,
-                        coverageJob: 'edx-platform-unit-coverage',
-                        workerLabel: 'jenkins-worker',
-                        whitelistBranchRegex: /^((?!open-release\/).)*$/,
-                        context: 'jenkins/python',
-                        triggerPhrase: /.*jenkins\W+run\W+python.*/,
-                        targetBranch: 'origin/master',
-                        defaultTestengBranch: 'master'
-                        ]
-
 Map privateJobConfig = [ open: false,
                          jobName: 'edx-platform-python-unittests-pr_private',
                          flowWorkerLabel: 'flow-worker-python',
@@ -111,66 +95,6 @@ Map privateHawthornJobConfig = [ open: false,
                                 defaultTestengBranch: 'origin/open-release/hawthorn.master'
                                 ]
 
-Map publicGinkgoJobConfig = [ open: true,
-                              jobName: 'ginkgo-python-unittests-pr',
-                              flowWorkerLabel: 'flow-worker-python',
-                              subsetJob: 'edx-platform-test-subset',
-                              repoName: 'edx-platform',
-                              runCoverage: true,
-                              coverageJob: 'edx-platform-unit-coverage',
-                              workerLabel: 'ginkgo-jenkins-worker',
-                              whitelistBranchRegex: /open-release\/ginkgo.master/,
-                              context: 'jenkins/ginkgo/python',
-                              triggerPhrase: /.*ginkgo\W+run\W+python.*/,
-                              targetBranch: 'origin/open-release/ginkgo.master',
-                              defaultTestengBranch: 'origin/open-release/ginkgo.master'
-                              ]
-
-Map privateGinkgoJobConfig = [ open: false,
-                               jobName: 'ginkgo-python-unittests-pr_private',
-                               flowWorkerLabel: 'flow-worker-python',
-                               subsetJob: 'edx-platform-test-subset_private',
-                               repoName: 'edx-platform-private',
-                               runCoverage: true,
-                               coverageJob: 'edx-platform-unit-coverage_private',
-                               workerLabel: 'ginkgo-jenkins-worker',
-                               whitelistBranchRegex: /open-release\/ginkgo.master/,
-                               context: 'jenkins/ginkgo/python',
-                               triggerPhrase: /.*ginkgo\W+run\W+python.*/,
-                               targetBranch: 'origin/security/release',
-                               defaultTestengBranch: 'origin/open-release/ginkgo.master'
-                               ]
-
-Map publicFicusJobConfig = [ open: true,
-                             jobName: 'ficus-python-unittests-pr',
-                             flowWorkerLabel: 'flow-worker-python',
-                             subsetJob: 'edx-platform-test-subset',
-                             repoName: 'edx-platform',
-                             runCoverage: true,
-                             coverageJob: 'edx-platform-unit-coverage',
-                             workerLabel: 'ficus-jenkins-worker',
-                             whitelistBranchRegex: /open-release\/ficus.master/,
-                             context: 'jenkins/ficus/python',
-                             triggerPhrase: /.*ficus\W+run\W+python.*/,
-                             targetBranch: 'origin/open-release/ficus.master',
-                             defaultTestengBranch: 'origin/open-release/ficus.master'
-                             ]
-
-Map privateFicusJobConfig = [ open: false,
-                              jobName: 'ficus-python-unittests-pr_private',
-                              flowWorkerLabel: 'flow-worker-python',
-                              subsetJob: 'edx-platform-test-subset_private',
-                              repoName: 'edx-platform-private',
-                              runCoverage: true,
-                              coverageJob: 'edx-platform-unit-coverage_private',
-                              workerLabel: 'ficus-jenkins-worker',
-                              whitelistBranchRegex: /open-release\/ficus.master/,
-                              context: 'jenkins/ficus/python',
-                              triggerPhrase: /.*ficus\W+run\W+python.*/,
-                              targetBranch: 'origin/security-release',
-                              defaultTestengBranch: 'origin/open-release/ficus.master'
-                              ]
-
 Map python3JobConfig = [ open: true,
                          jobName: 'edx-platform-python3-unittests-pr',
                          flowWorkerLabel: 'flow-worker-python',
@@ -188,14 +112,9 @@ Map python3JobConfig = [ open: true,
                          toxEnv: 'py35-django111'
                          ]
 
-List jobConfigs = [ publicJobConfig,
-                    privateJobConfig,
+List jobConfigs = [ privateJobConfig,
                     publicHawthornJobConfig,
                     privateHawthornJobConfig,
-                    publicGinkgoJobConfig,
-                    privateGinkgoJobConfig,
-                    publicFicusJobConfig,
-                    privateFicusJobConfig,
                     python3JobConfig
                     ]
 

--- a/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
@@ -36,8 +36,8 @@ Map publicBokchoyJobConfig = [
 Map publicLettuceJobConfig = [
     jobName: 'edx-platform-lettuce-pipeline-pr',
     context: 'jenkins/lettuce',
-    onlyTriggerPhrase: true,
-    triggerPhrase: /.*jenkins\W+run\W+pipeline\W+lettuce.*/,
+    onlyTriggerPhrase: false,
+    triggerPhrase: /.*jenkins\W+run\W+lettuce.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'lettuce'
 ]
@@ -45,8 +45,8 @@ Map publicLettuceJobConfig = [
 Map publicPythonJobConfig = [
     jobName: 'edx-platform-python-pipeline-pr',
     context: 'jenkins/python',
-    onlyTriggerPhrase: true,
-    triggerPhrase: /.*jenkins\W+run\W+pipeline\W+python.*/,
+    onlyTriggerPhrase: false,
+    triggerPhrase: /.*jenkins\W+run\W+python.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'python'
 ]

--- a/src/test/groovy/platform/pipelines/edxPlatformPipelinesMasterSpec.groovy
+++ b/src/test/groovy/platform/pipelines/edxPlatformPipelinesMasterSpec.groovy
@@ -14,7 +14,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 
-class edxPlatformMasterJobSpec extends Specification {
+class edxPlatformPipelinesMasterJobSpec extends Specification {
 
     @Shared
     @ClassRule
@@ -35,7 +35,7 @@ class edxPlatformMasterJobSpec extends Specification {
         loader = new DslScriptLoader(jm)
 
         when:
-        File dslScriptPath = new File("platform/jobs/${dslFile}")
+        File dslScriptPath = new File("platform/jobs/pipelines/${dslFile}")
         GeneratedItems generatedItems = loader.runScript(dslScriptPath.text)
 
         then:
@@ -44,13 +44,6 @@ class edxPlatformMasterJobSpec extends Specification {
 
         where:
         dslFile                                   | numJobs
-        'edxPlatformAccessibilityMaster.groovy'   | 5
-        'edxPlatformBokChoyMaster.groovy'         | 5
-        'edxPlatformJsMaster.groovy'              | 5
-        'edxPlatformLettuceMaster.groovy'         | 2
-        'edxPlatformPythonUnitTestsMaster.groovy' | 2
-        'edxPlatformQualityMaster.groovy'         | 3
-        'edxPlatformQualityDiff.groovy'           | 2
-        'edxPlatformUnitCoverage.groovy'          | 2
+        'edxPlatformPipelineMaster.groovy'        | 4
     }
 }


### PR DESCRIPTION
This seems like it should cover all the code changes that need to be made; let me know if I've overlooked anything.  I checked with Ned, he can't think of any reasons we need to keep any Ficus or Ginkgo jobs around.  Additional manual steps to take:

* Disable all of the jobs removed in this PR in both build and test Jenkins.
* After a couple of weeks (or when we're ready to remove the Build Flow plugin), remove those jobs.  We should also remove old Django upgrade jobs and such which had already been removed from the DSL.

We shouldn't need to change the required checks setting in GitHub, since the pipeline PR jobs are already configured to use the same context names as the existing jobs.  Other tickets need to land before we can remove the private repo and Hawthorn jobs.

We may not want to pull the trigger on this until after the holidays, but I'd like it to be ready to go whenever we decide to go ahead with it.