### PR TITLE
Don't use parameterized downstream w/o parameters.

### DIFF
--- a/dataeng/jobs/analytics/SqlScripts.groovy
+++ b/dataeng/jobs/analytics/SqlScripts.groovy
@@ -32,11 +32,7 @@ class SqlScripts {
                 publishers common_publishers(allVars)
                 if (env_config.containsKey('DOWNSTREAM_JOBS_TO_TRIGGER')) {
                     publishers {
-                        downstreamParameterized {
-                            trigger(env_config.get('DOWNSTREAM_JOBS_TO_TRIGGER')) {
-                                condition('SUCCESS')
-                            }
-                        }
+                        downstream(env_config.get('DOWNSTREAM_JOBS_TO_TRIGGER'), 'SUCCESS')
                     }
                 }
                 steps {


### PR DESCRIPTION
Switch to regular downstream, since we don't need to use parameters.