### PR TITLE
make the e2e pipeline job do a shallow git clone

### DIFF
--- a/platform/jobs/edxEndToEndTestsJob.groovy
+++ b/platform/jobs/edxEndToEndTestsJob.groovy
@@ -238,6 +238,9 @@ jobConfigs.each { jobConfig ->
                 if (jobConfig.testSuite == 'microsites') {
                     extensions {
                         relativeTargetDirectory('edx-e2e-tests')
+                        if (jobConfig.trigger == 'pipeline') {
+                            shallow(true)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
the edx-e2e-tests job has been failing recently with the following message: 
```
00:00:00.867 hudson.plugins.git.GitException: Command "git checkout -f 32a07adaf177812bc32516d3b6e6b0fedd02ab7c" returned status code 128:
00:00:00.868 stdout: 
00:00:00.868 stderr: fatal: reference is not a tree: 32a07adaf177812bc32516d3b6e6b0fedd02ab7c
```
Normally this job should only run on the master branch of the edx-e2e-tests repo, but it was manually triggered with a branch. The branch was then force pushed to, which led to the commit hash mentioned in the error message above dissappearing from git history. This simple change has confused the Jenkins Git plugin enough that even if you try to build master, it does a complete fetch and fails when it encounters this conflict in the git history.

I *think* if we do a shallow clone it will only look for the branch we specify in the scm section of the job.