### PR TITLE
change sparse checkout path in pipeline jobs

### DIFF
--- a/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
@@ -238,10 +238,16 @@ jobConfigs.each { jobConfig ->
                                 noTags(true)
                                 shallow(true)
                             }
+                            // To speed up builds, do a sparse checkout of just
+                            // the files needed to run the pipeline. However, in
+                            // case old branches/forks trigger this job, check
+                            // out the 'scripts' directory to avoid the case
+                            // where Jenkins tries to do a sparse check out of
+                            // non-existent files (and corrupts the git state)
                             sparseCheckoutPaths {
                                 sparseCheckoutPaths {
                                     sparseCheckoutPath {
-                                        path(jobConfig.jenkinsFileDir)
+                                        path('scripts')
                                     }
                                 }
                             }


### PR DESCRIPTION
It seems my attempt to block PRs by commit ancestry does not work with shallow clones, because they do not have git history. Rather than try to hack it any further, I vote we just sparse checkout 'scripts' directory, which is many years old, and just fail jobs that try to run non-existent Jenkinsfiles.