### PR TITLE
default job to enabled

### DIFF
--- a/dataeng/jobs/analytics/ProgramEnrollmentReports.groovy
+++ b/dataeng/jobs/analytics/ProgramEnrollmentReports.groovy
@@ -15,9 +15,6 @@ class ProgramEnrollmentReports {
 
         dslFactory.job('program-enrollment-reports') {
 
-            // disabled until downstream reporting work is complete
-            disabled(true)
-
             logRotator common_log_rotator(allVars)
             parameters common_parameters(allVars)
             parameters {


### PR DESCRIPTION
@edx/masters-devs 

Was thinking I could just manually do this in the UI as-needed for testing not realizing permissions to the enable button are locked down.