### PR TITLE
Seed job for devstack snapshot installers

### DIFF
--- a/openedx/jobs/devstackSnapshot.groovy
+++ b/openedx/jobs/devstackSnapshot.groovy
@@ -1,0 +1,36 @@
+package openedx
+
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
+
+// This is the job DSL responsible for creating the main pipeline job for
+// building devstack snapshots for offline installation during conferences, etc.
+pipelineJob('devstack-snapshot') {
+
+    definition {
+
+        parameters {
+            stringParam('BRANCH', 'master',
+                        'The branch of the devstack repository which should be used to build the snapshot')
+        }
+
+        logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
+
+        cpsScm {
+            scm {
+                git {
+                    branch('${BRANCH}')
+                    remote {
+                        credentials('jenkins-worker')
+                        extensions {
+                            relativeTargetDirectory('devstack')
+                        }
+                        github('edx/devstack', 'ssh', 'github.com')
+                        refspec('+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}')
+                    }
+                }
+            }
+            scriptPath('devstack/scripts/Jenkinsfiles/snapshot')
+        }
+
+    }
+}


### PR DESCRIPTION
Seed job to be able to build an offline devstack installer on demand.  Takes the devstack repo branch as a parameter to enable iteration on changes in devstack PRs; doesn't really support installers for named Open edX releases, but we haven't had demand for that yet either.