### PR TITLE
update rest of platform master jobs to use correct private branch

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -45,8 +45,8 @@ Map privateJobConfig = [
     repoName: 'edx-platform-private',
     workerLabel: 'jenkins-worker',
     context: 'jenkins/a11y',
-    refSpec : '+refs/heads/master:refs/remotes/origin/master',
-    defaultBranch : 'master'
+    refSpec : '+refs/heads/security-release:refs/remotes/origin/security-release',
+    defaultBranch : 'security-release'
 ]
 
 Map hawthornJobConfig = [

--- a/platform/jobs/edxPlatformBokChoyMaster.groovy
+++ b/platform/jobs/edxPlatformBokChoyMaster.groovy
@@ -49,8 +49,8 @@ Map privateJobConfig = [
     workerLabel: 'jenkins-worker',
     context: 'jenkins/bokchoy',
     defaultTestengBranch: 'master',
-    refSpec : '+refs/heads/master:refs/remotes/origin/master',
-    defaultBranch : 'master'
+    refSpec : '+refs/heads/security-release:refs/remotes/origin/security-release',
+    defaultBranch : 'security-release'
 ]
 
 Map publicHawthornJobConfig = [

--- a/platform/jobs/edxPlatformJsMaster.groovy
+++ b/platform/jobs/edxPlatformJsMaster.groovy
@@ -48,8 +48,8 @@ Map privateJobConfig = [
     repoName: 'edx-platform-private',
     workerLabel: 'jenkins-worker',
     context: 'jenkins/js',
-    refSpec : '+refs/heads/master:refs/remotes/origin/master',
-    defaultBranch : 'master'
+    refSpec : '+refs/heads/security-release:refs/remotes/origin/security-release',
+    defaultBranch : 'security-release'
 ]
 
 Map hawthornJobConfig = [

--- a/platform/jobs/edxPlatformLettuceMaster.groovy
+++ b/platform/jobs/edxPlatformLettuceMaster.groovy
@@ -51,8 +51,8 @@ Map privateJobConfig = [
     workerLabel: 'jenkins-worker',
     context: 'jenkins/lettuce',
     defaultTestengBranch : 'master',
-    refSpec : '+refs/heads/master:refs/remotes/origin/master',
-    defaultBranch : 'master'
+    refSpec : '+refs/heads/security-release:refs/remotes/origin/security-release',
+    defaultBranch : 'security-release'
 ]
 
 Map hawthornJobConfig = [

--- a/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
+++ b/platform/jobs/edxPlatformPythonUnitTestsMaster.groovy
@@ -64,8 +64,8 @@ Map privateJobConfig = [
     context: 'jenkins/python',
     targetBranch: 'origin/security-release',
     defaultTestengBranch : 'master',
-    refSpec : '+refs/heads/master:refs/remotes/origin/master',
-    defaultBranch : 'master'
+    refSpec : '+refs/heads/security-release:refs/remotes/origin/security-release',
+    defaultBranch : 'security-release'
 ]
 
 Map hawthornJobConfig = [


### PR DESCRIPTION
It turns out that we were not using the correct branch for the private repo for any of the platform "master" jobs. This should fix that.