### PR TITLE
ORA2 auto-auth script should change the correct environment override files

### DIFF
--- a/ora2/resources/enable-auto-auth.sh
+++ b/ora2/resources/enable-auto-auth.sh
@@ -1,2 +1,2 @@
 # Enable auto auth for a sandbox
-ssh ${SSH_USER}@${SANDBOX_HOST} -o StrictHostKeyChecking=no "sudo sed -i 's/\"AUTOMATIC_AUTH_FOR_TESTING\": false/\"AUTOMATIC_AUTH_FOR_TESTING\": true/' /edx/app/edxapp/cms.env.json && sudo sed -i 's/\"AUTOMATIC_AUTH_FOR_TESTING\": false/\"AUTOMATIC_AUTH_FOR_TESTING\": true/' /edx/app/edxapp/lms.env.json && sudo /edx/bin/supervisorctl restart lms cms"
+ssh ${SSH_USER}@${SANDBOX_HOST} -o StrictHostKeyChecking=no "sudo sed -i 's/AUTOMATIC_AUTH_FOR_TESTING: false/AUTOMATIC_AUTH_FOR_TESTING: true/' /edx/etc/studio.yml && sudo sed -i 's/AUTOMATIC_AUTH_FOR_TESTING: false/AUTOMATIC_AUTH_FOR_TESTING: true/' /edx/etc/lms.yml && sudo /edx/bin/supervisorctl restart lms cms"


### PR DESCRIPTION
Fixes https://openedx.atlassian.net/browse/EDUCATOR-4778

A while back, we switched to overriding environment settings in the `/edx/etc/*.yml` files, instead of the `*.env.json` files.  That was never accounted for in the ORA2 auto-auth job.