### PR TITLE
Set downstream's job RUN_DATE parameter.

### DIFF
--- a/dataeng/jobs/analytics/LoadVerticaSchemaToSnowflake.groovy
+++ b/dataeng/jobs/analytics/LoadVerticaSchemaToSnowflake.groovy
@@ -13,7 +13,7 @@ class LoadVerticaSchemaToSnowflake {
                 logRotator common_log_rotator(allVars, schema_config)
                 parameters common_parameters(allVars, schema_config)
                 parameters {
-                    stringParam('RUN_DATE', schema_config.get('RUN_DATE', allVars.get('RUN_DATE')), 'Leave empty to use the current date.  Set value by: --date 2018-04-24')
+                    stringParam('RUN_DATE', schema_config.get('RUN_DATE', allVars.get('RUN_DATE', 'today')), 'Run date for the job. A string that can be parsed by the GNU coreutils "date" utility.')
                     stringParam('OVERWRITE', schema_config.get('OVERWRITE', allVars.get('OVERWRITE')), 'Set to: --overwrite if you want to enable overwrite.')
                     stringParam('SNOWFLAKE_CREDENTIALS', schema_config.get('SNOWFLAKE_CREDENTIALS', allVars.get('SNOWFLAKE_CREDENTIALS')), 'The path to the Snowflake credentials file.')
                     stringParam('WAREHOUSE', schema_config.get('WAREHOUSE', allVars.get('WAREHOUSE')), '')

--- a/dataeng/resources/load-vertica-schema-to-snowflake.sh
+++ b/dataeng/resources/load-vertica-schema-to-snowflake.sh
@@ -4,7 +4,7 @@ env
 
 ${WORKSPACE}/analytics-configuration/automation/run-automated-task.sh \
  VerticaSchemaToSnowflakeTask --local-scheduler \
- ${RUN_DATE} \
+ --date $(date +%Y-%m-%d -d "$RUN_DATE") \
  ${OVERWRITE} \
  --credentials $SNOWFLAKE_CREDENTIALS \
  --warehouse $WAREHOUSE \

--- a/dataeng/resources/vertica-to-bigquery-schema-copy.sh
+++ b/dataeng/resources/vertica-to-bigquery-schema-copy.sh
@@ -7,7 +7,7 @@ ${WORKSPACE}/analytics-configuration/automation/run-automated-task.sh \
  --vertica-schema-name $SCHEMA \
  --vertica-credentials $VERTICA_CREDENTIALS \
  --gcp-credentials $GCP_CREDENTIALS \
- ${RUN_DATE} \
+ --date $(date +%Y-%m-%d -d "$RUN_DATE") \
  ${OVERWRITE} \
  ${EXCLUDE} \
  ${EXTRA_ARGS}


### PR DESCRIPTION
BUILD_ID environment variable used to give us the date timestamp, not anymore. The secure-repo PR sets 'today' as default for the upstream job(currently being defaulted by luigi pipeline code).

secure-repo PR: https://github.com/edx-ops/analytics-secure/pull/258