### PR TITLE
disable lettuce jobs

### DIFF
--- a/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
@@ -158,6 +158,10 @@ jobConfigs.each { jobConfig ->
                 GITHUB_CONTEXT: "${jobConfig.context}"
             )
 
+            if (jobConfig.context == 'jenkins/lettuce') {
+                disabled()
+            }
+
             triggers {
                 githubPush()
             }

--- a/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
@@ -314,7 +314,7 @@ jobConfigs.each { jobConfig ->
                 TOX_ENV: "${jobConfig.toxEnv}"
             )
 
-            if (jobConfig.context == 'jenkins/lettuce' || jobConfig == 'jenkins/py35-django111.5/lettuce') {
+            if (jobConfig.context == 'jenkins/lettuce' || jobConfig.context == 'jenkins/py35-django111.5/lettuce') {
                 disabled()
             }
 

--- a/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
@@ -314,7 +314,7 @@ jobConfigs.each { jobConfig ->
                 TOX_ENV: "${jobConfig.toxEnv}"
             )
 
-            if (jobConfig.context == 'jenkins/lettuce' or jobConfig == 'jenkins/py35-django111.5/lettuce') {
+            if (jobConfig.context == 'jenkins/lettuce' || jobConfig == 'jenkins/py35-django111.5/lettuce') {
                 disabled()
             }
 

--- a/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
@@ -314,6 +314,10 @@ jobConfigs.each { jobConfig ->
                 TOX_ENV: "${jobConfig.toxEnv}"
             )
 
+            if (jobConfig.context == 'jenkins/lettuce' or jobConfig == 'jenkins/py35-django111.5/lettuce') {
+                disabled()
+            }
+
             triggers {
                 githubPullRequest {
                     admins(ghprbMap['admin'])


### PR DESCRIPTION
All of the lettuce tests have now been converted to bokchoy. This will just disable the PR/Master jobs from running automatically (we will also need to change the settings for the expected contexts in the platform repo itself). Once this is done, we can begin work on removing the lettuce infrastructure from our code