### PR TITLE
Include common_publishers after custom post-build.

### DIFF
--- a/dataeng/jobs/analytics/EventExportIncremental.groovy
+++ b/dataeng/jobs/analytics/EventExportIncremental.groovy
@@ -30,12 +30,12 @@ class EventExportIncremental {
 
                 triggers common_triggers(allVars, env_config)
                 wrappers common_wrappers(allVars)
-                publishers common_publishers(allVars)
                 publishers {
                     postBuildTask {
                         task('org with Errors=', 'exit 1', true)
                     }
                 }
+                publishers common_publishers(allVars)
                 steps {
                     shell(dslFactory.readFileFromWorkspace('dataeng/resources/event-export-incremental.sh'))
                     if (env_config.get('SNITCH')) {

--- a/dataeng/jobs/analytics/VerticaDiskUsageMonitor.groovy
+++ b/dataeng/jobs/analytics/VerticaDiskUsageMonitor.groovy
@@ -27,12 +27,12 @@ class VerticaDiskUsageMonitor {
             wrappers {
                 timestamps()
             }
-            publishers common_publishers(allVars)
             publishers {
                 postBuildTask {
                     task('Error we are approaching our license usage capacity', 'exit 1', true, true)
                 }
             }
+            publishers common_publishers(allVars)
             steps {
                 virtualenv {
                     nature("shell")


### PR DESCRIPTION
That way, if there is an error identified by the post-build step, it
will trigger a notification.