### PR TITLE
add general ghprb pipeline file starting with codejail

### DIFF
--- a/testingPipelines/jobs/generalPRPipeline.groovy
+++ b/testingPipelines/jobs/generalPRPipeline.groovy
@@ -1,0 +1,103 @@
+import org.yaml.snakeyaml.Yaml
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_CANCEL_BUILDS_ON_UPDATE
+
+/* stdout logger */
+Map config = [:]
+Binding bindings = getBinding()
+config.putAll(bindings.getVariables())
+PrintStream out = config['out']
+
+/* Map to hold the k:v pairs parsed from the secret file */
+Map ghprbMap = [:]
+try {
+    out.println('Parsing secret YAML file')
+    String ghprbConfigContents = new File("${GHPRB_SECRET}").text
+    Yaml yaml = new Yaml()
+    ghprbMap = yaml.load(ghprbConfigContents)
+    out.println('Successfully parsed secret YAML file')
+}
+catch (any) {
+    out.println('Jenkins DSL: Error parsing secret YAML file')
+    out.println('Exiting with error code 1')
+    return 1
+}
+
+Map codejailJobConfig = [
+    open: true,
+    jobName: 'codejail-pr',
+    repoName: 'codejail',
+    context: 'jenkins',
+    onlyTriggerPhrase: false,
+    triggerPhrase: /.*jenkins\W+run.*/,
+    jenkinsFileDir: '.',
+    jenkinsFileName: 'Jenkinsfile'
+]
+
+
+List jobConfigs = [
+    codejailJobConfig
+]
+
+/* Iterate over the job configurations */
+jobConfigs.each { jobConfig ->
+
+    // This is the job DSL responsible for creating the main pipeline job.
+    pipelineJob(jobConfig.jobName) {
+
+        definition {
+
+            if (!jobConfig.open.toBoolean()) {
+                authorization GENERAL_PRIVATE_JOB_SECURITY()
+            }
+            properties {
+                githubProjectUrl("https://github.com/edx/${jobConfig.repoName}/")
+            }
+            logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
+            label('codejail-worker')
+
+            triggers {
+                githubPullRequest {
+                    admins(ghprbMap['admin'])
+                    useGitHubHooks()
+                    triggerPhrase(jobConfig.triggerPhrase)
+                    onlyTriggerPhrase(jobConfig.onlyTriggerPhrase)
+                    userWhitelist(ghprbMap['userWhiteList'])
+                    orgWhitelist(ghprbMap['orgWhiteList'])
+                    whiteListTargetBranches([jobConfig.whitelistBranchRegex])
+                    extensions {
+                        commitStatus {
+                            context(jobConfig.context)
+                        }
+                    }
+                }
+            }
+
+            configure GHPRB_CANCEL_BUILDS_ON_UPDATE(false)
+
+            cpsScm {
+                scm {
+                    git {
+                        extensions {
+                            cleanBeforeCheckout()
+                            cloneOptions {
+                                honorRefspec(true)
+                                noTags(true)
+                                shallow(true)
+                            }
+                        }
+                        remote {
+                            credentials('jenkins-worker')
+                            github("edx/${jobConfig.repoName}", 'ssh', 'github.com')
+                            refspec('+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*')
+                            branch('\${sha1}')
+                        }
+                    }
+                }
+                scriptPath(jobConfig.jenkinsFileDir + '/' + jobConfig.jenkinsFileName)
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
This creates a simple job dsl definition for  a generic GHPRB triggered pipeline. Much of the script is boilerplate, which should allow us to simplify setting up CI for new repos by just adding entries into the `jobConfigs` list.

For the first job, I am adding `codejail` as part of the work to put that repo under CI.