### PR TITLE
Remove edx-platform Py2 jobs

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -36,7 +36,8 @@ Map publicJobConfig = [
     workerLabel: 'jenkins-worker',
     context: 'jenkins/a11y',
     refSpec : '+refs/heads/master:refs/remotes/origin/master',
-    defaultBranch : 'master'
+    defaultBranch : 'master',
+    pythonVersion: '3.5',
 ]
 
 Map privateJobConfig = [
@@ -46,18 +47,8 @@ Map privateJobConfig = [
     workerLabel: 'jenkins-worker',
     context: 'jenkins/a11y',
     refSpec : '+refs/heads/security-release:refs/remotes/origin/security-release',
-    defaultBranch : 'security-release'
-]
-
-Map python3JobConfig = [
-    open : true,
-    jobName : 'edx-platform-python3-accessibility-master',
-    repoName : 'edx-platform',
-    workerLabel: 'jenkins-worker',
-    context: 'jenkins/python3.5/a11y',
-    refSpec : '+refs/heads/master:refs/remotes/origin/master',
-    defaultBranch : 'master',
-    toxEnv: 'py35-django111'
+    defaultBranch : 'security-release',
+    pythonVersion: '3.5',
 ]
 
 Map ironwoodJobConfig = [
@@ -73,7 +64,6 @@ Map ironwoodJobConfig = [
 List jobConfigs = [
     publicJobConfig,
     privateJobConfig,
-    python3JobConfig,
     ironwoodJobConfig
 ]
 
@@ -90,6 +80,7 @@ jobConfigs.each { jobConfig ->
         logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
         concurrentBuild()
         environmentVariables {
+            env('PYTHON_VERSION', jobConfig.pythonVersion),
             env('TOX_ENV', jobConfig.toxEnv)
         }
         parameters {
@@ -145,18 +136,10 @@ jobConfigs.each { jobConfig ->
             shell("cd ${jobConfig.repoName}; TEST_SUITE=a11y bash scripts/accessibility-tests.sh")
         }
         publishers {
-            publishHtml {
-               report("${jobConfig.repoName}/reports/pa11ycrawler/html") {
-               reportName('HTML Report')
-               allowMissing()
-               keepAll()
-               }
-            }
             archiveArtifacts {
                pattern(JENKINS_PUBLIC_JUNIT_REPORTS)
                pattern('edx-platform*/test_root/log/**/*.png')
                pattern('edx-platform*/test_root/log/**/*.log')
-               pattern('edx-platform*/reports/pa11ycrawler/**/*')
                allowEmpty()
                defaultExcludes()
             }

--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -80,7 +80,7 @@ jobConfigs.each { jobConfig ->
         logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
         concurrentBuild()
         environmentVariables {
-            env('PYTHON_VERSION', jobConfig.pythonVersion),
+            env('PYTHON_VERSION', jobConfig.pythonVersion)
             env('TOX_ENV', jobConfig.toxEnv)
         }
         parameters {

--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -47,7 +47,8 @@ Map publicJobConfig = [
     workerLabel: 'js-worker',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/a11y',
-    triggerPhrase: /.*jenkins\W+run\W+a11y.*/
+    triggerPhrase: /.*jenkins\W+run\W+a11y.*/,
+    pythonVersion: '3.5',
 ]
 
 Map privateJobConfig = [

--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -102,7 +102,7 @@ jobConfigs.each { jobConfig ->
         logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
         concurrentBuild()
         environmentVariables {
-            env('PYTHON_VERSION', jobConfig.pythonVersion),
+            env('PYTHON_VERSION', jobConfig.pythonVersion)
             env('TOX_ENV', jobConfig.toxEnv)
         }
         parameters {

--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -57,18 +57,8 @@ Map privateJobConfig = [
     workerLabel: 'js-worker',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/a11y',
-    triggerPhrase: /.*jenkins\W+run\W+a11y.*/
-]
-
-Map python3JobConfig = [
-    open : true,
-    jobName : 'edx-platform-python3-accessibility-pr',
-    repoName : 'edx-platform',
-    workerLabel: 'js-worker',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/python3.5/a11y',
-    triggerPhrase: /.*jenkins\W+run\W+py35-django111\W+a11y.*/,
-    toxEnv: 'py35-django111'
+    triggerPhrase: /.*jenkins\W+run\W+a11y.*/,
+    pythonVersion: '3.5',
 ]
 
 Map publicIronwoodJobConfig = [
@@ -94,7 +84,6 @@ Map privateIronwoodJobConfig = [
 List jobConfigs = [
     publicJobConfig,
     privateJobConfig,
-    python3JobConfig,
     publicIronwoodJobConfig,
     privateIronwoodJobConfig
 ]
@@ -113,6 +102,7 @@ jobConfigs.each { jobConfig ->
         logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
         concurrentBuild()
         environmentVariables {
+            env('PYTHON_VERSION', jobConfig.pythonVersion),
             env('TOX_ENV', jobConfig.toxEnv)
         }
         parameters {
@@ -179,18 +169,10 @@ jobConfigs.each { jobConfig ->
            shell("cd ${jobConfig.repoName}; TEST_SUITE=a11y bash scripts/accessibility-tests.sh")
        }
        publishers {
-           publishHtml {
-               report("${jobConfig.repoName}/reports/pa11ycrawler/html") {
-               reportName('HTML Report')
-               allowMissing()
-               keepAll()
-               }
-           }
            archiveArtifacts {
                pattern(JENKINS_PUBLIC_JUNIT_REPORTS)
                pattern('edx-platform*/test_root/log/**/*.png')
                pattern('edx-platform*/test_root/log/**/*.log')
-               pattern('edx-platform*/reports/pa11ycrawler/**/*')
                allowEmpty()
                defaultExcludes()
            }

--- a/platform/jobs/edxPlatformJsMaster.groovy
+++ b/platform/jobs/edxPlatformJsMaster.groovy
@@ -39,7 +39,8 @@ Map publicJobConfig = [
     workerLabel: 'js-worker',
     context: 'jenkins/js',
     refSpec : '+refs/heads/master:refs/remotes/origin/master',
-    defaultBranch : 'master'
+    defaultBranch : 'master',
+    pythonVersion: '3.5',
 ]
 
 Map privateJobConfig = [
@@ -49,18 +50,8 @@ Map privateJobConfig = [
     workerLabel: 'js-worker',
     context: 'jenkins/js',
     refSpec : '+refs/heads/security-release:refs/remotes/origin/security-release',
-    defaultBranch : 'security-release'
-]
-
-Map python3JobConfig = [
-    open : true,
-    jobName : 'edx-platform-python3-js-master',
-    repoName: 'edx-platform',
-    workerLabel: 'js-worker',
-    context: 'jenkins/python3.5/js',
-    refSpec : '+refs/heads/master:refs/remotes/origin/master',
-    defaultBranch : 'master',
-    toxEnv: 'py35-django111'
+    defaultBranch : 'security-release',
+    pythonVersion: '3.5',
 ]
 
 Map ironwoodJobConfig = [
@@ -76,7 +67,6 @@ Map ironwoodJobConfig = [
 List jobConfigs = [
     publicJobConfig,
     privateJobConfig,
-    python3JobConfig,
     ironwoodJobConfig
 ]
 
@@ -95,6 +85,7 @@ jobConfigs.each { jobConfig ->
         logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
         concurrentBuild()
         environmentVariables {
+            env('PYTHON_VERSION', jobConfig.pythonVersion),
             env('TOX_ENV', jobConfig.toxEnv)
         }
         parameters {

--- a/platform/jobs/edxPlatformJsMaster.groovy
+++ b/platform/jobs/edxPlatformJsMaster.groovy
@@ -85,7 +85,7 @@ jobConfigs.each { jobConfig ->
         logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
         concurrentBuild()
         environmentVariables {
-            env('PYTHON_VERSION', jobConfig.pythonVersion),
+            env('PYTHON_VERSION', jobConfig.pythonVersion)
             env('TOX_ENV', jobConfig.toxEnv)
         }
         parameters {

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -56,7 +56,8 @@ Map publicJobConfig = [
     workerLabel: 'js-worker',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/js',
-    triggerPhrase: /.*jenkins\W+run\W+js.*/
+    triggerPhrase: /.*jenkins\W+run\W+js.*/,
+    pythonVersion: '3.5',
 ]
 
 Map privateJobConfig = [
@@ -66,18 +67,8 @@ Map privateJobConfig = [
     workerLabel: 'js-worker',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/js',
-    triggerPhrase: /.*jenkins\W+run\W+js.*/
-]
-
-Map python3JobConfig = [
-    open : true,
-    jobName : 'edx-platform-python3-js-pr',
-    repoName: 'edx-platform',
-    workerLabel: 'js-worker',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/python3.5/js',
-    triggerPhrase: /.*jenkins\W+run\W+py35-django111\W+js.*/,
-    toxEnv: 'py35-django111'
+    triggerPhrase: /.*jenkins\W+run\W+js.*/,
+    pythonVersion: '3.5',
 ]
 
 Map publicIronwoodJobConfig = [
@@ -103,7 +94,6 @@ Map privateIronwoodJobConfig = [
 List jobConfigs = [
     publicJobConfig,
     privateJobConfig,
-    python3JobConfig,
     publicIronwoodJobConfig,
     privateIronwoodJobConfig
 ]
@@ -123,6 +113,7 @@ jobConfigs.each { jobConfig ->
         logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
         concurrentBuild()
         environmentVariables {
+            env('PYTHON_VERSION', jobConfig.pythonVersion),
             env('TOX_ENV', jobConfig.toxEnv)
         }
         parameters {

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -113,7 +113,7 @@ jobConfigs.each { jobConfig ->
         logRotator JENKINS_PUBLIC_LOG_ROTATOR(7)
         concurrentBuild()
         environmentVariables {
-            env('PYTHON_VERSION', jobConfig.pythonVersion),
+            env('PYTHON_VERSION', jobConfig.pythonVersion)
             env('TOX_ENV', jobConfig.toxEnv)
         }
         parameters {

--- a/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
@@ -11,7 +11,7 @@ Map publicBokchoyJobConfig = [
     jenkinsFileName: 'bokchoy',
     branch: 'master',
     context: 'jenkins/bokchoy',
-    pythonVersion: '2.7',
+    pythonVersion: '3.5',
 ]
 
 Map privateBokchoyJobConfig = [
@@ -22,19 +22,7 @@ Map privateBokchoyJobConfig = [
     jenkinsFileName: 'bokchoy',
     branch: 'security-release',
     context: 'jenkins/bokchoy',
-    pythonVersion: '2.7',
-]
-
-Map publicBokchoyPython3JobConfig = [
-    open : true,
-    jobName : 'edx-platform-python3-bokchoy-pipeline-master',
-    repoName: 'edx-platform',
-    jenkinsFileDir: 'scripts/Jenkinsfiles',
-    jenkinsFileName: 'bokchoy',
-    branch: 'master',
-    context: 'jenkins/py35-django111/bokchoy',
     pythonVersion: '3.5',
-    toxEnv: 'py35-django111',
 ]
 
 Map ironwoodBokchoyJobConfig = [
@@ -67,7 +55,7 @@ Map publicPythonJobConfig = [
     jenkinsFileName: 'python',
     branch: 'master',
     context: 'jenkins/python',
-    pythonVersion: '2.7',
+    pythonVersion: '3.5',
 ]
 
 Map privatePythonJobConfig = [
@@ -78,19 +66,7 @@ Map privatePythonJobConfig = [
     jenkinsFileName: 'python',
     branch: 'security-release',
     context: 'jenkins/python',
-    pythonVersion: '2.7',
-]
-
-Map publicPythonPython3JobConfig = [
-    open: true,
-    jobName: 'edx-platform-python3-python-pipeline-master',
-    repoName: 'edx-platform',
-    jenkinsFileDir: 'scripts/Jenkinsfiles',
-    jenkinsFileName: 'python',
-    branch: 'master',
-    context: 'jenkins/py35-django111/python',
     pythonVersion: '3.5',
-    toxEnv: 'py35-django111',
 ]
 
 Map ironwoodPythonJobConfig = [
@@ -112,7 +88,7 @@ Map publicQualityJobConfig = [
     jenkinsFileName: 'quality',
     branch: 'master',
     context: 'jenkins/quality',
-    pythonVersion: '2.7',
+    pythonVersion: '3.5',
 ]
 
 Map privateQualityJobConfig = [
@@ -123,19 +99,7 @@ Map privateQualityJobConfig = [
     jenkinsFileName: 'quality',
     branch: 'security-release',
     context: 'jenkins/quality',
-    pythonVersion: '2.7',
-]
-
-Map publicQualityPython3JobConfig = [
-    open : true,
-    jobName : 'edx-platform-python3-quality-pipeline-master',
-    repoName: 'edx-platform',
-    jenkinsFileDir: 'scripts/Jenkinsfiles',
-    jenkinsFileName: 'quality',
-    branch: 'master',
-    context: 'jenkins/py35-django111/quality',
     pythonVersion: '3.5',
-    toxEnv: 'py35-django111',
 ]
 
 Map ironwoodQualityJobConfig = [
@@ -152,16 +116,13 @@ Map ironwoodQualityJobConfig = [
 List jobConfigs = [
     publicBokchoyJobConfig,
     privateBokchoyJobConfig,
-    publicBokchoyPython3JobConfig,
     ironwoodBokchoyJobConfig,
     ironwoodLettuceJobConfig,
     publicPythonJobConfig,
     privatePythonJobConfig,
-    publicPythonPython3JobConfig,
     ironwoodPythonJobConfig,
     publicQualityJobConfig,
     privateQualityJobConfig,
-    publicQualityPython3JobConfig,
     ironwoodQualityJobConfig
 ]
 

--- a/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
@@ -36,7 +36,7 @@ Map publicBokchoyJobConfig = [
     triggerPhrase: /.*jenkins\W+run\W+bokchoy.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'bokchoy',
-    pythonVersion: '2.7',
+    pythonVersion: '3.5',
 ]
 
 Map privateBokchoyJobConfig = [
@@ -49,20 +49,6 @@ Map privateBokchoyJobConfig = [
     triggerPhrase: /.*jenkins\W+run\W+bokchoy.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'bokchoy',
-    pythonVersion: '2.7',
-]
-
-Map publicBokchoyPython3JobConfig = [
-    open : true,
-    jobName : 'edx-platform-python3-bokchoy-pipeline-pr',
-    repoName: 'edx-platform',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/py35-django111/bokchoy',
-    onlyTriggerPhrase: false,
-    triggerPhrase: /.*jenkins\W+run\W+py35-django111\W+bokchoy.*/,
-    jenkinsFileDir: 'scripts/Jenkinsfiles',
-    jenkinsFileName: 'bokchoy',
-    toxEnv: 'py35-django111',
     pythonVersion: '3.5',
 ]
 
@@ -128,7 +114,7 @@ Map publicPythonJobConfig = [
     triggerPhrase: /.*jenkins\W+run\W+python.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'python',
-    pythonVersion: '2.7',
+    pythonVersion: '3.5',
 ]
 
 Map privatePythonJobConfig = [
@@ -139,20 +125,6 @@ Map privatePythonJobConfig = [
     context: 'jenkins/python',
     onlyTriggerPhrase: false,
     triggerPhrase: /.*jenkins\W+run\W+python.*/,
-    jenkinsFileDir: 'scripts/Jenkinsfiles',
-    jenkinsFileName: 'python',
-    pythonVersion: '2.7',
-]
-
-Map publicPythonPython3JobConfig = [
-    open: true,
-    jobName: 'edx-platform-python3-python-pipeline-pr',
-    repoName: 'edx-platform',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/py35-django111/python',
-    onlyTriggerPhrase: false,
-    triggerPhrase: /.*jenkins\W+run\W+py35-django111\W+python.*/,
-    toxEnv: 'py35-django111',
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'python',
     pythonVersion: '3.5',
@@ -194,7 +166,7 @@ Map publicQualityJobConfig = [
     triggerPhrase: /.*jenkins\W+run\W+quality.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'quality',
-    pythonVersion: '2.7',
+    pythonVersion: '3.5',
 ]
 
 Map privateQualityJobConfig = [
@@ -205,20 +177,6 @@ Map privateQualityJobConfig = [
     context: 'jenkins/quality',
     onlyTriggerPhrase: false,
     triggerPhrase: /.*jenkins\W+run\W+quality.*/,
-    jenkinsFileDir: 'scripts/Jenkinsfiles',
-    jenkinsFileName: 'quality',
-    pythonVersion: '2.7',
-]
-
-Map publicQualityPython3JobConfig = [
-    open : true,
-    jobName : 'edx-platform-python3-quality-pipeline-pr',
-    repoName: 'edx-platform',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/py35-django111/quality',
-    onlyTriggerPhrase: false,
-    triggerPhrase: /.*jenkins\W+run\W+py35-django111\W+quality.*/,
-    toxEnv: 'py35-django111',
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'quality',
     pythonVersion: '3.5',
@@ -253,19 +211,16 @@ Map privateQualityIronwoodJobConfig = [
 List jobConfigs = [
     publicBokchoyJobConfig,
     privateBokchoyJobConfig,
-    publicBokchoyPython3JobConfig,
     publicBokchoyIronwoodJobConfig,
     privateBokchoyIronwoodJobConfig,
     publicLettuceIronwoodJobConfig,
     privateLettuceIronwoodJobConfig,
     publicPythonJobConfig,
     privatePythonJobConfig,
-    publicPythonPython3JobConfig,
     publicPythonIronwoodJobConfig,
     privatePythonIronwoodJobConfig,
     publicQualityJobConfig,
     privateQualityJobConfig,
-    publicQualityPython3JobConfig,
     publicQualityIronwoodJobConfig,
     privateQualityIronwoodJobConfig
 ]

--- a/src/test/groovy/platform/edxPlatformMasterSpec.groovy
+++ b/src/test/groovy/platform/edxPlatformMasterSpec.groovy
@@ -44,7 +44,7 @@ class edxPlatformMasterJobSpec extends Specification {
 
         where:
         dslFile                                   | numJobs
-        'edxPlatformAccessibilityMaster.groovy'   | 4
-        'edxPlatformJsMaster.groovy'              | 4
+        'edxPlatformAccessibilityMaster.groovy'   | 3
+        'edxPlatformJsMaster.groovy'              | 3
     }
 }

--- a/src/test/groovy/platform/pipelines/edxPlatformPipelinesMasterSpec.groovy
+++ b/src/test/groovy/platform/pipelines/edxPlatformPipelinesMasterSpec.groovy
@@ -44,6 +44,6 @@ class edxPlatformPipelinesMasterJobSpec extends Specification {
 
         where:
         dslFile                                   | numJobs
-        'edxPlatformPipelineMaster.groovy'        | 13
+        'edxPlatformPipelineMaster.groovy'        | 10
     }
 }


### PR DESCRIPTION
Stop running the edx-platform tests under Python 2 on master and PRs against it, now that edx-platform is running on Python 3 in production.  The reduction in test job count should help reduce the number of PRs that hit problems with flaky tests, and switching the Python 3 jobs from tox to run directly in a Python 3.5 virtualenv should also somewhat reduce the time to feedback.  The Ironwood jobs still run under Python 2.

Also removed some obsolete artifact handling code related to pa11ycrawler, which we don't run anymore.