### PR TITLE
Remove USER and SSH_USER from masters sandbox update script

### DIFF
--- a/devops/jobs/UpdateMastersSandbox.groovy
+++ b/devops/jobs/UpdateMastersSandbox.groovy
@@ -13,7 +13,6 @@
 
    * FOLDER_NAME: "Sandboxes"
    * ACCESS_CONTROL: List of org or org*team from GitHub who get access to the jobs
-   * SSH_USER: ssh username that we can use to access the sandbox and sudo to add a user
 
    This job expects the sandbox-ssh-keys credential to contain an ssh key it can user
    to access any sandbox.
@@ -98,10 +97,6 @@ class UpdateMastersSandbox {
 
       wrappers {
         sshAgent('sandbox-ssh-keys')
-      }
-
-      environmentVariables {
-        env('SSH_USER',extraVars.get('SSH_USER','ubuntu'))
       }
 
       steps {

--- a/devops/resources/update-masters-sandbox.sh
+++ b/devops/resources/update-masters-sandbox.sh
@@ -11,14 +11,11 @@ CREDENTIALS="client_id=${MASTERS_AUTOMATION_CLIENT_ID} client_secret=${MASTERS_A
 MORE_VARS="give_sudo=true USER_FAIL_MISSING_KEYS=true"
 
 if [ -z "${MASTERS_AUTOMATION_CLIENT_ID}" ] || \
-   [ -z "${MASTERS_AUTOMATION_CLIENT_SECRET}" ] || \
-   [ -z "${SSH_USER}" ] || \
-   [ -z "${USER}" ] || \
-   [ "${USER}" == "jenkins" ]; \
+   [ -z "${MASTERS_AUTOMATION_CLIENT_SECRET}" ]; \
 then
    exit 1
 else
-   ansible-playbook --user ${SSH_USER} \
+   ansible-playbook --user ubuntu \
                     -i "$sandbox," \
                     -e "${PARAMS} ${CREDENTIALS} ${MORE_VARS}" \
                     masters_sandbox_update.yml


### PR DESCRIPTION
@edx/masters-neem 
https://openedx.atlassian.net/browse/EDUCATOR-4473

This PR:
* Removes the `${USER}` parameter, which was copied over from `GrantSandboxSSHAccess`, but we never set in `UpdateMastersSandbox`. This should stop our `UpdateMastersSandbox` job from failing like this: https://tools-edx-jenkins.edx.org/job/Sandboxes/job/UpdateMastersSandbox/2/console
* Removes `${SSH_USER}` and hard-code in `ubuntu`. We don't need this to be settable according to Fred.

