### PR TITLE
Adding new job

### DIFF
--- a/testeng/jobs/repoHealthReport.groovy
+++ b/testeng/jobs/repoHealthReport.groovy
@@ -1,0 +1,87 @@
+package testeng
+
+def pytest_repo_health_gitURL = 'git@github.com:edx/pytest-repo-health.git'
+def edx_repo_health_gitURL = 'git@github.com:edx/edx-repo-health.git'
+def destination_repo_health_gitURL = "git@github.com:edx/repo-tools-data.git"
+def githubUserReviewers = []
+def githubTeamReviewers = ['platform-core', 'arch-bom']
+
+
+job('repo-health-report') {
+
+    description('Generate a report listing repository structure standard compliance accross edX repos')
+    parameters {
+        stringParam('GITHUB_REPO_URL', 'https://github.com/edx/edx-platform',
+                    'Github repo url on which to run pytest-repo-health checks')
+    }
+    concurrentBuild(false)
+    environmentVariables(
+            PR_USER_REVIEWERS: githubUserReviewers.join(","),
+            PR_TEAM_REVIEWERS: githubTeamReviewers.join(",")
+        )
+    multiscm {
+        git {
+            remote {
+                url(pytest_repo_health_gitURL)
+            }
+            branch('master')
+            browser()
+            extensions {
+                cleanAfterCheckout()
+                relativeTargetDirectory('pytest-repo-health')
+            }
+        }
+        git {
+            remote {
+                url(edx_repo_health_gitURL )
+            }
+            branch('master')
+            browser()
+            extensions {
+                cleanAfterCheckout()
+                relativeTargetDirectory('edx-repo-health')
+            }
+        }
+        git {
+                remote {
+                    url('https://github.com/edx/testeng-ci.git')
+                }
+                branch('*/msingh/repo_health')
+                extensions {
+                    cleanBeforeCheckout()
+                    relativeTargetDirectory('testeng-ci')
+                }
+            }
+        git {
+            remote {
+                credentials('jenkins-worker')
+                url('${GITHUB_REPO_URL}')
+            }
+            branch('*/master')
+            browser()
+            extensions {
+                cleanAfterCheckout()
+                relativeTargetDirectory('target_repo')
+            }
+        }
+        git {
+            remote {
+                credentials('jenkins-worker')
+                url(destination_repo_health_gitURL )
+            }
+            branch('*/master')
+            browser()
+            extensions {
+                cleanAfterCheckout()
+                relativeTargetDirectory('data_repo')
+            }
+        }
+    }
+    triggers {
+        cron('@midnight')
+    }
+    steps{
+        shell(readFileFromWorkspace('testeng/resources/create-repo-health-report.sh'))
+    }
+
+}

--- a/testeng/resources/create-repo-health-report.sh
+++ b/testeng/resources/create-repo-health-report.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e -v
+
+# click requires this to work cause it interfaces weirdly with python 3 ASCII default
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
+virtualenv --python=/usr/bin/python3.6 venv -q
+source venv/bin/activate
+
+# get name of target_repo
+cd target_repo
+REPO_NAME="$(basename -s .git `git config --get remote.origin.url`)"
+OUTPUT_FILE_POSTFIX="_repo_health.yaml"
+OUTPUT_FILE_NAME=$REPO_NAME$OUTPUT_FILE_POSTFIX
+
+# install pytest and all necessary things
+cd ../pytest-repo-health
+make requirements
+pip install -e .
+deactivate
+source ../venv/bin/activate
+
+# (TODO: jinder):I need to add install for checks as well
+
+
+# Run checks
+touch tmp.txt
+pytest --repo-health --repo-health-path ../edx-repo-health --repo-path ../target_repo --output-path $OUTPUT_FILE_NAME -c tmp.txt --noconftest
+mv $OUTPUT_FILE_NAME ../data_repo/$OUTPUT_FILE_NAME
+
+cd ../data_repo
+export CURRENT_SHA=$(git rev-parse HEAD)
+
+echo "Running script to create PR..."
+cd ../testeng-ci
+pip install -r requirements/base.txt
+python -m jenkins.upgrade_python_requirements --sha=$CURRENT_SHA --repo_root="../data_repo" --repo_name=$REPO_NAME --org='edx' --user_reviewers=$PR_USER_REVIEWERS --team_reviewers=$PR_TEAM_REVIEWERS
+
+# Remove all downloaded things
+deactivate
+cd ..
+rm -rf venv


### PR DESCRIPTION
Arch-bom is working on creating a repo health dashboard for edx repos([ticket link](https://openedx.atlassian.net/jira/software/projects/ARCHBOM/boards/612/roadmap?selectedIssue=ARCHBOM-1002)). One of the steps necessary is creating an jenkins job that downloads all the necessary repos, runs checks on them, and creates a PR with results.

PR for python script to create PR for check results: https://github.com/edx/testeng-ci/pull/224