### PR TITLE
Switch to SSH for make upgrade checkouts

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -267,7 +267,7 @@ jobConfigs.each { jobConfig ->
             git {
                 remote {
                     credentials('jenkins-worker')
-                    url("https://github.com/edx/${jobConfig.repoName}.git")
+                    url("git@github.com:edx/${jobConfig.repoName}.git")
                 }
                 branch('master')
                 extensions {


### PR DESCRIPTION
Switch from HTTPS to SSH for make upgrade job checkouts in order to utilize the SSH credentials needed for private repositories.