### PR TITLE
Start Python 3 tests on edx-platform master

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -49,6 +49,15 @@ Map privateJobConfig = [
     defaultBranch : 'security-release'
 ]
 
+Map python3JobConfig = [
+    open : true,
+    jobName : 'edx-platform-python3-accessibility-master',
+    repoName : 'edx-platform',
+    workerLabel: 'jenkins-worker',
+    context: 'jenkins/python3.5/a11y',
+    refSpec : '+refs/heads/master:refs/remotes/origin/master',
+    toxEnv: 'py35-django111'
+
 Map ironwoodJobConfig = [
     open: true,
     jobName: 'ironwood-accessibility-master',
@@ -62,6 +71,7 @@ Map ironwoodJobConfig = [
 List jobConfigs = [
     publicJobConfig,
     privateJobConfig,
+    python3JobConfig,
     ironwoodJobConfig
 ]
 
@@ -77,6 +87,9 @@ jobConfigs.each { jobConfig ->
         }
         logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
         concurrentBuild()
+        environmentVariables {
+            env('TOX_ENV', jobConfig.toxEnv)
+        }
         parameters {
             labelParam('WORKER_LABEL') {
                 description('Select a Jenkins worker label for running this job')

--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -57,6 +57,7 @@ Map python3JobConfig = [
     context: 'jenkins/python3.5/a11y',
     refSpec : '+refs/heads/master:refs/remotes/origin/master',
     toxEnv: 'py35-django111'
+]
 
 Map ironwoodJobConfig = [
     open: true,

--- a/platform/jobs/edxPlatformJsMaster.groovy
+++ b/platform/jobs/edxPlatformJsMaster.groovy
@@ -52,6 +52,16 @@ Map privateJobConfig = [
     defaultBranch : 'security-release'
 ]
 
+Map python3JobConfig = [
+    open : true,
+    jobName : 'edx-platform-python3-js-master',
+    repoName: 'edx-platform',
+    workerLabel: 'js-worker',
+    context: 'jenkins/python3.5/js',
+    refSpec : '+refs/heads/master:refs/remotes/origin/master',
+    toxEnv: 'py35-django111'
+]
+
 Map ironwoodJobConfig = [
     open: true,
     jobName: 'ironwood-js-master',
@@ -65,6 +75,7 @@ Map ironwoodJobConfig = [
 List jobConfigs = [
     publicJobConfig,
     privateJobConfig,
+    python3JobConfig,
     ironwoodJobConfig
 ]
 
@@ -82,6 +93,9 @@ jobConfigs.each { jobConfig ->
         }
         logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
         concurrentBuild()
+        environmentVariables {
+            env('TOX_ENV', jobConfig.toxEnv)
+        }
         parameters {
             labelParam('WORKER_LABEL') {
                 description('Select a Jenkins worker label for running this job')

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -76,9 +76,9 @@ Map python3JobConfig = [
     workerLabel: 'js-worker',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/python3.5/js',
-    triggerPhrase: /.*jenkins\W+run\W+py36-django111\W+js.*/,
+    triggerPhrase: /.*jenkins\W+run\W+py35-django111\W+js.*/,
     commentOnly: true,
-    toxEnv: 'py36-django111'
+    toxEnv: 'py35-django111'
 ]
 
 Map publicIronwoodJobConfig = [

--- a/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
@@ -26,6 +26,18 @@ Map privateBokchoyJobConfig = [
     pythonVersion: '2.7',
 ]
 
+Map publicBokchoyPython3JobConfig = [
+    open : true,
+    jobName : 'edx-platform-python3-bokchoy-pipeline-master',
+    repoName: 'edx-platform',
+    jenkinsFileDir: 'scripts/Jenkinsfiles',
+    jenkinsFileName: 'bokchoy',
+    branch: 'master',
+    context: 'jenkins/py35-django111/bokchoy',
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django111',
+]
+
 Map ironwoodBokchoyJobConfig = [
     open: true,
     jobName: 'ironwood-bokchoy-pipeline-master',
@@ -70,6 +82,18 @@ Map privatePythonJobConfig = [
     pythonVersion: '2.7',
 ]
 
+Map publicPythonPython3JobConfig = [
+    open: true,
+    jobName: 'edx-platform-python3-python-pipeline-master',
+    repoName: 'edx-platform',
+    jenkinsFileDir: 'scripts/Jenkinsfiles',
+    jenkinsFileName: 'python',
+    branch: 'master',
+    context: 'jenkins/py35-django111/python',
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django111',
+]
+
 Map ironwoodPythonJobConfig = [
     open: true,
     jobName: 'ironwood-python-pipeline-master',
@@ -103,6 +127,18 @@ Map privateQualityJobConfig = [
     pythonVersion: '2.7',
 ]
 
+Map publicQualityPython3JobConfig = [
+    open : true,
+    jobName : 'edx-platform-python3-quality-pipeline-master',
+    repoName: 'edx-platform',
+    jenkinsFileDir: 'scripts/Jenkinsfiles',
+    jenkinsFileName: 'quality',
+    branch: 'master',
+    context: 'jenkins/py35-django111/quality',
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django111',
+]
+
 Map ironwoodQualityJobConfig = [
     open: true,
     jobName: 'ironwood-quality-pipeline-master',
@@ -117,13 +153,16 @@ Map ironwoodQualityJobConfig = [
 List jobConfigs = [
     publicBokchoyJobConfig,
     privateBokchoyJobConfig,
+    publicBokchoyPython3JobConfig,
     ironwoodBokchoyJobConfig,
     ironwoodLettuceJobConfig,
     publicPythonJobConfig,
     privatePythonJobConfig,
+    publicPythonPython3JobConfig,
     ironwoodPythonJobConfig,
     publicQualityJobConfig,
     privateQualityJobConfig,
+    publicQualityPython3JobConfig,
     ironwoodQualityJobConfig
 ]
 
@@ -143,6 +182,7 @@ jobConfigs.each { jobConfig ->
                 REPO_NAME: "${jobConfig.repoName}",
                 BRANCH_NAME: "${jobConfig.branch}",
                 GITHUB_CONTEXT: "${jobConfig.context}",
+                TOX_ENV: "${jobConfig.toxEnv}",
                 PYTHON_VERSION: "${jobConfig.pythonVersion}"
             )
 

--- a/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
@@ -2,7 +2,6 @@ package platform
 
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_PRIVATE_JOB_SECURITY
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
-import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_CANCEL_BUILDS_ON_UPDATE
 
 Map publicBokchoyJobConfig = [
     open: true,

--- a/src/test/groovy/platform/edxPlatformMasterSpec.groovy
+++ b/src/test/groovy/platform/edxPlatformMasterSpec.groovy
@@ -44,7 +44,7 @@ class edxPlatformMasterJobSpec extends Specification {
 
         where:
         dslFile                                   | numJobs
-        'edxPlatformAccessibilityMaster.groovy'   | 3
-        'edxPlatformJsMaster.groovy'              | 3
+        'edxPlatformAccessibilityMaster.groovy'   | 4
+        'edxPlatformJsMaster.groovy'              | 4
     }
 }

--- a/src/test/groovy/platform/pipelines/edxPlatformPipelinesMasterSpec.groovy
+++ b/src/test/groovy/platform/pipelines/edxPlatformPipelinesMasterSpec.groovy
@@ -44,6 +44,6 @@ class edxPlatformPipelinesMasterJobSpec extends Specification {
 
         where:
         dslFile                                   | numJobs
-        'edxPlatformPipelineMaster.groovy'        | 10
+        'edxPlatformPipelineMaster.groovy'        | 13
     }
 }


### PR DESCRIPTION
Start running Python 3 versions of all the edx-platform tests on merges to master.  Also start running a Python 3 version of the JS tests on PRs, to catch any regressions in the paver code Python 3 compatibility.