### PR TITLE
Use mysql rename for video-timeline and enrollments.

### DIFF
--- a/dataeng/resources/enrollment.sh
+++ b/dataeng/resources/enrollment.sh
@@ -11,5 +11,6 @@ ${WORKSPACE}/analytics-configuration/automation/run-automated-task.sh \
   --interval $(date +%Y-%m-%d -d "$FROM_DATE")-$(date +%Y-%m-%d -d "$TO_DATE") \
   --n-reduce-tasks $NUM_REDUCE_TASKS \
   --overwrite-mysql \
+  --EnrollmentByGenderMysqlTask-use-temp-table-for-overwrite \
   $EXTRA_ARGS
 

--- a/dataeng/resources/video-timeline.sh
+++ b/dataeng/resources/video-timeline.sh
@@ -8,4 +8,5 @@ ${WORKSPACE}/analytics-configuration/automation/run-automated-task.sh \
   InsertToMysqlAllVideoTask --local-scheduler \
   --interval $(date +%Y-%m-%d -d "$FROM_DATE")-$(date +%Y-%m-%d -d "$TO_DATE") \
   --n-reduce-tasks $NUM_REDUCE_TASKS \
+  --InsertToMysqlVideoTimelineTask-use-temp-table-for-overwrite \
   $EXTRA_ARGS


### PR DESCRIPTION
This will bring down the runtime of both workflows by 6-7 hours. 