### PR TITLE
add devops team to plugin scanner job

### DIFF
--- a/testeng/jobs/scanPluginUpdatesJob.groovy
+++ b/testeng/jobs/scanPluginUpdatesJob.groovy
@@ -11,6 +11,7 @@ job('scan-plugin-updates') {
     authorization {
         blocksInheritance(true)
         permissionAll('edx*testeng')
+        permissionAll('edx*devops')
     }
 
     logRotator JENKINS_PUBLIC_LOG_ROTATOR()


### PR DESCRIPTION
Make sure devops can see this job. Please let me know if this is the right team name to use