### PR TITLE
Fixes for latest Python 3 jobs

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -56,6 +56,7 @@ Map python3JobConfig = [
     workerLabel: 'jenkins-worker',
     context: 'jenkins/python3.5/a11y',
     refSpec : '+refs/heads/master:refs/remotes/origin/master',
+    defaultBranch : 'master',
     toxEnv: 'py35-django111'
 ]
 

--- a/platform/jobs/edxPlatformJsMaster.groovy
+++ b/platform/jobs/edxPlatformJsMaster.groovy
@@ -59,6 +59,7 @@ Map python3JobConfig = [
     workerLabel: 'js-worker',
     context: 'jenkins/python3.5/js',
     refSpec : '+refs/heads/master:refs/remotes/origin/master',
+    defaultBranch : 'master',
     toxEnv: 'py35-django111'
 ]
 

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -77,7 +77,6 @@ Map python3JobConfig = [
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/python3.5/js',
     triggerPhrase: /.*jenkins\W+run\W+py35-django111\W+js.*/,
-    commentOnly: true,
     toxEnv: 'py35-django111'
 ]
 


### PR DESCRIPTION
Add missing `defaultBranch` fields to the new Python 3 a11y and JS tests on edx-platform master, and make the Python 3 JS tests run on all PRs automatically.