### PR TITLE
Switch cookiecutter-django-app upgrades to 3.5

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -34,7 +34,7 @@ Map completion = [
 Map cookiecutterDjangoApp = [
     org: 'edx',
     repoName: 'cookiecutter-django-app',
-    pythonVersion: '2.7',
+    pythonVersion: '3.5',
     cronValue: '@weekly',
     githubUserReviewers: [],
     githubTeamReviewers: ['testeng'],


### PR DESCRIPTION
We've dropped support for Python 2.7 in cookiecutter-django-app, switch to 3.5 for running `make upgrade`.