### PR TITLE
Add learner portal service to sandbox UI

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -179,6 +179,9 @@ class CreateSandbox {
                             "Key for Organization to be created in Registrar. Must match key in Discovery catalog. Ignore this setting if Registrar is disabled.")
                 stringParam("program_manager_version","master",
                             "The repository version of the frontend-app-program-manager")
+                
+                booleanParam("learner_portal",false,"Learner Portal")
+                stringParam("learner_portal_version","master","The version for the frontend-app-learner-portal")
 
                 booleanParam("video_pipeline",false,
                              "video_pipeline and video_encode_worker must be selected for video pipeline to work")


### PR DESCRIPTION
For the purpose of adding the `learner-portal` MFE to a sandbox. depends on configuration PR [#5278](https://github.com/edx/configuration/pull/5278).