### PR TITLE
Switch edx-platform jobs from 2.7 to 3.5

### DIFF
--- a/testeng/jobs/bokchoyDbCacheUploader.groovy
+++ b/testeng/jobs/bokchoyDbCacheUploader.groovy
@@ -119,6 +119,7 @@ secretMap.each { jobConfigs ->
 
         environmentVariables {
             env('AWS_DEFAULT_REGION', jobConfig['region'])
+            env('PYTHON_VERSION', '3.5')
         }
 
         wrappers {

--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -114,7 +114,7 @@ Map edxOrganizations = [
 Map edxPlatform = [
     org: 'edx',
     repoName: 'edx-platform',
-    pythonVersion: '2.7',
+    pythonVersion: '3.5',
     cronValue: '@daily',
     githubUserReviewers: [],
     githubTeamReviewers: ['platform-core', 'testeng'],


### PR DESCRIPTION
Use Python 3.5 instead of 2.7 for running `make upgrade` and updating the bok-choy database cache in edx-platform.