### PR TITLE
run retirement jobs on retirement worker

### DIFF
--- a/platform/jobs/RetirementJobEdxTriggers.groovy
+++ b/platform/jobs/RetirementJobEdxTriggers.groovy
@@ -89,10 +89,8 @@ jobConfigs.each { jobConfig ->
             //permission('hudson.model.Item.Discover', 'edx/customer-support')
         }
 
-        // jenkins-worker is way overkill for this job, but it'll do for now.
-        // TODO: either create a new lightweight worker label, or wait until we
-        // convert this job to use Pipelines.
-        label('jenkins-worker')
+        // retirement-workers are configured to only execute one build at a time
+        label('retirement-worker')
 
         // Disallow this job to have simultaneous instances building at the same
         // time.  This might help prevent race conditions related to triggering

--- a/platform/jobs/RetirementJobs.groovy
+++ b/platform/jobs/RetirementJobs.groovy
@@ -79,11 +79,8 @@ job('user-retirement-driver') {
         //permission('hudson.model.Item.Discover', 'edx/customer-support')
     }
 
-    // The jenkins-worker is intended for platform workers, but they'll work
-    // well for this job, at least for now.  Specifically, this label is
-    // configured to disallow more than one simultaneous job per instance, and
-    // generally there are always available jenkins-worker instances idling.
-    label('jenkins-worker')
+    // retirement-workers are configured to only execute one build at a time
+    label('retirement-worker')
 
     // Allow this job to have simultaneous instances running at the same time
     // in general, but use the throttle-concurrents plugin to limit only one
@@ -215,11 +212,8 @@ job('user-retirement-collector') {
         //permission('hudson.model.Item.Discover', 'edx/customer-support')
     }
 
-    // The jenkins-worker is intended for platform workers, but they'll work
-    // well for this job, at least for now.  Specifically, this label is
-    // configured to disallow more than one simultaneous job per instance, and
-    // generally there are always available jenkins-worker instances idling.
-    label('jenkins-worker')
+    // retirement-workers are configured to only execute one build at a time
+    label('retirement-worker')
 
     // Allow this job to have simultaneous builds at the same time in general,
     // but use the throttle-concurrents plugin to limit only one instance of
@@ -389,10 +383,8 @@ job('retirement-partner-reporter') {
         }
     }
 
-    // This label is configured to disallow more than one simultaneous job
-    // per instance, and generally there are always available jenkins-worker
-    // instances idling.
-    label('jenkins-worker')
+    // retirement-workers are configured to only execute one build at a time
+    label('retirement-worker')
 
     // Only one of these jobs should be running at a time per environment
     concurrentBuild(true)
@@ -527,10 +519,8 @@ job('retirement-partner-report-cleanup') {
         }
     }
 
-    // This label is configured to disallow more than one simultaneous job
-    // per instance, and generally there are always available jenkins-worker
-    // instances idling.
-    label('jenkins-worker')
+    // retirement-workers are configured to only execute one build at a time
+    label('retirement-worker')
 
     // Only one of these jobs should be running at a time per environment
     concurrentBuild(true)
@@ -663,11 +653,8 @@ job('user-retirement-bulk-status') {
         }
     }
 
-    // The jenkins-worker is intended for platform workers, but they'll work
-    // well for this job, at least for now.  Specifically, this label is
-    // configured to disallow more than one simultaneous job per instance, and
-    // generally there are always available jenkins-worker instances idling.
-    label('jenkins-worker')
+    // retirement-workers are configured to only execute one build at a time
+    label('retirement-worker')
 
     // Only one of these should run at a time.
     concurrentBuild(false)


### PR DESCRIPTION
Move all of the retirement jobs onto `retirement-workers`, t3.micro boxes that only allow 1 build at a time