### PR TITLE
Configure botuser in jobs with slack integration

### DIFF
--- a/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
@@ -64,6 +64,7 @@ class JenkinsPublicConstants {
         it /
             publishers /
             'jenkins.plugins.slack.SlackNotifier' {
+                botUser true
                 startNotification false
                 notifySuccess false
                 notifyAborted true

--- a/testeng/jobs/toggleSpigot.groovy
+++ b/testeng/jobs/toggleSpigot.groovy
@@ -108,6 +108,7 @@ secretMap.each { jobConfigs ->
             mailer(jobConfig['email'])
             configure {
                 it / publishers / 'jenkins.plugins.slack.SlackNotifier' {
+                    botUser true
                     startNotification false
                     notifySuccess true
                     notifyAborted false


### PR DESCRIPTION
Without this I was seeing jobs failing to reach slack with this very helpful error message:

`[Slack Notifications] Exception attempting Slack notification: null`