### PR TITLE
job for planning jenkins plugin upgrade

### DIFF
--- a/testeng/jobs/pluginUpdateJob.groovy
+++ b/testeng/jobs/pluginUpdateJob.groovy
@@ -30,7 +30,7 @@ job('plan-plugin-upgrade-path') {
         )
         stringParam(
             'TARGET_CONFIG_PLUGIN_FILE',
-            'base-configuration/playbooks/roles/jenkins_build/defaults/main.yml',
+            'target-configuration/playbooks/roles/jenkins_build/defaults/main.yml',
             '.'
         )
         stringParam(
@@ -63,7 +63,7 @@ job('plan-plugin-upgrade-path') {
             }
             branch('\${TARGET_CONFIG_BRANCH}')
             extensions {
-                relativeTargetDirectory('new-configuration')
+                relativeTargetDirectory('target-configuration')
             }
         }
     }

--- a/testeng/jobs/pluginUpdateJob.groovy
+++ b/testeng/jobs/pluginUpdateJob.groovy
@@ -43,7 +43,7 @@ job('plan-plugin-upgrade-path') {
             remote {
                 url('https://github.com/edx/jenkins-configuration.git')
             }
-            branch("${JENKINS_CONFIG_BRANCH}")
+            branch('\${JENKINS_CONFIG_BRANCH}')
             extensions {
                 relativeTargetDirectory('jenkins-configuration')
             }
@@ -52,7 +52,7 @@ job('plan-plugin-upgrade-path') {
             remote {
                 url('https://github.com/edx/configuration.git')
             }
-            branch("${BASE_CONFIG_BRANCH}")
+            branch('\${BASE_CONFIG_BRANCH}')
             extensions {
                 relativeTargetDirectory('base-configuration')
             }
@@ -61,7 +61,7 @@ job('plan-plugin-upgrade-path') {
             remote {
                 url('https://github.com/edx/configuration.git')
             }
-            branch("${TARGET_CONFIG_BRANCH}")
+            branch('\${TARGET_CONFIG_BRANCH}')
             extensions {
                 relativeTargetDirectory('new-configuration')
             }

--- a/testeng/jobs/pluginUpdateJob.groovy
+++ b/testeng/jobs/pluginUpdateJob.groovy
@@ -1,0 +1,81 @@
+package testeng
+
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GENERAL_SLACK_STATUS
+
+job('plan-plugin-upgrade-path') {
+
+
+    logRotator JENKINS_PUBLIC_LOG_ROTATOR()
+    label('jenkins-worker')
+    concurrentBuild(false)
+
+    parameters {
+        stringParam(
+            'JENKINS_CONFIG_BRANCH', 'master', '.'
+        )
+        stringParam(
+            'BASE_CONFIG_BRANCH', 'master', '.'
+        )
+        stringParam(
+            'BASE_CONFIG_PLUGIN_FILE',
+            'base-configuration/playbooks/roles/jenkins_build/defaults/main.yml',
+            '.'
+        )
+        stringParam(
+            'BASE_CONFIG_PLUGIN_KEY', 'build_jenkins_plugins_list', '.'
+        )
+        stringParam(
+            'TARGET_CONFIG_BRANCH', 'master', '.'
+        )
+        stringParam(
+            'TARGET_CONFIG_PLUGIN_FILE',
+            'base-configuration/playbooks/roles/jenkins_build/defaults/main.yml',
+            '.'
+        )
+        stringParam(
+            'TARGET_CONFIG_PLUGIN_KEY', 'build_jenkins_plugins_list', '.'
+        )
+    }
+
+    multiscm {
+        git {
+            remote {
+                url('https://github.com/edx/jenkins-configuration.git')
+            }
+            branch("${JENKINS_CONFIG_BRANCH}")
+            extensions {
+                relativeTargetDirectory('jenkins-configuration')
+            }
+        }
+        git {
+            remote {
+                url('https://github.com/edx/configuration.git')
+            }
+            branch("${BASE_CONFIG_BRANCH}")
+            extensions {
+                relativeTargetDirectory('base-configuration')
+            }
+        }
+        git {
+            remote {
+                url('https://github.com/edx/configuration.git')
+            }
+            branch("${TARGET_CONFIG_BRANCH}")
+            extensions {
+                relativeTargetDirectory('new-configuration')
+            }
+        }
+    }
+
+    wrappers {
+        timestamps()
+    }
+
+
+    steps {
+        shell(readFileFromWorkspace('testeng/resources/compare-plugin-updates.sh'))
+    }
+
+
+}

--- a/testeng/resources/compare-plugin-updates.sh
+++ b/testeng/resources/compare-plugin-updates.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+
+cd jenkins-configuration
+source local_env.sh.sample
+
+export PLUGIN_OUTPUT_FILE='base-installed-plugins'
+export PLUGIN_CONFIG=${BASE_CONFIG_PLUGIN_FILE}
+export PLUGIN_CONFIG_KEY=${BASE_CONFIG_PLUGIN_KEY}
+make clean plugins show
+
+export PLUGIN_OUTPUT_FILE='new-installed-plugins'
+export PLUGIN_CONFIG=${TARGET_CONFIG_PLUGIN_FILE}
+export PLUGIN_CONFIG_KEY=${TARGET_CONFIG_PLUGIN_KEY}
+make clean plugins show
+
+python scripts/compare_installed_plugins base-installed-plugins new-installed-plugins

--- a/testeng/resources/compare-plugin-updates.sh
+++ b/testeng/resources/compare-plugin-updates.sh
@@ -5,12 +5,12 @@ cd jenkins-configuration
 source local_env.sh.sample
 
 export PLUGIN_OUTPUT_FILE='base-installed-plugins'
-export PLUGIN_CONFIG=${BASE_CONFIG_PLUGIN_FILE}
+export PLUGIN_CONFIG=../${BASE_CONFIG_PLUGIN_FILE}
 export PLUGIN_CONFIG_KEY=${BASE_CONFIG_PLUGIN_KEY}
 make clean plugins show
 
 export PLUGIN_OUTPUT_FILE='new-installed-plugins'
-export PLUGIN_CONFIG=${TARGET_CONFIG_PLUGIN_FILE}
+export PLUGIN_CONFIG=../${TARGET_CONFIG_PLUGIN_FILE}
 export PLUGIN_CONFIG_KEY=${TARGET_CONFIG_PLUGIN_KEY}
 make clean plugins show
 

--- a/testeng/resources/compare-plugin-updates.sh
+++ b/testeng/resources/compare-plugin-updates.sh
@@ -14,4 +14,4 @@ export PLUGIN_CONFIG=../${TARGET_CONFIG_PLUGIN_FILE}
 export PLUGIN_CONFIG_KEY=${TARGET_CONFIG_PLUGIN_KEY}
 make clean plugins show
 
-python scripts/compare_installed_plugins base-installed-plugins new-installed-plugins
+python scripts/compare_installed_plugins.py base-installed-plugins new-installed-plugins


### PR DESCRIPTION
Tie all of https://github.com/edx/jenkins-configuration/pull/146 together into a job.

Output of running this job with edx/configuration @ master and @ estute/dummy-testing:
```
00:02:00.688 1 actionable task: 1 executed
00:02:01.217 The following plugins will be installed:
00:02:01.217 trilead-api: 1.0.3
00:02:01.217 
00:02:01.217 The following plugins will be removed:
00:02:01.217 email-ext: 2.66
00:02:01.217 
00:02:01.217 The following plugins will be updated:
00:02:01.217 aws-java-sdk: 1.11.457 -> 1.11.700
00:02:01.217 jackson2-api: 2.8.11.3 -> 2.10.1
00:02:01.217 apache-httpcomponents-client-4-api: 4.5.5 -> 4.5.10
00:02:01.217 ec2: 1.44.1 -> 1.49.1
00:02:01.217 bouncycastle-api: 2.17 -> 2.18
```