### PR TITLE
download dbt dependencies in warehouse transforms script

### DIFF
--- a/dataeng/resources/warehouse-transforms.sh
+++ b/dataeng/resources/warehouse-transforms.sh
@@ -10,6 +10,7 @@ pip install -r tools/dbt_schema_builder/requirements.txt
 cd $WORKSPACE/warehouse-transforms/warehouse_transforms_project
 
 dbt clean
+dbt deps
 dbt seed --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
 dbt run --models tag:$MODEL_TAG --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
 dbt test --models tag:$MODEL_TAG --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/


### PR DESCRIPTION
Call `dbt deps` (https://docs.getdbt.com/docs/deps) to install dbt packages after running a `clean` command but before invoking any real dbt commands. I did a quick scan of the other jobs we have that invoke dbt, and this seems to be the only one that would need access to packages (the others were the schema-builder and dbt-source-freshness)