### PR TITLE
adding auth token

### DIFF
--- a/devops/jobs/CreateSandboxSSHAccess.groovy
+++ b/devops/jobs/CreateSandboxSSHAccess.groovy
@@ -70,7 +70,7 @@ class CreateSandboxSSHAccess {
         sshAgent('sandbox-ssh-keys')
       }
 
-      authenticationToken(extraVars.get('JENKINS_SANDBOX_JOB_KEY', 'S@nD80%'))
+      authenticationToken(extraVars.get('JENKINS_SANDBOX_JOB_KEY'))
 
       environmentVariables {
         env('SSH_USER',extraVars.get('SSH_USER','ubuntu'))

--- a/devops/jobs/CreateSandboxSSHAccess.groovy
+++ b/devops/jobs/CreateSandboxSSHAccess.groovy
@@ -70,6 +70,8 @@ class CreateSandboxSSHAccess {
         sshAgent('sandbox-ssh-keys')
       }
 
+      authenticationToken(extraVars.get('JENKINS_SANDBOX_JOB_KEY', 'S@nD80%'))
+
       environmentVariables {
         env('SSH_USER',extraVars.get('SSH_USER','ubuntu'))
       }


### PR DESCRIPTION
In order for clamps to build a jenkins job remotely (GrantSSHAccess to Sandbox), I need to set a job token to my POST Request.