### PR TITLE
run schema builder for each dbt project

### DIFF
--- a/dataeng/resources/snowflake-schema-builder.sh
+++ b/dataeng/resources/snowflake-schema-builder.sh
@@ -18,6 +18,9 @@ branchname="builder_$now"
 git checkout -b "$branchname"
 
 # Run the dbt script to update schemas and sql
+cd $WORKSPACE/warehouse-transforms/warehouse_transforms_project
+python tools/dbt_schema_builder/schema_builder.py build --raw-schemas $SCHEMAS --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
+cd $WORKSPACE/warehouse-transforms/app_views_project
 python tools/dbt_schema_builder/schema_builder.py build --raw-schemas $SCHEMAS --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
 
 # Check if any files are added, deleted, or changed. If so, commit them and create a PR.


### PR DESCRIPTION
Now that we are no longer passing the `project` cli option, we need to run schema builder from the directory that contains the `dbt_project.yml` file (which means twice, as there are two projects)