### PR TITLE
Add prod credentials binding to UpdateMastersSandbox job

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -171,7 +171,7 @@ class CreateSandbox {
                 booleanParam("journals",false,"Journals service")
                 stringParam("journals_version","master","")
 
-                booleanParam("registrar",false,"Enable the Registrar service")
+                booleanParam("registrar",false,"Enable the Registrar service, along with the Program Manager micro-frontend")
                 stringParam("registrar_version","master","")
                 stringParam("registrar_user_email","registrar@example.com",
                             "Email (and username) for user to be created in Registrar. Ignore this setting if Registrar is disabled.")

--- a/devops/jobs/UpdateMastersSandbox.groovy
+++ b/devops/jobs/UpdateMastersSandbox.groovy
@@ -18,8 +18,8 @@
    This job expects the sandbox-ssh-keys credential to contain an ssh key it can user
    to access any sandbox.
 
-   This job also expects sandbox-masters-automation-client-credentials
-   to be a string in the format client_id:client_secret, giving the masters sandbox
+   This job also expects the strings sandbox-masters-automation-client-id and
+   sandbox-masters-automation-client-secret to be set, giving the masters sandbox
    ansible task the ability to pull data from the production catalog API.
 
 */
@@ -44,7 +44,8 @@ class UpdateMastersSandbox {
 
       wrappers {
           credentialsBinding {
-              string('MASTERS_AUTOMATION_CLIENT_CREDENTIALS', 'sandbox-masters-automation-client-credentials')
+              string('MASTERS_AUTOMATION_CLIENT_ID', 'sandbox-masters-automation-client-id')
+              string('MASTERS_AUTOMATION_CLIENT_SECRET', 'sandbox-masters-automation-client-secret')
           }
       }
 
@@ -75,16 +76,14 @@ class UpdateMastersSandbox {
       parameters {
         stringParam("sandbox",'CHANGEME.sandbox.edx.org',
                     "DNS name of sandbox to update. The sandbox must have been built with Registrar enabled.")
-        stringParam("org_key","edX",'Key of the Organization whose catalog data will be synced with production.')
-        textParam("program_key_map",
-                  "b12075a1-a039-4983-abf8-f31f125c4695:my-groovy-program,"
-                  + "6d5989e1-70c0-475f-8e28-302bb7e1a1cd:another-groovy-program,"
-                  + "40e4b95c-ae35-4f4b-ac10-0980df5e153c:the-grooviest-program",
-                  "Mapping from program UUIDs to desired external program keys. "
-                  + "Omitted programs will have their keys default to their marketing slug, "
-                  + "as set in Discovery. "
-                  + "Separate each UUID from its external key with a colon, "
-                  + "and separate UUID-key pairs with commas."
+        textParam("program_uuids",
+                  "b12075a1-a039-4983-abf8-f31f125c4695,"
+                  + "6d5989e1-70c0-475f-8e28-302bb7e1a1cd:this-is-an-external-key,"
+                  + "40e4b95c-ae35-4f4b-ac10-0980df5e153c:and-another-external-key",
+                  "List of UUIDs for programs that will be loaded from production Discovery. "
+                  + "Separate program UUIDs with commas. "
+                  + "You may set a program's external by appending ':external_key'"
+                  + "to the UUID."
         )
       }
 

--- a/devops/jobs/UpdateMastersSandbox.groovy
+++ b/devops/jobs/UpdateMastersSandbox.groovy
@@ -17,6 +17,11 @@
 
    This job expects the sandbox-ssh-keys credential to contain an ssh key it can user
    to access any sandbox.
+
+   This job also expects sandbox-masters-automation-client-credentials
+   to be a string in the format client_id:client_secret, giving the masters sandbox
+   ansible task the ability to pull data from the production catalog API.
+
 */
 package devops.jobs
 
@@ -36,6 +41,12 @@ class UpdateMastersSandbox {
       )
 
       wrappers common_wrappers
+
+      wrappers {
+          credentialsBinding {
+              string('MASTERS_AUTOMATION_CLIENT_CREDENTIALS', 'sandbox-masters-automation-client-credentials')
+          }
+      }
 
       def access_control = extraVars.get('ACCESS_CONTROL',[])
       access_control.each { acl ->

--- a/devops/resources/update-masters-sandbox.sh
+++ b/devops/resources/update-masters-sandbox.sh
@@ -6,11 +6,12 @@ pip install -r requirements.txt
 
 cd playbooks
 
-PARAMS="organization_key=${org_key}"
-CREDENTIALS="client_credentials=${MASTERS_AUTOMATION_CLIENT_CREDENTIALS}"
+PARAMS="program_uuids=${program_uuids}"
+CREDENTIALS="client_id=${MASTERS_AUTOMATION_CLIENT_ID} client_secret=${MASTERS_AUTOMATION_CLIENT_SECRET}"
 MORE_VARS="give_sudo=true USER_FAIL_MISSING_KEYS=true"
 
-if [ -z "${MASTERS_AUTOMATION_CLIENT_CREDENTIALS}" ] || \
+if [ -z "${MASTERS_AUTOMATION_CLIENT_ID}" ] || \
+   [ -z "${MASTERS_AUTOMATION_CLIENT_SECRET}" ] || \
    [ -z "${SSH_USER}" ] || \
    [ -z "${USER}" ] || \
    [ "${USER}" == "jenkins" ]; \

--- a/devops/resources/update-masters-sandbox.sh
+++ b/devops/resources/update-masters-sandbox.sh
@@ -6,8 +6,19 @@ pip install -r requirements.txt
 
 cd playbooks
 
-if [ -z "${SSH_USER}" ] || [ -z "${USER}" ] || [ "${USER}" == "jenkins" ] ; then
+PARAMS="organization_key=${org_key}"
+CREDENTIALS="client_credentials=${MASTERS_AUTOMATION_CLIENT_CREDENTIALS}"
+MORE_VARS="give_sudo=true USER_FAIL_MISSING_KEYS=true"
+
+if [ -z "${MASTERS_AUTOMATION_CLIENT_CREDENTIALS}" ] || \
+   [ -z "${SSH_USER}" ] || \
+   [ -z "${USER}" ] || \
+   [ "${USER}" == "jenkins" ]; \
+then
    exit 1
 else
-   ansible-playbook --user ${SSH_USER} -i "$sandbox," -e "org_key=${org_key} give_sudo=true USER_FAIL_MISSING_KEYS=true" masters_sandbox_update.yml
+   ansible-playbook --user ${SSH_USER} \
+                    -i "$sandbox," \
+                    -e "${PARAMS} ${CREDENTIALS} ${MORE_VARS}" \
+                    masters_sandbox_update.yml
 fi


### PR DESCRIPTION
@edx/masters-neem 
@edx/devops 
https://openedx.atlassian.net/browse/EDUCATOR-4473

The `UpdateMastersSandbox` job will call the Ansible playbook `masters_sandbox_update.yml` (which will be created [here](https://github.com/edx/configuration/pull/5271)) from edx/configuration. That playbook will, among other tasks, invoke [this](https://github.com/edx/course-discovery/pull/2013) management command, which requires a production staff client-id and client-secret in order to hit [this](https://github.com/edx/course-discovery/blob/master/course_discovery/apps/edx_catalog_extensions/api/v1/views.py#L36) view.

If this looks good, then we will need DevOps to create the masters-sandbox-automation staff user in production, and store its client-id and client-secret in Jenkins under `sandbox-masters-automation-client-credentials`.