### PR TITLE
Fix args passed into masters_sandbox_update.yml

### DIFF
--- a/devops/jobs/UpdateMastersSandbox.groovy
+++ b/devops/jobs/UpdateMastersSandbox.groovy
@@ -73,8 +73,10 @@ class UpdateMastersSandbox {
       }
 
       parameters {
-        stringParam("sandbox",'CHANGEME.sandbox.edx.org',
-                    "DNS name of sandbox to update. The sandbox must have been built with Registrar enabled.")
+        stringParam("dns_name","univ-of-change-me",
+                    "DNS name of sandbox to update. The sandbox must have been built with Registrar enabled. "
+                    + "Example: if your sandbox is unseen.sandbox.edx.org, enter 'unseen' here."
+        )
         textParam("program_uuids",
                   "b12075a1-a039-4983-abf8-f31f125c4695,"
                   + "6d5989e1-70c0-475f-8e28-302bb7e1a1cd:this-is-an-external-key,"

--- a/devops/resources/update-masters-sandbox.sh
+++ b/devops/resources/update-masters-sandbox.sh
@@ -6,17 +6,18 @@ pip install -r requirements.txt
 
 cd playbooks
 
-PARAMS="program_uuids=${program_uuids}"
-CREDENTIALS="client_id=${MASTERS_AUTOMATION_CLIENT_ID} client_secret=${MASTERS_AUTOMATION_CLIENT_SECRET}"
-MORE_VARS="give_sudo=true USER_FAIL_MISSING_KEYS=true"
-
-if [ -z "${MASTERS_AUTOMATION_CLIENT_ID}" ] || \
-   [ -z "${MASTERS_AUTOMATION_CLIENT_SECRET}" ]; \
-then
+if [ -z "${MASTERS_AUTOMATION_CLIENT_ID}" ] || [ -z "${MASTERS_AUTOMATION_CLIENT_SECRET}" ]; then
+   echo "Error: Missing automation client credentials!"
    exit 1
-else
-   ansible-playbook --user ubuntu \
-                    -i "$sandbox," \
-                    -e "${PARAMS} ${CREDENTIALS} ${MORE_VARS}" \
-                    masters_sandbox_update.yml
+elif [ -z "${program_uuids}" ] || [ -z "${dns_name}" ]; then
+   echo "Error: Missing dns_name or program_uuids!"
+   exit 2
 fi
+
+CREDENTIALS="client_id=${MASTERS_AUTOMATION_CLIENT_ID} client_secret=${MASTERS_AUTOMATION_CLIENT_SECRET}"
+PARAMS="program_uuids=${program_uuids} dns_name=${dns_name}"
+
+ansible-playbook --user ubuntu \
+                 -i "${dns_name}.sandbox.edx.org," \
+                 -e "${CREDENTIALS} ${PARAMS}" \
+                 masters_sandbox_update.yml


### PR DESCRIPTION
@edx/masters-neem 
https://openedx.atlassian.net/browse/EDUCATOR-4473

We were passing in irrelevant arguments to `masters_sandbox.yml`, and not passing in the sandbox DNS name.
