### PR TITLE
Add DBT seed command before run command.

### DIFF
--- a/dataeng/resources/warehouse-transforms.sh
+++ b/dataeng/resources/warehouse-transforms.sh
@@ -10,5 +10,6 @@ pip install -r tools/dbt_schema_builder/requirements.txt
 cd $WORKSPACE/warehouse-transforms/warehouse_transforms_project
 dbt clean
 
+dbt seed --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
 dbt run --models tag:$MODEL_TAG --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
 


### PR DESCRIPTION
The merged DBT user dimension uses some seed data so the process will need to run `dbt seed` first before a `dbt run` will work. This PR adds the `dbt seed` command to the automated tagged DBT model runs.