### PR TITLE
Remove '--project' parameter when running 'dbt run' from intended pro…

### DIFF
--- a/dataeng/resources/warehouse-transforms.sh
+++ b/dataeng/resources/warehouse-transforms.sh
@@ -10,5 +10,5 @@ pip install -r tools/dbt_schema_builder/requirements.txt
 cd $WORKSPACE/warehouse-transforms/warehouse_transforms_project
 dbt clean
 
-dbt run --models tag:$MODEL_TAG --project $DBT_PROJECT --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
+dbt run --models tag:$MODEL_TAG --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
 


### PR DESCRIPTION
Remove '--project' parameter when running 'dbt run' from intended project dir. The param is not needed and causes this error:
```
02:41:34 + dbt run --models tag:daily --project dbt_project --profile warehouse_transforms --target prod --profiles-dir /var/lib/jenkins/workspace/warehouse-transforms-daily/analytics-secure/warehouse-transforms/
02:41:34 Running with dbt=0.14.0
02:41:34 Encountered an error:
02:41:34 Runtime Error
02:41:34   fatal: Invalid --project-dir flag. Not a dbt project. Missing dbt_project.yml file
```