### PR TITLE
inject environment name in user retirement archiver job

### DIFF
--- a/devops/resources/user-retirement-archiver.sh
+++ b/devops/resources/user-retirement-archiver.sh
@@ -14,5 +14,5 @@ pip install -r requirements.txt
 
 # Call the script to read the retirement statuses from the LMS, send them to S3, and delete them from the LMS.
 python scripts/retirement_archive_and_cleanup.py \
-    --config_file=$WORKSPACE/user-retirement-secure/$ENVIRONMENT.yml \
+    --config_file=$WORKSPACE/user-retirement-secure/${ENVIRONMENT_DEPLOYMENT}.yml \
     --cool_off_days=$COOL_OFF_DAYS

--- a/src/main/groovy/org/edx/jenkins/dsl/UserRetirementConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/UserRetirementConstants.groovy
@@ -44,6 +44,9 @@ class UserRetirementConstants {
             buildUserVars() /* gives us access to BUILD_USER_ID, among other things */
             buildName('#${BUILD_NUMBER}, ' + extraVars.get('ENVIRONMENT_DEPLOYMENT'))
             timestamps()
+            environmentVariables {
+                env('ENVIRONMENT_DEPLOYMENT', extraVars.get('ENVIRONMENT_DEPLOYMENT'))
+            }
         }
     }
 


### PR DESCRIPTION
This variable was left behind when we pivoted away from the "trigger
job" model which supplied this variable via a string parameter.