### PR TITLE
remove space from param in terminate cluster job

### DIFF
--- a/dataeng/jobs/analytics/TerminateCluster.groovy
+++ b/dataeng/jobs/analytics/TerminateCluster.groovy
@@ -8,7 +8,7 @@ class TerminateCluster {
         dslFactory.job("terminate-cluster") {
             logRotator common_log_rotator(allVars)
             parameters {
-                stringParam('CLUSTER_NAME', ' ', 'Name of the EMR cluster to terminate.')
+                stringParam('CLUSTER_NAME', '', 'Name of the EMR cluster to terminate.')
                 stringParam('CONFIG_REPO', 'git@github.com:edx/edx-analytics-configuration.git', '')
                 stringParam('CONFIG_BRANCH', '$ANALYTICS_CONFIGURATION_RELEASE', 'e.g. tagname or origin/branchname, or $ANALYTICS_CONFIGURATION_RELEASE')
             }


### PR DESCRIPTION
The default value in this job was a space character. I had assumed it was empty and just clicked in the input box to paste in a cluster name, but accidentally input something like " clusterName", which did not actually map to anything in our EMR space. Unfortunately, this wasn't viewed as a failure by Ansible, which returned a success but didn't actually do anything.