### PR TITLE
Fix import error triggered by changes to support Python 3

### DIFF
--- a/testeng/resources/edx-platform-test-notifier.sh
+++ b/testeng/resources/edx-platform-test-notifier.sh
@@ -8,4 +8,4 @@ echo "Installing python requirements..."
 pip install -q -r requirements/base.txt
 
 echo "Running test notifier script..."
-python jenkins/edx_platform_test_notifier.py --repo $REPO --pr_number $PR_NUMBER
+python -m jenkins.edx_platform_test_notifier --repo $REPO --pr_number $PR_NUMBER


### PR DESCRIPTION
Some refactoring in `testeng-ci` triggered the following error in edx-platform-test-notifier:

```
Traceback (most recent call last):
  File "jenkins/edx_platform_test_notifier.py", line 10, in <module>
    from .github_helpers import connect_to_repo, get_github_token
ValueError: Attempted relative import in non-package
```

Execute the code as part of a package to fix this.