### PR TITLE
Add clean before checkout to pipeline PR jobs

### DIFF
--- a/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
@@ -232,6 +232,7 @@ jobConfigs.each { jobConfig ->
                 scm {
                     git {
                         extensions {
+                            cleanBeforeCheckout()
                             cloneOptions {
                                 honorRefspec(true)
                                 noTags(true)


### PR DESCRIPTION
We saw a lot of bokchoy issues today, with cryptic errors such as `stderr: error: Entry 'common/djangoapps/terrain/stubs/data/ora_graded_rubric.xml' not uptodate. Cannot update sparse checkout.` As well as errors with testing files that were likely persisting from previous builds on the worker. This cleanup should be a harmless addition, and we will monitor if it helps reduce any of these problems.