### PR TITLE
Fix git checkout for private jobs

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -45,8 +45,8 @@ Map privateJobConfig = [
     repoName: 'edx-platform-private',
     workerLabel: 'jenkins-worker',
     context: 'jenkins/a11y',
-    refSpec : '+refs/heads/master:refs/remotes/origin/master',
-    defaultBranch : 'master'
+    refSpec : '+refs/heads/security-release:refs/remotes/origin/security-release',
+    defaultBranch : 'security-release'
 ]
 
 Map hawthornJobConfig = [

--- a/platform/jobs/edxPlatformJsMaster.groovy
+++ b/platform/jobs/edxPlatformJsMaster.groovy
@@ -48,8 +48,8 @@ Map privateJobConfig = [
     repoName: 'edx-platform-private',
     workerLabel: 'jenkins-worker',
     context: 'jenkins/js',
-    refSpec : '+refs/heads/master:refs/remotes/origin/master',
-    defaultBranch : 'master'
+    refSpec : '+refs/heads/security-release:refs/remotes/origin/security-release',
+    defaultBranch : 'security-release'
 ]
 
 Map hawthornJobConfig = [

--- a/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
@@ -2,6 +2,7 @@ package platform
 
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_CANCEL_BUILDS_ON_UPDATE
 
 Map publicBokchoyJobConfig = [
     open: true,
@@ -126,7 +127,7 @@ jobConfigs.each { jobConfig ->
                         }
                         remote {
                             credentials('jenkins-worker')
-                            github('edx/edx-platform', 'ssh', 'github.com')
+                            github("edx/${jobConfig.repoName}", 'ssh', 'github.com')
                             refspec("+refs/heads/${jobConfig.branch}:refs/remotes/origin/${jobConfig.branch}")
                             branch(jobConfig.branch)
                         }

--- a/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
@@ -3,6 +3,7 @@ package platform
 import org.yaml.snakeyaml.Yaml
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_CANCEL_BUILDS_ON_UPDATE
 
 /* stdout logger */
 Map config = [:]
@@ -135,6 +136,9 @@ jobConfigs.each { jobConfig ->
             if (!jobConfig.open.toBoolean()) {
                 authorization GENERAL_PRIVATE_JOB_SECURITY()
             }
+            properties {
+                githubProjectUrl("https://github.com/edx/${jobConfig.repoName}/")
+            }
             logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
             environmentVariables(
                 REPO_NAME: "${jobConfig.repoName}"
@@ -156,6 +160,8 @@ jobConfigs.each { jobConfig ->
                 }
             }
 
+            configure GHPRB_CANCEL_BUILDS_ON_UPDATE(false)
+
             cpsScm {
                 scm {
                     git {
@@ -175,7 +181,7 @@ jobConfigs.each { jobConfig ->
                         }
                         remote {
                             credentials('jenkins-worker')
-                            github('edx/edx-platform', 'ssh', 'github.com')
+                            github("edx/${jobConfig.repoName}", 'ssh', 'github.com')
                             refspec('+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*')
                             branch('\${sha1}')
                         }

--- a/platform/views/platformViews.groovy
+++ b/platform/views/platformViews.groovy
@@ -56,3 +56,12 @@ listView("edx-platform-pipeline-pr-tests") {
     }
     columns DEFAULT_VIEW.call()
 }
+
+listView("edx-platform-private-tests") {
+    description('Jobs for running tests on edx-platform-private')
+
+    jobs {
+        regex(".*_private")
+    }
+    columns DEFAULT_VIEW.call()
+}


### PR DESCRIPTION
Some small fixes. Makes sure the git checkout is correct for private pipelines, changes the branch for js/a11y private merge jobs, adds a private view for jobs.