### PR TITLE
block prs if they do not have Jenkinsfiles via ancestry

### DIFF
--- a/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
@@ -232,6 +232,12 @@ jobConfigs.each { jobConfig ->
                 scm {
                     git {
                         extensions {
+                            // Only build pull requests that contain the
+                            // following hash in their ancestry. The hash
+                            // is from the creation of `scripts/Jenkinsfiles`
+                            choosingStrategy {
+                                ancestry(365, '84d780e68197b0ec7a27b4807527e01dbfd62b43')
+                            }
                             cleanBeforeCheckout()
                             cloneOptions {
                                 honorRefspec(true)

--- a/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
@@ -236,7 +236,7 @@ jobConfigs.each { jobConfig ->
                             // following hash in their ancestry. The hash
                             // is from the creation of `scripts/Jenkinsfiles`
                             choosingStrategy {
-                                ancestry(365, '84d780e68197b0ec7a27b4807527e01dbfd62b43')
+                                ancestry(365, '5c88962d24540136676318271e55275f073d22c0')
                             }
                             cleanBeforeCheckout()
                             cloneOptions {


### PR DESCRIPTION
This morning all of our pipeline-based pull request jobs for the edx-platform were failing with the following message:
```
ERROR: Error fetching remote repo 'origin'
hudson.plugins.git.GitException: Failed to fetch from git@github.com:edx/edx-platform.git
	at hudson.plugins.git.GitSCM.fetchFrom(GitSCM.java:888)
	at hudson.plugins.git.GitSCM.retrieveChanges(GitSCM.java:1155)
	at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1186)
	at org.jenkinsci.plugins.workflow.steps.scm.SCMStep.checkout(SCMStep.java:109)
	at org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition.create(CpsScmFlowDefinition.java:143)
	at org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition.create(CpsScmFlowDefinition.java:67)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:234)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
Caused by: hudson.plugins.git.GitException: Command "git reset --hard" returned status code 128:
stdout: 
stderr: error: Sparse checkout leaves no entry on working directory
fatal: Could not reset index file to revision 'HEAD'.

	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:1990)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:1958)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:1954)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommand(CliGitAPIImpl.java:1592)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.reset(CliGitAPIImpl.java:458)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.clean(CliGitAPIImpl.java:781)
	at hudson.plugins.git.GitAPI.clean(GitAPI.java:311)
	at hudson.plugins.git.extensions.impl.CleanBeforeCheckout.decorateFetchCommand(CleanBeforeCheckout.java:30)
	at hudson.plugins.git.GitSCM.fetchFrom(GitSCM.java:884)
	... 8 more
ERROR: Error fetching remote repo 'origin'
```

I dug through the build history until the first failure in this series. The first failure actually contained a different error message. It was run from the [edx-solutions](https://github.com/edx-solutions/edx-platform) fork, which states that it is `This branch is 4317 commits ahead, 6774 commits behind edx:master.`, and subsequently does not include our Jenkinsfiles. It seems that trying to do a sparse checkout of a file that does not exist in a repo corrupts the state of how Jenkins stores git checkouts.

I was able to fix this, by removing the setting to 'clean before checkout' on our pipeline jobs, but I believe this to be unrelated. I think that by doing that, I was really just getting Jenkins to refresh its state and reread the job xml.

I was able to reproduce this error by creating a pull request from the fork in question into the edx-platform (https://github.com/edx/edx-platform/pull/19756) . The build failed with the expected:
```
ERROR: /var/lib/jenkins/workspace/edx-platform-bokchoy-pipeline-pr@script/scripts/Jenkinsfiles/bokchoy not found
Finished: FAILURE
```
Then, a normal, non-fork-based pull request (https://github.com/edx/edx-platform/pull/19713) run afterwards failed with sparse checkout error.

I think we can protect against this type of error by blocking pull requests that do not contain Jenkinsfiles. From the DSL docs:
```
choosingStrategy {
    // Selects branches in priority order based on which branch exists.
    alternative()
    // Selects commits to be build by maximum age and ancestor commit.
    ancestry(int maxAge, String commit)
    // This strategy must be selected when using the Gerrit Trigger Plugin.
    gerritTrigger()
    // Build all branches except for those which match the branch specifiers.
    inverse()
}
```

The oldest commit that contains all of the Jenkinsfiles we care about is https://github.com/edx/edx-platform/commit/5c88962d24540136676318271e55275f073d22c0#diff-d6c5855a62cf32a4dadbc2831f0f295f. 