### PR TITLE
[OPS-2889] Updating Image Builder job to be run weekly.

### DIFF
--- a/devops/jobs/ImageBuilder.groovy
+++ b/devops/jobs/ImageBuilder.groovy
@@ -119,6 +119,10 @@ class ImageBuilder {
                     }
                 }
 
+                triggers {
+                    cron("H H * * H")
+                }
+
                 steps {
                     // run the build-push-app shell script in a virtual environment called venv
                     virtualenv {


### PR DESCRIPTION
https://openedx.atlassian.net/browse/OPS-2889

Scheduled all image builder jobs to run once a week & tested the job DSL locally via https://github.com/edx/jenkins-job-dsl/blob/master/README-Hacking.md

References: https://stackoverflow.com/questions/12472645/how-do-i-schedule-jobs-in-jenkins/12472740#12472740

https://crontab.guru/#1_1_*_*_MON