### PR TITLE
Estute/standardize exporter jobs

### DIFF
--- a/dataeng/jobs/analytics/AnalyticsEmailOptin.groovy
+++ b/dataeng/jobs/analytics/AnalyticsEmailOptin.groovy
@@ -86,6 +86,7 @@ class AnalyticsEmailOptin {
                     extensions {
                         pruneBranches()
                         relativeTargetDirectory('edx-platform')
+                        cleanBeforeCheckout()
                     }
                 }
                 git {
@@ -127,6 +128,7 @@ class AnalyticsEmailOptin {
                     command(
                         dslFactory.readFileFromWorkspace("dataeng/resources/setup-platform-venv.sh")
                     )
+                    clear(true)
                 }
                 virtualenv {
                     nature("shell")
@@ -134,6 +136,7 @@ class AnalyticsEmailOptin {
                     command(
                         dslFactory.readFileFromWorkspace("dataeng/resources/setup-exporter-email-optin.sh")
                     )
+                    clear(true)
                 }
                 downstreamParameterized {
                     trigger('analytics-email-optin-worker') {

--- a/dataeng/jobs/analytics/AnalyticsExporter.groovy
+++ b/dataeng/jobs/analytics/AnalyticsExporter.groovy
@@ -9,7 +9,7 @@ class AnalyticsExporter {
             parameters {
                 stringParam('COURSES', '', 'Space separated list of courses to process. E.g. --course=course-v1:BerkleeX+BMPR365_3x+1T2015')
                 stringParam('EXPORTER_BRANCH', 'environment/production', 'Branch from the analytics-exporter repository. For tags use tags/[tag-name].')
-                stringParam('PLATFORM_BRANCH', 'origin/zafft/analytics-exporter-settings-hotfix', 'Branch from the exporter repository. For tags use tags/[tag-name].')
+                stringParam('PLATFORM_BRANCH', 'aed/analytics-exporter-settings-hotfix', 'Branch from the exporter repository. For tags use tags/[tag-name].')
                 stringParam('CONFIG_FILENAME', 'course_exporter.yaml', 'Name of configuration file in analytics-secure/analytics-exporter.')
                 stringParam('OUTPUT_BUCKET', '', 'Name of the bucket for the destination of the export data. Can use a path. (eg. export-data/test).')
                 stringParam('NOTIFICATION_EMAILS', '', 'Space separated list of emails to notify in case of failure.')

--- a/dataeng/jobs/analytics/AnalyticsExporter.groovy
+++ b/dataeng/jobs/analytics/AnalyticsExporter.groovy
@@ -62,7 +62,7 @@ class AnalyticsExporter {
                 virtualenv {
                     nature("shell")
                     command(
-                        dslFactory.readFileFromWorkspace("dataeng/resources/setup-platform-venv.sh")
+                        dslFactory.readFileFromWorkspace("dataeng/resources/setup-platform-venv-legacy.sh")
                     )
                     clear(true)
                 }

--- a/dataeng/jobs/analytics/AnalyticsExporter.groovy
+++ b/dataeng/jobs/analytics/AnalyticsExporter.groovy
@@ -28,6 +28,7 @@ class AnalyticsExporter {
                     extensions {
                         pruneBranches()
                         relativeTargetDirectory('edx-platform')
+                        cleanBeforeCheckout()
                     }
                 }
                 git {
@@ -63,6 +64,7 @@ class AnalyticsExporter {
                     command(
                         dslFactory.readFileFromWorkspace("dataeng/resources/setup-platform-venv.sh")
                     )
+                    clear(true)
                 }
                 virtualenv {
                     nature("shell")
@@ -70,6 +72,7 @@ class AnalyticsExporter {
                     command(
                         dslFactory.readFileFromWorkspace("dataeng/resources/run-course-exporter.sh")
                     )
+                    clear(true)
                 }
             }
         }
@@ -153,6 +156,7 @@ class AnalyticsExporter {
                     extensions {
                         pruneBranches()
                         relativeTargetDirectory('edx-platform')
+                        cleanBeforeCheckout()
                     }
                 }
                 git {
@@ -194,6 +198,7 @@ class AnalyticsExporter {
                     command(
                         dslFactory.readFileFromWorkspace("dataeng/resources/setup-platform-venv-legacy.sh")
                     )
+                    clear(true)
                 }
                 virtualenv {
                     nature("shell")
@@ -201,6 +206,7 @@ class AnalyticsExporter {
                     command(
                         dslFactory.readFileFromWorkspace("dataeng/resources/setup-exporter.sh")
                     )
+                    clear(true)
                 }
 
                 downstreamParameterized {

--- a/dataeng/resources/run-course-exporter.sh
+++ b/dataeng/resources/run-course-exporter.sh
@@ -4,6 +4,7 @@ mkdir -p ${WORKING_DIRECTORY}/course-data
 
 # Install requirements into this (exporter) virtual environment
 pushd analytics-exporter/
+pip install "setuptools<45"
 pip install -r github_requirements.txt
 pip install mysql-connector-python -e .
 popd

--- a/dataeng/resources/setup-exporter-email-optin.sh
+++ b/dataeng/resources/setup-exporter-email-optin.sh
@@ -3,6 +3,7 @@ mkdir -p /var/lib/jenkins/tmp/analytics-exporter/course-data
 
 # Install requirements into this (exporter) virtual environment
 pushd analytics-exporter/
+pip install "setuptools<45"
 pip install -r github_requirements.txt
 pip install mysql-connector-python -e .
 popd

--- a/dataeng/resources/setup-exporter.sh
+++ b/dataeng/resources/setup-exporter.sh
@@ -9,6 +9,7 @@ mkdir -p /var/lib/jenkins/tmp/analytics-exporter/course-data
 
 # Install requirements into this (exporter) virtual environment
 pushd analytics-exporter/
+pip install "setuptools<45"
 pip install -r github_requirements.txt
 pip install mysql-connector-python -e .
 popd

--- a/dataeng/resources/setup-platform-venv-legacy.sh
+++ b/dataeng/resources/setup-platform-venv-legacy.sh
@@ -6,6 +6,7 @@
 
 # Install requirements
 pushd edx-platform
+pip install "setuptools<45"
 pip install --exists-action w -r requirements/edx/pre.txt
 pip install --exists-action w -r requirements/edx/django.txt
 pip install --exists-action w -r requirements/edx/base.txt


### PR DESCRIPTION
Currently, the `analytics-exporter-course` job uses a different branch of the edx-platform (and a different set up script). There was a recent bug that required us to pin setuptools, but it exposed the fact that the change would need to make the fix twice. I want to standardize the version of the platform used by both jobs to make fixing/testing easier. Since the `analytics-exporter-master` job is the one that is currently creating output that is consumed by partners, I have chosen to modify the `course` job to use the same branch/setup as the `master` job.

While testing this, the constant branch swapping was causing issues. To fix this, I have made the jobs always create fresh virtualenvs and do clean git checkouts for each build.

NOTE: the `analytics-email-optin` jobs still currently use the platform branch/setup that the `course` jobs used to use (zafft/analytics-exporter-settings-hotfix). I spoke to @brianhw and we think it is ok to leave for now.