### PR TITLE
Give a11y jobs more RAM

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -44,7 +44,7 @@ Map publicJobConfig = [
     open : true,
     jobName : 'edx-platform-accessibility-pr',
     repoName : 'edx-platform',
-    workerLabel: 'jenkins-worker',
+    workerLabel: 'js-worker',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/a11y',
     triggerPhrase: /.*jenkins\W+run\W+a11y.*/
@@ -54,7 +54,7 @@ Map privateJobConfig = [
     open: false,
     jobName: 'edx-platform-accessibility-pr_private',
     repoName: 'edx-platform-private',
-    workerLabel: 'jenkins-worker',
+    workerLabel: 'js-worker',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/a11y',
     triggerPhrase: /.*jenkins\W+run\W+a11y.*/
@@ -64,7 +64,7 @@ Map python3JobConfig = [
     open : true,
     jobName : 'edx-platform-python3-accessibility-pr',
     repoName : 'edx-platform',
-    workerLabel: 'jenkins-worker',
+    workerLabel: 'js-worker',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/python3.5/a11y',
     triggerPhrase: /.*jenkins\W+run\W+py35-django111\W+a11y.*/,


### PR DESCRIPTION
The Python 3 a11y job has been intermittently failing random tests, and insufficient RAM (causing the browser to be killed by the OS) is one likely culprit.  Switch all the a11y jobs to use the same larger instance type as the JS jobs; this will provide 2x the RAM, vCPUs, and storage compared to the base `jenkins-worker` instances.  While this may not technically be needed for the non-Python 3 jobs, it's best to keep them consistent (and it may reduce the job duration a little).

There are only 2 of these a11y workers per PR compared to 41 workers running unit and bok-choy tests, so the increased cost over the smaller instance type is fairly insignificant.