### PR TITLE
Load vertica schema to SF using metadata.

### DIFF
--- a/dataeng/jobs/analytics/LoadVerticaSchemaToSnowflake.groovy
+++ b/dataeng/jobs/analytics/LoadVerticaSchemaToSnowflake.groovy
@@ -21,9 +21,7 @@ class LoadVerticaSchemaToSnowflake {
                     stringParam('SCHEMA', schema_config.get('SCHEMA', allVars.get('SCHEMA')), 'Schema')
                     stringParam('SCRATCH_SCHEMA', schema_config.get('SCRATCH_SCHEMA', allVars.get('SCRATCH_SCHEMA')), 'Scratch schema name - temporary loading location.')
                     stringParam('VERTICA_SCHEMA_NAME', schema_config.get('VERTICA_SCHEMA_NAME', allVars.get('VERTICA_SCHEMA_NAME')), 'Vertica Schema')
-                    stringParam('VERTICA_CREDENTIALS', schema_config.get('VERTICA_CREDENTIALS', allVars.get('VERTICA_CREDENTIALS')), 'The path to the Vertica credentials file.')
                     stringParam('VERTICA_WAREHOUSE_NAME', schema_config.get('VERTICA_WAREHOUSE_NAME', allVars.get('VERTICA_WAREHOUSE_NAME')), '')
-                    stringParam('EXCLUDE', schema_config.get('EXCLUDE', allVars.get('EXCLUDE')), 'as an example: --exclude [\"f_user_activity\",\"d_user_course_certificate\",\"d_user_course\"]')
                 }
                 multiscm common_multiscm(allVars)
                 wrappers common_wrappers(allVars)

--- a/dataeng/resources/load-vertica-schema-to-snowflake.sh
+++ b/dataeng/resources/load-vertica-schema-to-snowflake.sh
@@ -3,7 +3,7 @@
 env
 
 ${WORKSPACE}/analytics-configuration/automation/run-automated-task.sh \
- LoadVerticaSchemaFromS3ToSnowflakeTask --local-scheduler \
+LoadVerticaSchemaFromS3WithMetadataToSnowflakeTask --local-scheduler \
  --date $(date +%Y-%m-%d -d "$RUN_DATE") \
  ${OVERWRITE} \
  --credentials $SNOWFLAKE_CREDENTIALS \
@@ -14,6 +14,4 @@ ${WORKSPACE}/analytics-configuration/automation/run-automated-task.sh \
  --scratch-schema $SCRATCH_SCHEMA \
  --run-id $BUILD_ID \
  --vertica-schema-name $VERTICA_SCHEMA_NAME \
- --vertica-credentials $VERTICA_CREDENTIALS \
- --vertica-warehouse-name $VERTICA_WAREHOUSE_NAME \
- ${EXCLUDE}
+ --vertica-warehouse-name $VERTICA_WAREHOUSE_NAME


### PR DESCRIPTION
Use LoadVerticaSchemaFromS3WithMetadataToSnowflakeTask instead of LoadVerticaSchemaFromS3ToSnowflakeTask. 
Since this uses metadata in S3 instead of querying Vertica, we no longer need VERTICA_CREDENTIALS or EXCLUDE. 

Just tested (again) using http://jenkins.analytics.edx.org/job/load-vertica-schema-to-snowflake-financial_reporting/108.
