### PR TITLE
Add proper path prefix to find key/passphrase for Snowpipe refresh job.

### DIFF
--- a/dataeng/resources/snowflake-refresh-snowpipe.sh
+++ b/dataeng/resources/snowflake-refresh-snowpipe.sh
@@ -6,8 +6,8 @@ cd $WORKSPACE/analytics-tools/snowflake
 make requirements
 
 python refresh_snowpipe.py \
-    --key_path $KEY_PATH \
-    --passphrase_path $PASSPHRASE_PATH \
+    --key_path $WORKSPACE/analytics-secure/$KEY_PATH \
+    --passphrase_path $WORKSPACE/analytics-secure/$PASSPHRASE_PATH \
     --user $USER \
     --account $ACCOUNT \
     --pipe_name $PIPE_NAME \


### PR DESCRIPTION
https://openedx.atlassian.net/browse/DE-2048?oldIssueView=true

In response to this failure:
http://jenkins.analytics.edx.org/job/refresh-snowpipe-event-loader/2/console
add the proper path prefix for key/passphrase.