### PR TITLE
only run schema builder for the app views dbt project

### DIFF
--- a/dataeng/resources/snowflake-schema-builder.sh
+++ b/dataeng/resources/snowflake-schema-builder.sh
@@ -18,8 +18,6 @@ branchname="builder_$now"
 git checkout -b "$branchname"
 
 # Run the dbt script to update schemas and sql
-cd $WORKSPACE/warehouse-transforms/warehouse_transforms_project
-python $WORKSPACE/warehouse-transforms/tools/dbt_schema_builder/schema_builder.py build --raw-schemas $SCHEMAS --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
 cd $WORKSPACE/warehouse-transforms/app_views_project
 python $WORKSPACE/warehouse-transforms/tools/dbt_schema_builder/schema_builder.py build --raw-schemas $SCHEMAS --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
 


### PR DESCRIPTION
I assumed that since we split the dbt project into two separate projects, we would need to run the schema builder for both. However, when I ran the schema builder on the `warehouse_transforms_project`, it failed spectacularly, with all kinds of threading errors. 

Should we be running schema builder on this project yet?