### PR TITLE
Fix slack notifications

### DIFF
--- a/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
@@ -74,6 +74,10 @@ class JenkinsPublicConstants {
                 notifyFailure true
                 notifyBackToNormal true
                 notifyRepeatedFailure true
+                includeTestSummary false
+                includeFailedTests false
+                matrixTriggerMode ONLY_CONFIGURATIONS
+                commitInfoChoice NONE
             }
     }
   }

--- a/testeng/jobs/toggleSpigot.groovy
+++ b/testeng/jobs/toggleSpigot.groovy
@@ -118,9 +118,13 @@ secretMap.each { jobConfigs ->
                     notifyFailure false
                     notifyBackToNormal false
                     notifyRepeatedFailure false
+                    includeTestSummary false
+                    includeFailedTests false
                     includeCustomMessage true
                     customMessage '@here The Spigot is now: $SPIGOT_STATE ($SPIGOT_MESSAGE)'
                     room 'TestEngineering'
+                    matrixTriggerMode ONLY_CONFIGURATIONS
+                    commitInfoChoice NONE
                 }
             }
         }


### PR DESCRIPTION
I was missing some fields in the configure block. It still seeded, but slack threw an error during job execution. When debugging normally, lots of different changes were working... because it turns out just opening the UI and saving the job fixed the underlying XML issues. This should allow the jobs to report to slack immediately once we seed them.