### PR TITLE
Add repo argument to notifier

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -219,7 +219,7 @@ jobConfigs.each { jobConfig ->
            }
            archiveJunit(JENKINS_PUBLIC_JUNIT_REPORTS)
            if (jobConfig.repoName == "edx-platform") {
-               downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER.call(${jobConfig.repoName}, ${ghprbPullId})
+               downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER.call("${jobConfig.repoName}", "${ghprbPullId}")
            }
        }
     }

--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -219,7 +219,7 @@ jobConfigs.each { jobConfig ->
            }
            archiveJunit(JENKINS_PUBLIC_JUNIT_REPORTS)
            if (jobConfig.repoName == "edx-platform") {
-               downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER.call("${jobConfig.repoName}", "${ghprbPullId}")
+               downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER.call("${jobConfig.repoName}", '${ghprbPullId}')
            }
        }
     }

--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -219,7 +219,7 @@ jobConfigs.each { jobConfig ->
            }
            archiveJunit(JENKINS_PUBLIC_JUNIT_REPORTS)
            if (jobConfig.repoName == "edx-platform") {
-               downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER.call('${ghprbPullId}')
+               downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER.call(${jobConfig.repoName}, ${ghprbPullId})
            }
        }
     }

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -229,7 +229,7 @@ jobConfigs.each { jobConfig ->
             }
             archiveJunit(JENKINS_PUBLIC_JUNIT_REPORTS)
             if (jobConfig.repoName == "edx-platform") {
-                downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER.call("${jobConfig.repoName}", "${ghprbPullId}")
+                downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER.call("${jobConfig.repoName}", '${ghprbPullId}')
             }
         }
     }

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -229,7 +229,7 @@ jobConfigs.each { jobConfig ->
             }
             archiveJunit(JENKINS_PUBLIC_JUNIT_REPORTS)
             if (jobConfig.repoName == "edx-platform") {
-                downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER.call(${jobConfig.repoName}, ${ghprbPullId})
+                downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER.call("${jobConfig.repoName}", "${ghprbPullId}")
             }
         }
     }

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -229,7 +229,7 @@ jobConfigs.each { jobConfig ->
             }
             archiveJunit(JENKINS_PUBLIC_JUNIT_REPORTS)
             if (jobConfig.repoName == "edx-platform") {
-                downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER.call('${ghprbPullId}')
+                downstreamParameterized JENKINS_EDX_PLATFORM_TEST_NOTIFIER.call(${jobConfig.repoName}, ${ghprbPullId})
             }
         }
     }

--- a/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/JenkinsPublicConstants.groovy
@@ -98,11 +98,12 @@ class JenkinsPublicConstants {
                                                               'javascript_xunit*.xml,edx-platform*/reports/a11y/**/xunit.xml,' +
                                                               '**/reports/bok_choy/**/xunit.xml'
 
-    public static final Closure JENKINS_EDX_PLATFORM_TEST_NOTIFIER = { prNumber ->
+    public static final Closure JENKINS_EDX_PLATFORM_TEST_NOTIFIER = { repo, prNumber ->
         return {
             trigger('edx-platform-test-notifier') {
                 condition('ALWAYS')
                 parameters {
+                    predefinedProp('REPO', repo)
                     predefinedProp('PR_NUMBER', prNumber)
                 }
             }

--- a/testeng/jobs/edxPlatformTestNotifierJob.groovy
+++ b/testeng/jobs/edxPlatformTestNotifierJob.groovy
@@ -12,8 +12,10 @@ job('edx-platform-test-notifier') {
     authorization GENERAL_PRIVATE_JOB_SECURITY()
 
     parameters {
+        stringParam('REPO', "edx-platform",
+                    'Github repository of PR')
         stringParam('PR_NUMBER', null,
-                    'edx-platform PR number to comment')
+                    'PR number')
     }
 
     logRotator JENKINS_PUBLIC_LOG_ROTATOR()

--- a/testeng/resources/edx-platform-test-notifier.sh
+++ b/testeng/resources/edx-platform-test-notifier.sh
@@ -8,4 +8,4 @@ echo "Installing python requirements..."
 pip install -q -r requirements/base.txt
 
 echo "Running test notifier script..."
-python jenkins/edx_platform_test_notifier.py --pr_number $PR_NUMBER
+python jenkins/edx_platform_test_notifier.py --repo $REPO --pr_number $PR_NUMBER


### PR DESCRIPTION
The notifier now takes in the repo as an argument as well. Setting the default repo name will preserve functionality on PRs that haven't rebased for the new changes.