### PR TITLE
fix schema builder cli option

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeSchemaBuilder.groovy
+++ b/dataeng/jobs/analytics/SnowflakeSchemaBuilder.groovy
@@ -14,7 +14,6 @@ class SnowflakeSchemaBuilder {
                 stringParam('WAREHOUSE_TRANSFORMS_URL', allVars.get('WAREHOUSE_TRANSFORMS_URL'), 'URL for the Warehouse Transforms Repo.')
                 stringParam('WAREHOUSE_TRANSFORMS_BRANCH', allVars.get('WAREHOUSE_TRANSFORMS_BRANCH'), 'Branch of Warehouse Transforms to use.')
                 stringParam('SCHEMAS', allVars.get('SCHEMAS'), 'Snowflake schemas to work on')
-                stringParam('DBT_PROJECT', allVars.get('DBT_PROJECT'), 'dbt project in warehouse-transforms to work on.')
                 stringParam('DBT_PROFILE', allVars.get('DBT_PROFILE'), 'dbt profile from analytics-secure to work on.')
                 stringParam('DBT_TARGET', allVars.get('DBT_TARGET'), 'dbt target from analytics-secure to work on.')
                 stringParam('NOTIFY', allVars.get('NOTIFY','$PAGER_NOTIFY'), 'Space separated list of emails to send notifications to.')

--- a/dataeng/resources/snowflake-schema-builder.sh
+++ b/dataeng/resources/snowflake-schema-builder.sh
@@ -5,7 +5,9 @@ set -ex
 cd $WORKSPACE/warehouse-transforms
 pip install -r tools/dbt_schema_builder/requirements.txt
 
-cd $DBT_PROJECT
+cd $WORKSPACE/warehouse-transforms/app_views_project
+dbt clean
+cd $WORKSPACE/warehouse-transforms/warehouse_transforms_project
 dbt clean
 
 cd $WORKSPACE/warehouse-transforms
@@ -16,7 +18,7 @@ branchname="builder_$now"
 git checkout -b "$branchname"
 
 # Run the dbt script to update schemas and sql
-python tools/dbt_schema_builder/schema_builder.py build --schemas $SCHEMAS --project $DBT_PROJECT --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
+python tools/dbt_schema_builder/schema_builder.py build --raw-schemas $SCHEMAS --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
 
 # Check if any files are added, deleted, or changed. If so, commit them and create a PR.
 if [[ -z $(git status -s) ]]


### PR DESCRIPTION
A flag on the schema-builder will change once this PR (https://github.com/edx/warehouse-transforms/pull/22) merges. From the comments:

```
The schema-builder CLI changed:

    --schemas becomes --raw-schemas and the list of schemas passed into it must include a _RAW suffix.

```