### PR TITLE
use same env setup script for both exporter jobs

### DIFF
--- a/dataeng/jobs/analytics/AnalyticsExporter.groovy
+++ b/dataeng/jobs/analytics/AnalyticsExporter.groovy
@@ -9,7 +9,7 @@ class AnalyticsExporter {
             parameters {
                 stringParam('COURSES', '', 'Space separated list of courses to process. E.g. --course=course-v1:BerkleeX+BMPR365_3x+1T2015')
                 stringParam('EXPORTER_BRANCH', 'environment/production', 'Branch from the analytics-exporter repository. For tags use tags/[tag-name].')
-                stringParam('PLATFORM_BRANCH', 'origin/zafft/analytics-exporter-settings-hotfix', 'Branch from the exporter repository. For tags use tags/[tag-name].')
+                stringParam('PLATFORM_BRANCH', 'aed/analytics-exporter-settings-hotfix', 'Branch from the edx-platform repository. For tags use tags/[tag-name].')
                 stringParam('CONFIG_FILENAME', 'course_exporter.yaml', 'Name of configuration file in analytics-secure/analytics-exporter.')
                 stringParam('OUTPUT_BUCKET', '', 'Name of the bucket for the destination of the export data. Can use a path. (eg. export-data/test).')
                 stringParam('NOTIFICATION_EMAILS', '', 'Space separated list of emails to notify in case of failure.')

--- a/dataeng/jobs/analytics/AnalyticsExporter.groovy
+++ b/dataeng/jobs/analytics/AnalyticsExporter.groovy
@@ -61,7 +61,7 @@ class AnalyticsExporter {
                 virtualenv {
                     nature("shell")
                     command(
-                        dslFactory.readFileFromWorkspace("dataeng/resources/setup-platform-venv.sh")
+                        dslFactory.readFileFromWorkspace("dataeng/resources/setup-platform-venv-legacy.sh")
                     )
                 }
                 virtualenv {


### PR DESCRIPTION
Currently, `analytics-exporter-course` cannot install dependencies. This is occurring when it tries to install the requirements for the edx-platform, and it hits some snags with setuptools. On the other hand, `analytics-exporter-master` can install dependencies. These jobs use two separate branches of the edx-platform. Both contain the same general commit (a hack never intended for production that fixed a bug used in this pipeline), but are based on different parent commits. This difference in commit lineage also includes differences in the sets of requirements files, which in turn requires the jobs use two separate bash scripts to install the dependencies, although the net result is the same.

Here is the comparison of each branch to master to show the near equivalence of the pertinent commits in the branches used by these jobs:
`analytics-exporter-course`: https://github.com/edx/edx-platform/compare/master...zafft/analytics-exporter-settings-hotfix?expand=1
`analytics-exporter-master`: https://github.com/edx/edx-platform/compare/master...aed/analytics-exporter-settings-hotfix?expand=1

My plan is to change `analytics-exporter-course` to use the platform branch used in `analytics-exporter-master`, seeing that it A) works and B) the needed commit is generally present in both branches. I will also change the DSL for `analytics-exporter-course` to use the bash installation script used by `analytics-exporter-master`, seeing that it has different requirement file names. One thing to call out is that one the branches also contains changes in `openedx/core/djangoapps/user_api/management/commands/email_opt_in_list.py`. Not sure if these need to be copied over/a new branch created. Any insight would be helpful.