### PR TITLE
Update all User Retirement jobs to use Python 3

### DIFF
--- a/platform/jobs/RetirementJobs.groovy
+++ b/platform/jobs/RetirementJobs.groovy
@@ -174,6 +174,7 @@ job('user-retirement-driver') {
             name('user-retirement-driver')
             nature('shell')
             command(readFileFromWorkspace('platform/resources/user-retirement-driver.sh'))
+            pythonName('PYTHON_3.5')
         }
     }
 
@@ -309,6 +310,7 @@ job('user-retirement-collector') {
             name('user-retirement-collector')
             nature('shell')
             command(readFileFromWorkspace('platform/resources/user-retirement-collector.sh'))
+            pythonName('PYTHON_3.5')
         }
         // This takes as input the properties files created in the previous
         // step, and triggers user-retirement-driver jobs per file.
@@ -472,6 +474,7 @@ job('retirement-partner-reporter') {
             name('retirement-partner-reporter')
             nature('shell')
             command(readFileFromWorkspace('platform/resources/retirement-partner-reporter.sh'))
+            pythonName('PYTHON_3.5')
         }
     }
 
@@ -599,6 +602,7 @@ job('retirement-partner-report-cleanup') {
             name('retirement-partner-report-cleanup')
             nature('shell')
             command(readFileFromWorkspace('platform/resources/retirement-partner-report-cleanup.sh'))
+            pythonName('PYTHON_3.5')
         }
     }
 
@@ -722,6 +726,7 @@ job('user-retirement-bulk-status') {
             name('user-retirement-bulk-status')
             nature('shell')
             command(readFileFromWorkspace('platform/resources/user-retirement-bulk-status.sh'))
+            pythonName('PYTHON_3.5')
         }
     }
     publishers {


### PR DESCRIPTION
This is a response to setuptools 45 now requiring python 3. It is easier
to just update these jobs which are already tested under python 3 to
actually run python 3.  It helps that the PYTHON_3.5 tool in
build-jenkins also already exists.