### PR TITLE
add snowpipe reresh job to dataeng seed job

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeRefreshSnowpipe.groovy
+++ b/dataeng/jobs/analytics/SnowflakeRefreshSnowpipe.groovy
@@ -10,21 +10,23 @@ import static org.edx.jenkins.dsl.AnalyticsConstants.secure_scm_parameters
 import static org.edx.jenkins.dsl.AnalyticsConstants.secure_scm
 
 
-// If you want to configure another table to a Snowpipe, create a config map
-// here and add it to the jobConfigs list.
-Map eventSnowpipeConfig = [
-    NAME: 'refresh-snowpipe-event-loader',
-    PIPE_NAME: 'snowpipe_event_loader',
-    TABLE_NAME: 'json_event_records',
-    DELAY: 120,
-    LIMIT: 7
-]
-List jobConfigs = [
-    eventSnowpipeConfig
-]
 
 class SnowflakeRefreshSnowpipe {
+
     public static def job = { dslFactory, allVars ->
+
+        // If you want to configure another table to a Snowpipe, create a config map
+        // here and add it to the jobConfigs list.
+        Map eventSnowpipeConfig = [
+            NAME: 'refresh-snowpipe-event-loader',
+            PIPE_NAME: 'snowpipe_event_loader',
+            TABLE_NAME: 'json_event_records',
+            DELAY: '120',
+            LIMIT: '7'
+        ]
+        List jobConfigs = [
+            eventSnowpipeConfig
+        ]
 
         jobConfigs.each { jobConfig ->
 

--- a/dataeng/jobs/createJobs.groovy
+++ b/dataeng/jobs/createJobs.groovy
@@ -51,6 +51,7 @@ import static analytics.SnowflakeReplicaImport.job as SnowflakeReplicaImportJob
 import static analytics.LoadPaypalCaseReportToVertica.job as PayPalCaseReportLoadJob
 import static analytics.WarehouseTransforms.job as WarehouseTransformsJob
 import static analytics.DBTSourceFreshness.job as DBTSourceFreshnessJob
+import static analytics.SnowflakeRefreshSnowpipe.job as SnowflakeRefreshSnowpipeJob
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.DEFAULT_VIEW
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.error.YAMLException
@@ -125,6 +126,7 @@ def taskMap = [
     LOAD_PAYPAL_CASEREPORT_TO_VERTICA_JOB: PayPalCaseReportLoadJob,
     WAREHOUSE_TRANSFORMS_JOB: WarehouseTransformsJob,
     DBT_SOURCE_FRESHNESS_JOB: DBTSourceFreshnessJob,
+    SNOWFLAKE_REFRESH_SNOWPIPE_JOB: SnowflakeRefreshSnowpipeJob,
 ]
 
 for (task in taskMap) {
@@ -184,6 +186,7 @@ listView('Warehouse') {
         name('generate-warehouse-docs')
         name('affiliate-window')
         name('snowflake-schema-builder')
+        regex('refresh-snowpipe-.*')
         regex('.+read-replica-import|load-.+|vertica-schema-to.+|.*sql-script.*')
     }
     columns DEFAULT_VIEW.call()


### PR DESCRIPTION
fixed 2 things:
1) I needed to add the dsl job to the seed job so that it would actually get run
2) When I tried to seed it, I got a cryptic duplicate class exception. It turns out that if groovy detects any code outside of the actual class definition, it automatically generates a wrapper class around it, pulling from the filename. In my case, since the file and class that I defined had the same name, this newly created class came into conflict. The fix was just to move this classless code inside.