### PR TITLE
Add USER_ROLES for per-job authorization.

### DIFF
--- a/dataeng/jobs/analytics/SqlScripts.groovy
+++ b/dataeng/jobs/analytics/SqlScripts.groovy
@@ -37,6 +37,13 @@ class SqlScripts {
 
     public static def single_script_job = { dslFactory, allVars ->
         dslFactory.job("single-sql-script") {
+            authorization {
+                allVars.get('USER_ROLES').each { github_id, roles ->
+                    roles.each {
+                        role -> permission(role, github_id)
+                    }
+                }
+            }
             logRotator common_log_rotator(allVars)
             parameters SqlScripts.sql_script_params(allVars)
             parameters {


### PR DESCRIPTION
Permit data-science and other users to run single SQL scripts.