### PR TITLE
expose python version in master and wtw jobs

### DIFF
--- a/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
@@ -142,7 +142,8 @@ jobConfigs.each { jobConfig ->
             environmentVariables(
                 REPO_NAME: "${jobConfig.repoName}",
                 BRANCH_NAME: "${jobConfig.branch}",
-                GITHUB_CONTEXT: "${jobConfig.context}"
+                GITHUB_CONTEXT: "${jobConfig.context}",
+                PYTHON_VERSION: "${jobConfig.pythonVersion}"
             )
 
             triggers {

--- a/platform/jobs/pipelines/edxPlatformPipelineMasterWTWNightly.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelineMasterWTWNightly.groovy
@@ -43,7 +43,8 @@ jobConfigs.each { jobConfig ->
                 REPO_NAME: "${jobConfig.repoName}",
                 BRANCH_NAME: "${jobConfig.branch}",
                 COLLECT_WHO_TESTS_WHAT: "true",
-                GITHUB_CONTEXT: "${jobConfig.context}"
+                GITHUB_CONTEXT: "${jobConfig.context}",
+                PYTHON_VERSION: "${jobConfig.pythonVersion}"
             )
 
             triggers {

--- a/platform/jobs/pipelines/edxPlatformPipelinePrWTW.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePrWTW.groovy
@@ -75,7 +75,8 @@ jobConfigs.each { jobConfig ->
             environmentVariables(
                 REPO_NAME: "${jobConfig.repoName}",
                 TOX_ENV: "${jobConfig.toxEnv}",
-                FILTER_WHO_TESTS_WHAT: "true"
+                FILTER_WHO_TESTS_WHAT: "true",
+                PYTHON_VERSION: "${jobConfig.pythonVersion}"
             )
 
             triggers {


### PR DESCRIPTION
Although I added this variable to our pipeline jobs yesterday, I did not expose the variable. It was already exposed in PR jobs, which explains why it did not cause errors on PRs, but it resulted in the following error message in master jobs:
```
00:09:11.577  tar: /home/jenkins/edx-venv_clean-.tar.gz: Cannot open: No such file or directory
00:09:11.577  tar: Error is not recoverable: exiting now
00:09:11.577  bash: ../edx-venv/bin/activate: No such file or directory
```