### PR TITLE
Break vertica export into three job definitions.

### DIFF
--- a/dataeng/jobs/analytics/LoadVerticaSchemaToBigquery.groovy
+++ b/dataeng/jobs/analytics/LoadVerticaSchemaToBigquery.groovy
@@ -6,31 +6,25 @@ import static org.edx.jenkins.dsl.AnalyticsConstants.common_wrappers
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_publishers
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_triggers
 
-class LoadVerticaSchemaToSnowflake {
+class LoadVerticaSchemaToBigquery {
     public static def job = { dslFactory, allVars ->
         allVars.get('VERTICA_SCHEMAS').each { schema, schema_config ->
-            dslFactory.job("load-vertica-schema-to-snowflake-$schema") {
+            dslFactory.job("load-vertica-schema-to-bigquery-$schema") {
                 logRotator common_log_rotator(allVars, schema_config)
                 parameters common_parameters(allVars, schema_config)
                 parameters {
                     stringParam('RUN_DATE', schema_config.get('RUN_DATE', allVars.get('RUN_DATE', 'today')), 'Run date for the job. A string that can be parsed by the GNU coreutils "date" utility.')
                     stringParam('OVERWRITE', schema_config.get('OVERWRITE', allVars.get('OVERWRITE')), 'Set to: --overwrite if you want to enable overwrite.')
-                    stringParam('SNOWFLAKE_CREDENTIALS', schema_config.get('SNOWFLAKE_CREDENTIALS', allVars.get('SNOWFLAKE_CREDENTIALS')), 'The path to the Snowflake credentials file.')
-                    stringParam('WAREHOUSE', schema_config.get('WAREHOUSE', allVars.get('WAREHOUSE')), '')
-                    stringParam('ROLE', schema_config.get('ROLE', allVars.get('ROLE')))
-                    stringParam('DATABASE', schema_config.get('DATABASE', allVars.get('DATABASE')))
-                    stringParam('SCHEMA', schema_config.get('SCHEMA', allVars.get('SCHEMA')), 'Schema')
+                    stringParam('GCP_CREDENTIALS', schema_config.get('GCP_CREDENTIALS', allVars.get('GCP_CREDENTIALS')), 'The path to the GCP credentials file.')
                     stringParam('VERTICA_SCHEMA_NAME', schema_config.get('VERTICA_SCHEMA_NAME', allVars.get('VERTICA_SCHEMA_NAME')), 'Vertica Schema')
                     stringParam('VERTICA_CREDENTIALS', schema_config.get('VERTICA_CREDENTIALS', allVars.get('VERTICA_CREDENTIALS')), 'The path to the Vertica credentials file.')
-                    stringParam('VERTICA_WAREHOUSE_NAME', schema_config.get('VERTICA_WAREHOUSE_NAME', allVars.get('VERTICA_WAREHOUSE_NAME')), '')
                     stringParam('EXCLUDE', schema_config.get('EXCLUDE', allVars.get('EXCLUDE')), 'as an example: --exclude [\"f_user_activity\",\"d_user_course_certificate\",\"d_user_course\"]')
-                    
                 }
                 multiscm common_multiscm(allVars)
                 wrappers common_wrappers(allVars)
                 publishers common_publishers(allVars)
                 steps {
-                    shell(dslFactory.readFileFromWorkspace('dataeng/resources/load-vertica-schema-to-snowflake.sh'))
+                    shell(dslFactory.readFileFromWorkspace('dataeng/resources/load-vertica-schema-to-bigquery.sh'))
                 }
             }
         }

--- a/dataeng/jobs/analytics/VerticaSchemaToS3.groovy
+++ b/dataeng/jobs/analytics/VerticaSchemaToS3.groovy
@@ -8,17 +8,16 @@ import static org.edx.jenkins.dsl.AnalyticsConstants.common_wrappers
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_publishers
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_triggers
 
-class VerticaToBigquerySchemaCopy {
+class VerticaSchemaToS3 {
     public static def job = { dslFactory, allVars ->
         allVars.get('VERTICA_SCHEMAS').each { schema, schema_config ->
-            dslFactory.job("vertica-to-bigquery-schema-copy-$schema") {
+            dslFactory.job("vertica-schema-to-s3-$schema") {
                 logRotator common_log_rotator(allVars, schema_config)
                 parameters common_parameters(allVars, schema_config)
                 parameters {
                     stringParam('SCHEMA', schema_config.get('SCHEMA', allVars.get('SCHEMA')), 'Vertica Schema')
                     stringParam('OVERWRITE', schema_config.get('OVERWRITE', allVars.get('OVERWRITE')), 'Set to: --overwrite if you want to enable overwrite.')
                     stringParam('VERTICA_CREDENTIALS', schema_config.get('VERTICA_CREDENTIALS', allVars.get('VERTICA_CREDENTIALS')), 'The path to the Vertica credentials file.')
-                    stringParam('GCP_CREDENTIALS', schema_config.get('GCP_CREDENTIALS', allVars.get('GCP_CREDENTIALS')), 'The path to the GCP credentials file.')
                     stringParam('EXCLUDE', schema_config.get('EXCLUDE', allVars.get('EXCLUDE')), 'as an example: --exclude [\"f_user_activity\",\"d_user_course_certificate\",\"d_user_course\"]')
                     stringParam('RUN_DATE', schema_config.get('RUN_DATE', allVars.get('RUN_DATE', 'today')), 'Run date for the job. A string that can be parsed by the GNU coreutils "date" utility.')
                 }
@@ -28,7 +27,7 @@ class VerticaToBigquerySchemaCopy {
                 publishers common_publishers(allVars)
                 publishers {
                     downstreamParameterized {
-                        trigger("load-vertica-$schema-schema-to-snowflake") {
+                        trigger("load-vertica-schema-to-snowflake-$schema,load-vertica-schema-to-bigquery-$schema") {
                             condition('SUCCESS')
                             parameters {
                                 // The contents of this file are generated as part of the script in the build step.
@@ -38,7 +37,7 @@ class VerticaToBigquerySchemaCopy {
                     }
                 }
                 steps {
-                    shell(dslFactory.readFileFromWorkspace('dataeng/resources/vertica-to-bigquery-schema-copy.sh'))
+                    shell(dslFactory.readFileFromWorkspace('dataeng/resources/vertica-schema-to-s3.sh'))
                 }
             }
         }

--- a/dataeng/jobs/createJobs.groovy
+++ b/dataeng/jobs/createJobs.groovy
@@ -28,7 +28,6 @@ import static analytics.LoadEvents.load_events_to_vertica_job as LoadEventsToVer
 import static analytics.LoadEvents.load_json_events_to_s3_job as LoadJsonEventsToS3Job
 import static analytics.LoadEvents.load_json_events_to_bigquery_job as LoadJsonEventsToBigqueryJob
 import static analytics.VerticaReplicaImport.job as VerticaReplicaImportJob
-import static analytics.VerticaToBigquerySchemaCopy.job as VerticaToBigquerySchemaCopyJob
 import static analytics.BackupVertica.job as BackupVerticaJob
 import static analytics.TotalEventsDailyReport.job as TotalEventsDailyReportJob
 import static analytics.JenkinsBackup.job as JenkinsBackupJob
@@ -44,7 +43,9 @@ import static analytics.LoadInsightsToVertica.job as LoadInsightsToVerticaJob
 import static analytics.LoadGoogleAnalyticsPermissions.job as LoadGoogleAnalyticsPermissionsJob
 import static analytics.AggregateDailyTrackingLogs.job as AggregateDailyTrackingLogsJob
 import static analytics.MonitorBigqueryEventLoading.job as MonitorBigqueryEventLoadingJob
+import static analytics.VerticaSchemaToS3.job as VerticaSchemaToS3Job
 import static analytics.LoadVerticaSchemaToSnowflake.job as LoadVerticaSchemaToSnowflakeJob
+import static analytics.LoadVerticaSchemaToBigquery.job as LoadVerticaSchemaToBigqueryJob
 import static analytics.LoadGoogleSpreadsheetToWarehouse.job as LoadGoogleSpreadsheetToWarehouseJob
 import static analytics.SnowflakeReplicaImport.job as SnowflakeReplicaImportJob
 import static analytics.LoadPaypalCaseReportToVertica.job as PayPalCaseReportLoadJob
@@ -98,7 +99,6 @@ def taskMap = [
     LOAD_JSON_EVENTS_TO_BIGQUERY_JOB: LoadJsonEventsToBigqueryJob,
     SNOWFLAKE_SCHEMA_BUILDER_JOB: SnowflakeSchemaBuilderJob,
     VERTICA_REPLICA_IMPORT_JOB: VerticaReplicaImportJob,
-    VERTICA_TO_BIGQUERY_SCHEMA_COPY_JOB: VerticaToBigquerySchemaCopyJob,
     BACKUP_VERTICA_JOB: BackupVerticaJob,
     TOTAL_EVENTS_DAILY_REPORT_JOB: TotalEventsDailyReportJob,
     JENKINS_BACKUP_JOB: JenkinsBackupJob,
@@ -115,7 +115,9 @@ def taskMap = [
     LOAD_GOOGLE_ANALYTICS_PERMISSIONS_JOB: LoadGoogleAnalyticsPermissionsJob,
     AGGREGATE_DAILY_TRACKING_LOGS_JOB: AggregateDailyTrackingLogsJob,
     MONITOR_BIGQUERY_EVENT_LOADING_JOB: MonitorBigqueryEventLoadingJob,
+    VERTICA_SCHEMA_TO_S3_JOB: VerticaSchemaToS3Job,
     LOAD_VERTICA_SCHEMA_TO_SNOWFLAKE_JOB: LoadVerticaSchemaToSnowflakeJob,
+    LOAD_VERTICA_SCHEMA_TO_BIGQUERY_JOB: LoadVerticaSchemaToBigqueryJob,
     LOAD_GOOGLE_SPREADSHEET_TO_WAREHOUSE_JOB: LoadGoogleSpreadsheetToWarehouseJob,
     SNOWFLAKE_REPLICA_IMPORT_JOB: SnowflakeReplicaImportJob,
     LOAD_PAYPAL_CASEREPORT_TO_VERTICA_JOB: PayPalCaseReportLoadJob,
@@ -178,7 +180,7 @@ listView('Warehouse') {
         name('generate-warehouse-docs')
         name('affiliate-window')
         name('snowflake-schema-builder')
-        regex('.+read-replica-import|load-.+|vertica-to-bigquery.+|.*sql-script.*')
+        regex('.+read-replica-import|load-.+|vertica-schema-to.+|.*sql-script.*')
     }
     columns DEFAULT_VIEW.call()
 }

--- a/dataeng/resources/load-vertica-schema-to-bigquery.sh
+++ b/dataeng/resources/load-vertica-schema-to-bigquery.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+env
+
+${WORKSPACE}/analytics-configuration/automation/run-automated-task.sh \
+ LoadVerticaSchemaFromS3ToBigQueryTask --local-scheduler \
+ --date $(date +%Y-%m-%d -d "$RUN_DATE") \
+ ${OVERWRITE} \
+ --gcp-credentials $GCP_CREDENTIALS \
+ --vertica-schema-name $VERTICA_SCHEMA_NAME \
+ --vertica-credentials $VERTICA_CREDENTIALS \
+ ${EXCLUDE} \
+ ${EXTRA_ARGS}

--- a/dataeng/resources/load-vertica-schema-to-snowflake.sh
+++ b/dataeng/resources/load-vertica-schema-to-snowflake.sh
@@ -3,7 +3,7 @@
 env
 
 ${WORKSPACE}/analytics-configuration/automation/run-automated-task.sh \
- VerticaSchemaToSnowflakeTask --local-scheduler \
+ LoadVerticaSchemaFromS3ToSnowflakeTask --local-scheduler \
  --date $(date +%Y-%m-%d -d "$RUN_DATE") \
  ${OVERWRITE} \
  --credentials $SNOWFLAKE_CREDENTIALS \

--- a/dataeng/resources/vertica-schema-to-s3.sh
+++ b/dataeng/resources/vertica-schema-to-s3.sh
@@ -10,10 +10,9 @@ INTERPOLATED_RUN_DATE="$(date +%Y-%m-%d -d "$RUN_DATE")"
 echo "RUN_DATE=${INTERPOLATED_RUN_DATE}" > "${WORKSPACE}/downstream.properties"
 
 ${WORKSPACE}/analytics-configuration/automation/run-automated-task.sh \
- VerticaSchemaToBigQueryTask --local-scheduler \
+ ExportVerticaSchemaToS3Task --local-scheduler \
  --vertica-schema-name $SCHEMA \
  --vertica-credentials $VERTICA_CREDENTIALS \
- --gcp-credentials $GCP_CREDENTIALS \
  --date "$INTERPOLATED_RUN_DATE" \
  ${OVERWRITE} \
  ${EXCLUDE} \


### PR DESCRIPTION
As part of work on DE-1700, this PR reorganizes Vertica export jobs to separate the writing to S3 from the loading into BigQuery and Snowflake. With separate Jenkins jobs to do the export versus the loading, the loading into BQ and Snowflake can then run in parallel.

Should be merged with https://github.com/edx/edx-analytics-pipeline/pull/764.