### PR TITLE
Enable the refresh-snowpipe-event-loader job.

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeRefreshSnowpipe.groovy
+++ b/dataeng/jobs/analytics/SnowflakeRefreshSnowpipe.groovy
@@ -32,9 +32,6 @@ class SnowflakeRefreshSnowpipe {
 
             dslFactory.job(jobConfig['NAME']) {
 
-                // This job should be disabled until the rest of the work in DE-1779 is complete!
-                disabled(true)
-
                 logRotator common_log_rotator(allVars)
                 parameters secure_scm_parameters(allVars)
                 parameters {


### PR DESCRIPTION
https://openedx.atlassian.net/browse/DE-2048

Turn on the daily running of the Jenkins job which runs `ALTER PIPE..REFRESH` on the event tracking log loading Snowpipe, along with some monitoring of the pipe.