### PR TITLE
run js tests on js workers

### DIFF
--- a/platform/jobs/edxPlatformJsMaster.groovy
+++ b/platform/jobs/edxPlatformJsMaster.groovy
@@ -36,7 +36,7 @@ Map publicJobConfig = [
     open: true,
     jobName: 'edx-platform-js-master',
     repoName: 'edx-platform',
-    workerLabel: 'jenkins-worker',
+    workerLabel: 'js-worker',
     context: 'jenkins/js',
     refSpec : '+refs/heads/master:refs/remotes/origin/master',
     defaultBranch : 'master'
@@ -46,7 +46,7 @@ Map privateJobConfig = [
     open: false,
     jobName: 'edx-platform-js-master_private',
     repoName: 'edx-platform-private',
-    workerLabel: 'jenkins-worker',
+    workerLabel: 'js-worker',
     context: 'jenkins/js',
     refSpec : '+refs/heads/security-release:refs/remotes/origin/security-release',
     defaultBranch : 'security-release'

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -53,7 +53,7 @@ Map publicJobConfig = [
     open : true,
     jobName : 'edx-platform-js-pr',
     repoName: 'edx-platform',
-    workerLabel: 'jenkins-worker',
+    workerLabel: 'js-worker',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/js',
     triggerPhrase: /.*jenkins\W+run\W+js.*/
@@ -63,7 +63,7 @@ Map privateJobConfig = [
     open: false,
     jobName: 'edx-platform-js-pr_private',
     repoName: 'edx-platform-private',
-    workerLabel: 'jenkins-worker',
+    workerLabel: 'js-worker',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/js',
     triggerPhrase: /.*jenkins\W+run\W+js.*/
@@ -73,7 +73,7 @@ Map python3JobConfig = [
     open : true,
     jobName : 'edx-platform-python3-js-pr',
     repoName: 'edx-platform',
-    workerLabel: 'jenkins-worker',
+    workerLabel: 'js-worker',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/python3.5/js',
     triggerPhrase: /.*jenkins\W+run\W+py35-django111\W+js.*/,


### PR DESCRIPTION
temporarily run js jobs on js-workers (c5d.xlarge). I did not include ironwood jobs in this, as it would be a more complex move, and there is little traffic there.