### PR TITLE
Upgrade Registrar deps using Python 3.5, not 3.6

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -234,7 +234,7 @@ Map portalDesigner = [
 Map registrar = [
     org: 'edx',
     repoName: 'registrar',
-    pythonVersion: '3.6',
+    pythonVersion: '3.5',
     cronValue: '@weekly',
     githubUserReviewers: [],
     githubTeamReviewers: ['masters-devs'],


### PR DESCRIPTION
Registrar still tests and deploys on Python 3.5. While it's generally 3.6-compatible, sometimes 'make upgrade' PRs will fail in our tests suite if they are upgraded using Python 3.6, because they pull
in packages that are not 3.5-compatible. Until we start upgrading to Python 3.6, run the upgrade job in Python 3.5.

@edx/masters-devs 