### PR TITLE
add jobs for expiring snowflake passwords

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeExpirePasswords.groovy
+++ b/dataeng/jobs/analytics/SnowflakeExpirePasswords.groovy
@@ -1,0 +1,86 @@
+package analytics
+
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_log_rotator
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_publishers
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_triggers
+import static org.edx.jenkins.dsl.AnalyticsConstants.secure_scm
+import static org.edx.jenkins.dsl.AnalyticsConstants.secure_scm_parameters
+
+
+class SnowflakeExpirePasswords {
+
+    public static def job = { dslFactory, allVars ->
+
+        Map SnowflakeExpirePasswordsQuarterlyConfig = [
+            NAME: 'expire-snowflake-passwords-quarterly',
+            MANUAL: false,
+            SCRIPT_TO_RUN: 'dataeng/resources/snowflake-expire-passwords.sh'
+        ]
+        Map SnowflakeExpirePasswordsManuallyConfig = [
+            NAME: 'expire-snowflake-passwords-manually',
+            MANUAL: true,
+            SCRIPT_TO_RUN: 'dataeng/resources/snowflake-expire-individual-password.sh'
+        ]
+        List jobConfigs = [
+            SnowflakeExpirePasswordsQuarterlyConfig,
+            SnowflakeExpirePasswordsManuallyConfig
+        ]
+
+        jobConfigs.each { jobConfig ->
+
+            dslFactory.job(jobConfig['NAME']) {
+
+                logRotator common_log_rotator(allVars)
+                parameters secure_scm_parameters(allVars)
+                parameters {
+                    stringParam('ANALYTICS_TOOLS_URL', allVars.get('ANALYTICS_TOOLS_URL'), 'URL for the analytics tools repo.')
+                    stringParam('ANALYTICS_TOOLS_BRANCH', allVars.get('ANALYTICS_TOOLS_BRANCH'), 'Branch of analytics tools repo to use.')
+                    if (jobConfig['MANUAL']) {
+                        stringParam('USER_TO_EXPIRE', '', 'Snowflake user to mark for password expiration.')
+                    }
+                }
+                environmentVariables {
+                    env('KEY_PATH', allVars.get('KEY_PATH'))
+                    env('PASSPHRASE_PATH', allVars.get('PASSPHRASE_PATH'))
+                    env('USER', allVars.get('USER'))
+                    env('ACCOUNT', allVars.get('ACCOUNT'))
+                }
+                logRotator common_log_rotator(allVars)
+                multiscm secure_scm(allVars) << {
+                    git {
+                        remote {
+                            url('$ANALYTICS_TOOLS_URL')
+                            branch('$ANALYTICS_TOOLS_BRANCH')
+                            credentials('1')
+                        }
+                        extensions {
+                            relativeTargetDirectory('analytics-tools')
+                            pruneBranches()
+                            cleanAfterCheckout()
+                        }
+                    }
+                }
+                if (!jobConfig['MANUAL']) {
+                    // Keep this job disabled until January
+                    disabled(true)
+                    triggers common_triggers(allVars)
+                }
+                wrappers {
+                    timestamps()
+                }
+                publishers common_publishers(allVars)
+                steps {
+
+                    virtualenv {
+                        pythonName('PYTHON_3.7')
+                        nature("shell")
+                        systemSitePackages(false)
+                        command(
+                            dslFactory.readFileFromWorkspace(jobConfig['SCRIPT_TO_RUN'])
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dataeng/jobs/createJobs.groovy
+++ b/dataeng/jobs/createJobs.groovy
@@ -53,6 +53,7 @@ import static analytics.WarehouseTransforms.job as WarehouseTransformsJob
 import static analytics.DBTSourceFreshness.job as DBTSourceFreshnessJob
 import static analytics.SnowflakeRefreshSnowpipe.job as SnowflakeRefreshSnowpipeJob
 import static analytics.ExpireVerticaPassword.job as ExpireVerticaPasswordJob
+import static analytics.SnowflakeExpirePasswords.job as SnowflakeExpirePasswordsJob
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.DEFAULT_VIEW
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.error.YAMLException
@@ -129,6 +130,7 @@ def taskMap = [
     DBT_SOURCE_FRESHNESS_JOB: DBTSourceFreshnessJob,
     SNOWFLAKE_REFRESH_SNOWPIPE_JOB: SnowflakeRefreshSnowpipeJob,
     EXPIRE_VERTICA_PASSWORD_JOB: ExpireVerticaPasswordJob,
+    SNOWFLAKE_EXPIRE_PASSWORDS_JOB: SnowflakeExpirePasswordsJob,
 ]
 
 for (task in taskMap) {

--- a/dataeng/resources/snowflake-expire-individual-password.sh
+++ b/dataeng/resources/snowflake-expire-individual-password.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -ex
+
+# Setup
+cd $WORKSPACE/analytics-tools/snowflake
+make requirements
+
+python expire_user_passwords.py \
+    --key_path $KEY_PATH \
+    --passphrase_path $PASSPHRASE_PATH \
+    --automation_user $USER \
+    --account $ACCOUNT \
+    --user_to_expire $USER_TO_EXPIRE

--- a/dataeng/resources/snowflake-expire-passwords.sh
+++ b/dataeng/resources/snowflake-expire-passwords.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ex
+
+# Setup
+cd $WORKSPACE/analytics-tools/snowflake
+make requirements
+
+python expire_user_passwords.py \
+    --key_path $KEY_PATH \
+    --passphrase_path $PASSPHRASE_PATH \
+    --automation_user $USER \
+    --account $ACCOUNT


### PR DESCRIPTION
This adds the DSL to create 2 jobs that run the `expire_user_passwords.py` script defined in https://github.com/edx/analytics-tools/pull/25:
* expire-snowflake-passwords-quarterly (an automated job)
* expire-snowflake-passwords-manually (a manual job for fixing issues when the first job fails)