### PR TITLE
Don't restrict ORA auto_auth

### DIFF
--- a/ora2/resources/enable-auto-auth.sh
+++ b/ora2/resources/enable-auto-auth.sh
@@ -1,2 +1,2 @@
 # Enable auto auth for a sandbox
-ssh ${SSH_USER}@${SANDBOX_HOST} -o StrictHostKeyChecking=no "sudo sed -i 's/AUTOMATIC_AUTH_FOR_TESTING: false/AUTOMATIC_AUTH_FOR_TESTING: true/' /edx/etc/studio.yml && sudo sed -i 's/AUTOMATIC_AUTH_FOR_TESTING: false/AUTOMATIC_AUTH_FOR_TESTING: true/' /edx/etc/lms.yml && sudo /edx/bin/supervisorctl restart lms cms"
+ssh ${SSH_USER}@${SANDBOX_HOST} -o StrictHostKeyChecking=no "sudo sed -i 's/AUTOMATIC_AUTH_FOR_TESTING: false/AUTOMATIC_AUTH_FOR_TESTING: true\n    RESTRICT_AUTOMATIC_AUTH: false/' /edx/etc/studio.yml && sudo sed -i 's/AUTOMATIC_AUTH_FOR_TESTING: false/AUTOMATIC_AUTH_FOR_TESTING: true\n    RESTRICT_AUTOMATIC_AUTH: false/' /edx/etc/lms.yml && sudo /edx/bin/supervisorctl restart lms cms"


### PR DESCRIPTION
Toggle the RESTRICT_AUTOMATIC_AUTH feature to false, so that bok choy tests can login an existing user (previously created with auto_auth) via the auto_auth endpoint.