### PR TITLE
Add more repos to `make upgrade` automation.

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -49,12 +49,28 @@ Map djangoConfigModels = [
     githubTeamReviewers: 'testeng'
 ]
 
+Map edxOrganizations = [
+    org: 'edx',
+    repoName: 'edx-organizations',
+    cronValue: '@weekly',
+    githubUserReviewers: 'feanil',
+    githubTeamReviewers: 'testeng'
+]
+
 Map edxPlatform = [
     org: 'edx',
     repoName: 'edx-platform',
     cronValue: '@daily',
     githubUserReviewers: '',
     githubTeamReviewers: 'testeng'
+]
+
+Map edxProctoring = [
+    org: 'edx',
+    repoName: 'edx-proctoring',
+    cronValue: '@weekly',
+    githubUserReviewers: 'feanil',
+    githubTeamReviewers: 'testeng,Masters-dahlia'
 ]
 
 Map testengCI = [
@@ -71,7 +87,9 @@ List jobConfigs = [
     cookiecutterDjangoApp,
     devstack,
     djangoConfigModels,
+    edxOrganizations,
     edxPlatform,
+    edxProctoring,
     testengCI,
 ]
 


### PR DESCRIPTION
Add two more repos to the make upgrade automation.

@davestgermain I added you to the list for edx-proctoring since you seem to be a recent contributor to this and probably have more context than me.  Let me know if it makes more sense to have a github team associated with this and what that should be.