### PR TITLE
create stub job to run code annotation report generator jenkinsfile

### DIFF
--- a/testeng/jobs/featureToggleReportJobs.groovy
+++ b/testeng/jobs/featureToggleReportJobs.groovy
@@ -1,0 +1,40 @@
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
+
+pipelineJob('code-annotation-report-generator') {
+
+    definition {
+
+        authorization GENERAL_PRIVATE_JOB_SECURITY()
+        parameters {
+            stringParam(
+                'BRANCH', 'master',
+                'the branch of edx-toggles to check out'
+            )
+            stringParam(
+                'ANNOTATION_REPORT_BUCKET', '',
+                'name of s3 bucket to write annotation reports to'
+            )
+        }
+
+        logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
+
+        cpsScm {
+            scm {
+                git {
+                    branch('${BRANCH}')
+                    remote {
+                        credentials('jenkins-worker')
+                        extensions {
+                            relativeTargetDirectory('edx-toggles')
+                        }
+                        github('edx/edx-toggles', 'ssh', 'github.com')
+                        refspec('+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}')
+                    }
+                }
+            }
+            scriptPath('edx-toggles/Jenkinsfiles/code-annotation-report-generator')
+        }
+
+    }
+}


### PR DESCRIPTION
Create the stub wrapper for https://github.com/edx/edx-toggles/pull/7

Currently, it consumes a branch and bucket name while I am testing, but I plan on setting those as environment variables as I continue.