### PR TITLE
Schedule MB ITK job to run everyday at 9am

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeMicrobachelorsITK.groovy
+++ b/dataeng/jobs/analytics/SnowflakeMicrobachelorsITK.groovy
@@ -44,7 +44,9 @@ class SnowflakeMicrobachelorsITK {
                     }
                 }
             }
-            triggers common_triggers(allVars)
+            triggers {
+                cron('0 6 * * 1-5')
+            }
             wrappers {
                 timestamps()
             }


### PR DESCRIPTION
The existing `common_triggers` schedules a cron job given an environment config, but we don't have one in this job, so we're just scheduling manually. 