### PR TITLE
Fix more github_helpers import errors

### DIFF
--- a/testeng/resources/bokchoy-db-cache-script.sh
+++ b/testeng/resources/bokchoy-db-cache-script.sh
@@ -8,5 +8,4 @@ paver update_local_bokchoy_db_from_s3 --rewrite_fingerprint
 
 cd ../testeng-ci
 pip install -r requirements/base.txt
-cd jenkins
-python bokchoy_db_pull_request.py --sha $GIT_COMMIT --repo_root "../../edx-platform"
+python -m jenkins.bokchoy_db_pull_request --sha $GIT_COMMIT --repo_root "../edx-platform"

--- a/testeng/resources/upgrade-python-requirements.sh
+++ b/testeng/resources/upgrade-python-requirements.sh
@@ -15,8 +15,8 @@ make upgrade
 echo "Running script to create PR..."
 cd ../testeng-ci
 pip install -r requirements/base.txt
-cd jenkins
-python upgrade_python_requirements.py --sha=$CURRENT_SHA --repo_root="../../$REPO_NAME" --org=$ORG --user_reviewers=$PR_USER_REVIEWERS --team_reviewers=$PR_TEAM_REVIEWERS
+python -m jenkins.upgrade_python_requirements --sha=$CURRENT_SHA --repo_root="../$REPO_NAME" --org=$ORG --user_reviewers=$PR_USER_REVIEWERS --team_reviewers=$PR_TEAM_REVIEWERS
 
 deactivate
+cd ..
 rm -rf upgrade_venv


### PR DESCRIPTION
This should be the last of them.  Also upgraded the `make upgrade` job to switch to the correct directory before trying to delete the virtualenv.