### PR TITLE
Use actual production pipe/table names for tracking event log loading.

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeRefreshSnowpipe.groovy
+++ b/dataeng/jobs/analytics/SnowflakeRefreshSnowpipe.groovy
@@ -19,8 +19,8 @@ class SnowflakeRefreshSnowpipe {
         // here and add it to the jobConfigs list.
         Map eventSnowpipeConfig = [
             NAME: 'refresh-snowpipe-event-loader',
-            PIPE_NAME: 'snowpipe_event_loader',
-            TABLE_NAME: 'json_event_records',
+            PIPE_NAME: 'prod.events.prod_edx_snowpipe_event_loader',
+            TABLE_NAME: 'prod.events.tracking_log_events_raw',
             DELAY: '120',
             LIMIT: '7'
         ]


### PR DESCRIPTION
https://openedx.atlassian.net/browse/DE-1783

The names have changed since initial implementation. This PR inserts the actual names.