### PR TITLE
Add edx-platform Django 2.x PR jobs BOM-1166

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -51,6 +51,45 @@ Map publicJobConfig = [
     pythonVersion: '3.5',
 ]
 
+Map django20JobConfig = [
+    open: true,
+    jobName: 'edx-platform-django-2.0-accessibility-pr',
+    repoName: 'edx-platform',
+    workerLabel: 'js-worker',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/django-2.0/a11y',
+    onlyTriggerPhrase: true,
+    triggerPhrase: /.*jenkins\W+run\W+django20\W+a11y.*/,
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django20',
+]
+
+Map django21JobConfig = [
+    open: true,
+    jobName: 'edx-platform-django-2.1-accessibility-pr',
+    repoName: 'edx-platform',
+    workerLabel: 'js-worker',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/django-2.1/a11y',
+    onlyTriggerPhrase: true,
+    triggerPhrase: /.*jenkins\W+run\W+django21\W+a11y.*/,
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django21',
+]
+
+Map django22JobConfig = [
+    open: true,
+    jobName: 'edx-platform-django-2.2-accessibility-pr',
+    repoName: 'edx-platform',
+    workerLabel: 'js-worker',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/django-2.2/a11y',
+    onlyTriggerPhrase: true,
+    triggerPhrase: /.*jenkins\W+run\W+django22\W+a11y.*/,
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django22',
+]
+
 Map privateJobConfig = [
     open: false,
     jobName: 'edx-platform-accessibility-pr_private',
@@ -84,6 +123,9 @@ Map privateIronwoodJobConfig = [
 
 List jobConfigs = [
     publicJobConfig,
+    django20JobConfig,
+    django21JobConfig,
+    django22JobConfig,
     privateJobConfig,
     publicIronwoodJobConfig,
     privateIronwoodJobConfig
@@ -139,7 +181,7 @@ jobConfigs.each { jobConfig ->
                 admins(ghprbMap['admin'])
                 useGitHubHooks()
                 triggerPhrase(jobConfig.triggerPhrase)
-                if (jobConfig.commentOnly) {
+                if (jobConfig.onlyTriggerPhrase) {
                     onlyTriggerPhrase(true)
                 }
                 userWhitelist(ghprbMap['userWhiteList'])

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -60,6 +60,45 @@ Map publicJobConfig = [
     pythonVersion: '3.5',
 ]
 
+Map django20JobConfig = [
+    open: true,
+    jobName: 'edx-platform-django-2.0-js-pr',
+    repoName: 'edx-platform',
+    workerLabel: 'js-worker',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/django-2.0/js',
+    onlyTriggerPhrase: true,
+    triggerPhrase: /.*jenkins\W+run\W+django20\W+js.*/,
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django20',
+]
+
+Map django21JobConfig = [
+    open: true,
+    jobName: 'edx-platform-django-2.1-js-pr',
+    repoName: 'edx-platform',
+    workerLabel: 'js-worker',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/django-2.1/js',
+    onlyTriggerPhrase: true,
+    triggerPhrase: /.*jenkins\W+run\W+django21\W+js.*/,
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django21',
+]
+
+Map django22JobConfig = [
+    open: true,
+    jobName: 'edx-platform-django-2.2-js-pr',
+    repoName: 'edx-platform',
+    workerLabel: 'js-worker',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/django-2.2/js',
+    onlyTriggerPhrase: true,
+    triggerPhrase: /.*jenkins\W+run\W+django22\W+js.*/,
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django22',
+]
+
 Map privateJobConfig = [
     open: false,
     jobName: 'edx-platform-js-pr_private',
@@ -93,6 +132,9 @@ Map privateIronwoodJobConfig = [
 
 List jobConfigs = [
     publicJobConfig,
+    django20JobConfig,
+    django21JobConfig,
+    django22JobConfig,
     privateJobConfig,
     publicIronwoodJobConfig,
     privateIronwoodJobConfig
@@ -150,7 +192,7 @@ jobConfigs.each { jobConfig ->
                 userWhitelist(ghprbMap['userWhiteList'])
                 orgWhitelist(ghprbMap['orgWhiteList'])
                 triggerPhrase(jobConfig.triggerPhrase)
-                if (jobConfig.commentOnly) {
+                if (jobConfig.onlyTriggerPhrase) {
                     onlyTriggerPhrase(true)
                 }
                 whiteListTargetBranches([jobConfig.whitelistBranchRegex])

--- a/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
@@ -39,6 +39,48 @@ Map publicBokchoyJobConfig = [
     pythonVersion: '3.5',
 ]
 
+Map django20BokchoyJobConfig = [
+    open: true,
+    jobName: 'edx-platform-django-2.0-bokchoy-pipeline-pr',
+    repoName: 'edx-platform',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/django-2.0/bokchoy',
+    onlyTriggerPhrase: true,
+    triggerPhrase: /.*jenkins\W+run\W+django20\W+bokchoy.*/,
+    jenkinsFileDir: 'scripts/Jenkinsfiles',
+    jenkinsFileName: 'bokchoy',
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django20',
+]
+
+Map django21BokchoyJobConfig = [
+    open: true,
+    jobName: 'edx-platform-django-2.1-bokchoy-pipeline-pr',
+    repoName: 'edx-platform',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/django-2.1/bokchoy',
+    onlyTriggerPhrase: true,
+    triggerPhrase: /.*jenkins\W+run\W+django21\W+bokchoy.*/,
+    jenkinsFileDir: 'scripts/Jenkinsfiles',
+    jenkinsFileName: 'bokchoy',
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django21',
+]
+
+Map django22BokchoyJobConfig = [
+    open: true,
+    jobName: 'edx-platform-django-2.2-bokchoy-pipeline-pr',
+    repoName: 'edx-platform',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/django-2.2/bokchoy',
+    onlyTriggerPhrase: true,
+    triggerPhrase: /.*jenkins\W+run\W+django22\W+bokchoy.*/,
+    jenkinsFileDir: 'scripts/Jenkinsfiles',
+    jenkinsFileName: 'bokchoy',
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django22',
+]
+
 Map privateBokchoyJobConfig = [
     open: false,
     jobName: 'edx-platform-bokchoy-pipeline-pr_private',
@@ -117,6 +159,48 @@ Map publicPythonJobConfig = [
     pythonVersion: '3.5',
 ]
 
+Map django20PythonJobConfig = [
+    open: true,
+    jobName: 'edx-platform-django-2.0-python-pipeline-pr',
+    repoName: 'edx-platform',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/django-2.0/python',
+    onlyTriggerPhrase: true,
+    triggerPhrase: /.*jenkins\W+run\W+django20\W+python.*/,
+    jenkinsFileDir: 'scripts/Jenkinsfiles',
+    jenkinsFileName: 'python',
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django20',
+]
+
+Map django21PythonJobConfig = [
+    open: true,
+    jobName: 'edx-platform-django-2.1-python-pipeline-pr',
+    repoName: 'edx-platform',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/django-2.1/python',
+    onlyTriggerPhrase: true,
+    triggerPhrase: /.*jenkins\W+run\W+django21\W+python.*/,
+    jenkinsFileDir: 'scripts/Jenkinsfiles',
+    jenkinsFileName: 'python',
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django21',
+]
+
+Map django22PythonJobConfig = [
+    open: true,
+    jobName: 'edx-platform-django-2.2-python-pipeline-pr',
+    repoName: 'edx-platform',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/django-2.2/python',
+    onlyTriggerPhrase: true,
+    triggerPhrase: /.*jenkins\W+run\W+django22\W+python.*/,
+    jenkinsFileDir: 'scripts/Jenkinsfiles',
+    jenkinsFileName: 'python',
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django22',
+]
+
 Map privatePythonJobConfig = [
     open: false,
     jobName: 'edx-platform-python-pipeline-pr_private',
@@ -169,6 +253,48 @@ Map publicQualityJobConfig = [
     pythonVersion: '3.5',
 ]
 
+Map django20QualityJobConfig = [
+    open: true,
+    jobName: 'edx-platform-django-2.0-quality-pipeline-pr',
+    repoName: 'edx-platform',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/django-2.0/quality',
+    onlyTriggerPhrase: true,
+    triggerPhrase: /.*jenkins\W+run\W+django20\W+quality.*/,
+    jenkinsFileDir: 'scripts/Jenkinsfiles',
+    jenkinsFileName: 'quality',
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django20',
+]
+
+Map django21QualityJobConfig = [
+    open: true,
+    jobName: 'edx-platform-django-2.1-quality-pipeline-pr',
+    repoName: 'edx-platform',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/django-2.1/quality',
+    onlyTriggerPhrase: true,
+    triggerPhrase: /.*jenkins\W+run\W+django21\W+quality.*/,
+    jenkinsFileDir: 'scripts/Jenkinsfiles',
+    jenkinsFileName: 'quality',
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django21',
+]
+
+Map django22QualityJobConfig = [
+    open: true,
+    jobName: 'edx-platform-django-2.2-quality-pipeline-pr',
+    repoName: 'edx-platform',
+    whitelistBranchRegex: /^((?!open-release\/).)*$/,
+    context: 'jenkins/django-2.2/quality',
+    onlyTriggerPhrase: true,
+    triggerPhrase: /.*jenkins\W+run\W+django22\W+quality.*/,
+    jenkinsFileDir: 'scripts/Jenkinsfiles',
+    jenkinsFileName: 'quality',
+    pythonVersion: '3.5',
+    toxEnv: 'py35-django22',
+]
+
 Map privateQualityJobConfig = [
     open: false,
     jobName: 'edx-platform-quality-pipeline-pr_private',
@@ -210,16 +336,25 @@ Map privateQualityIronwoodJobConfig = [
 
 List jobConfigs = [
     publicBokchoyJobConfig,
+    django20BokchoyJobConfig,
+    django21BokchoyJobConfig,
+    django22BokchoyJobConfig,
     privateBokchoyJobConfig,
     publicBokchoyIronwoodJobConfig,
     privateBokchoyIronwoodJobConfig,
     publicLettuceIronwoodJobConfig,
     privateLettuceIronwoodJobConfig,
     publicPythonJobConfig,
+    django20PythonJobConfig,
+    django21PythonJobConfig,
+    django22PythonJobConfig,
     privatePythonJobConfig,
     publicPythonIronwoodJobConfig,
     privatePythonIronwoodJobConfig,
     publicQualityJobConfig,
+    django20QualityJobConfig,
+    django21QualityJobConfig,
+    django22QualityJobConfig,
     privateQualityJobConfig,
     publicQualityIronwoodJobConfig,
     privateQualityIronwoodJobConfig

--- a/platform/views/platformViews.groovy
+++ b/platform/views/platformViews.groovy
@@ -54,3 +54,12 @@ branchList.each { branch ->
     }
 
 }
+
+listView('django-upgrade-pr-tests') {
+    description('jobs used to run tests on pull requests against various ' +
+                'versions of django during the upgrade process')
+    jobs {
+        regex('edx-platform-django-.*-pr')
+    }
+    columns DEFAULT_VIEW.call()
+}


### PR DESCRIPTION
* Add Django 2.0, 2.1, and 2.2 variations to each of the edx-platform PR test jobs
* The new jobs are triggered only by GitHub PR comments for now
* Unified across job types the configuration parameter for specifying that a job is to be triggered only by PR comments
* Created a new tab (view) listing all of the new jobs