### PR TITLE
Add program reports job

### DIFF
--- a/dataeng/jobs/analytics/ProgramEnrollmentReports.groovy
+++ b/dataeng/jobs/analytics/ProgramEnrollmentReports.groovy
@@ -1,0 +1,38 @@
+
+package analytics
+
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_multiscm
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_parameters
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_log_rotator
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_wrappers
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_publishers
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_triggers
+
+
+
+class ProgramReports {
+
+    public static def job = { dslFactory, allVars ->
+
+        dslFactory.job('program-enrollment-reports') {
+
+            // disabled until downstream reporting work is complete
+            disabled(true)
+
+            logRotator common_log_rotator(allVars)
+            parameters common_parameters(allVars)
+            parameters {
+                stringParam('OUTPUT_ROOT', env_config.get('OUTPUT_ROOT'), 'Report output location')
+                stringParam('VERTICA_CREDENTIALS', allVars.get('VERTICA_CREDENTIALS')), 'The path to the Vertica credentials file.')
+            }
+ 
+            multiscm common_multiscm(allVars)
+            triggers common_triggers(allVars)
+            wrappers common_wrappers(allVars)
+            publishers common_publishers(allVars)
+            steps {
+                shell(dslFactory.readFileFromWorkspace('dataeng/resources/program-enrollment-reports.sh'))
+            }
+        }
+    }
+}

--- a/dataeng/jobs/analytics/ProgramEnrollmentReports.groovy
+++ b/dataeng/jobs/analytics/ProgramEnrollmentReports.groovy
@@ -1,4 +1,3 @@
-
 package analytics
 
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_multiscm

--- a/dataeng/jobs/createJobs.groovy
+++ b/dataeng/jobs/createJobs.groovy
@@ -54,6 +54,7 @@ import static analytics.DBTSourceFreshness.job as DBTSourceFreshnessJob
 import static analytics.SnowflakeRefreshSnowpipe.job as SnowflakeRefreshSnowpipeJob
 import static analytics.ExpireVerticaPassword.job as ExpireVerticaPasswordJob
 import static analytics.SnowflakeExpirePasswords.job as SnowflakeExpirePasswordsJob
+import static analytics.ProgramEnrollmentReports.job as ProgramEnrollmentReportsJob
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.DEFAULT_VIEW
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.error.YAMLException
@@ -131,6 +132,7 @@ def taskMap = [
     SNOWFLAKE_REFRESH_SNOWPIPE_JOB: SnowflakeRefreshSnowpipeJob,
     EXPIRE_VERTICA_PASSWORD_JOB: ExpireVerticaPasswordJob,
     SNOWFLAKE_EXPIRE_PASSWORDS_JOB: SnowflakeExpirePasswordsJob,
+    PROGRAM_ENROLLMENT_REPORTS_JOB: ProgramEnrollmentReportsJob,
 ]
 
 for (task in taskMap) {

--- a/dataeng/resources/program-enrollment-reports.sh
+++ b/dataeng/resources/program-enrollment-reports.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if [ -z "$NUM_REDUCE_TASKS" ]; then
+    NUM_REDUCE_TASKS=$(( $NUM_TASK_CAPACITY*2 ))
+fi
+
+env
+
+${WORKSPACE}/analytics-configuration/automation/run-automated-task.sh \
+    BuildProgramReportsTask --local-scheduler \
+    --vertica-warehouse-name warehouse \
+    --vertica-credentials $VERTICA_CREDENTIALS \
+    --n-reduce-tasks $NUM_REDUCE_TASKS \
+    --overwrite \
+    --output-root $OUTPUT_ROOT \
+    $EXTRA_ARGS
+


### PR DESCRIPTION
@edx/masters-devs 

Adds DSL to generate a job to run the program reporting pipeline task here: https://github.com/edx/edx-analytics-pipeline/blob/master/edx/analytics/tasks/programs/program_reports.py

one open question on this, it appears there is a default env variable for the trigger cron.  I'm not sure where that is defined yet.