### PR TITLE
add pr number to build description of notifier job

### DIFF
--- a/testeng/jobs/edxPlatformTestNotifierJob.groovy
+++ b/testeng/jobs/edxPlatformTestNotifierJob.groovy
@@ -35,6 +35,7 @@ job('edx-platform-test-notifier') {
         credentialsBinding {
             string('GITHUB_TOKEN', 'GITHUB_STATUS_OAUTH_TOKEN')
         }
+        buildName('#${BUILD_NUMBER} Platform PR: ${ENV,var="PR_NUMBER"}')
     }
 
     steps {


### PR DESCRIPTION
While debugging a hanging build, I wanted to see which instance of the notifier job it had triggered, but this was tedious. This PR should make it a little easier to find the notifier build that corresponds to a given build