### PR TITLE
Run 3.5 a11y tests on all PRs BOM-959

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -67,9 +67,8 @@ Map python3JobConfig = [
     workerLabel: 'jenkins-worker',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/python3.5/a11y',
-    triggerPhrase: /.*jenkins\W+run\W+py36-django111\W+a11y.*/,
-    commentOnly: true,
-    toxEnv: 'py36-django111'
+    triggerPhrase: /.*jenkins\W+run\W+py35-django111\W+a11y.*/,
+    toxEnv: 'py35-django111'
 ]
 
 Map publicIronwoodJobConfig = [


### PR DESCRIPTION
These are all passing now, so run them on all PRs to avoid regressions.  Also undo the changes to this job from #744 since we're sticking with 3.5 for a while (those changes hadn't actually been applied to Jenkins yet).