### PR TITLE
Automatically upgrade cookiecutter-django-ida requirements

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -37,6 +37,15 @@ Map cookiecutterDjangoApp = [
     emails: ['testeng@edx.org']
 ]
 
+Map cookiecutterDjangoIda = [
+    org: 'edx',
+    repoName: 'cookiecutter-django-ida',
+    cronValue: '@weekly',
+    githubUserReviewers: [],
+    githubTeamReviewers: ['testeng'],
+    emails: ['testeng@edx.org']
+]
+
 Map courseDiscovery = [
     org: 'edx',
     repoName: 'course-discovery',
@@ -168,6 +177,7 @@ List jobConfigs = [
     bokchoy,
     completion,
     cookiecutterDjangoApp,
+    cookiecutterDjangoIda,
     courseDiscovery,
     credentials,
     devstack,


### PR DESCRIPTION
@edx/testeng 

In https://github.com/edx/cookiecutter-django-ida/pull/53, I add `make upgrade` to the IDA cookiecutter. It doesn't upgrade the requirements of the repo itself, but upgrades the requirements of to-be-cookie-cut IDA.

I will leave it up to y'all on test eng to decide whether this is worth merging or not.