### PR TITLE
Warn about hyphens in CreateSandbox dns_name

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -105,7 +105,8 @@ class CreateSandbox {
                          One reason you might want to override this field is if you are building a sandbox for review or a specific task. \
                          If setting this, you probably want to also set name_tag below. \
                          For example, if you are building a sandbox for pull request 1234 put in 'pr1234' which will setup the sandbox <i>pr1234.sandbox.edx.org</i>.<br /> \
-                         <b>If you are building a sandbox for yourself leave this blank</b><b>Do not use underscores</b>")
+                         <b>If you are building a sandbox for yourself leave this blank.</b> <br /> \
+                         <b>Do not use hyphens or underscores</b>.")
                 stringParam("name_tag","",
                         "This name tag uniquely identifies your sandbox.  <b>If a box already exists with this name tag, it will be terminated.</b><br /> \
                          If you want to have multiple sandboxes running simultaneously, you must give each one a unique name tag.")

--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -101,12 +101,13 @@ class CreateSandbox {
             parameters {
                 booleanParam("recreate",true,"Checking this option will terminate an existing instance if it already exists and start over from scratch")
                 stringParam("dns_name","",
-                        "DNS name, if left blank will default to your github username. \
+                        "DNS name, if left blank will default to your GitHub username. \
                          One reason you might want to override this field is if you are building a sandbox for review or a specific task. \
                          If setting this, you probably want to also set name_tag below. \
                          For example, if you are building a sandbox for pull request 1234 put in 'pr1234' which will setup the sandbox <i>pr1234.sandbox.edx.org</i>.<br /> \
-                         <b>If you are building a sandbox for yourself leave this blank.</b> <br /> \
-                         <b>Do not use hyphens or underscores</b>.")
+                         <b>Do not use hyphens or underscores here.</b> <br /> \
+                         If you are building a sandbox for yourself, you may leave this blank <b>unless</b> your GitHub \
+                         username contains underscores or hyphens. <br />")
                 stringParam("name_tag","",
                         "This name tag uniquely identifies your sandbox.  <b>If a box already exists with this name tag, it will be terminated.</b><br /> \
                          If you want to have multiple sandboxes running simultaneously, you must give each one a unique name tag.")


### PR DESCRIPTION
Hyphens in the sandbox dns_name cause some weird issues in the microservices, probably due to some nginx regex rules along the lines of `[service_name]-[dns_name]`. Let's warn about that.