### PR TITLE
update upgrade jobs

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -11,11 +11,15 @@ package testeng
 //     emails: List of emails that should be notified when job fails, e.g.: ['email1', 'email2']
 // ]
 
+// Cron values for: midnight-7:59am ET, Sunday-Thursday (times are in UTC)
+// See https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/triggers/TimerTrigger/help-spec.jelly
+def cronOffHoursBusinessWeek = '* H(4-11) * * H(0-4)'
+
 Map apiDocTools = [
     org: 'edx',
     repoName: 'api-doc-tools',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [''],
     githubTeamReviewers: ['teaching-and-learning'],
     emails: ['ned@edx.org']
@@ -25,7 +29,7 @@ Map bokchoy = [
     org: 'edx',
     repoName: 'bok-choy',
     pythonVersion: '2.7',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [],
     githubTeamReviewers: ['arch-bom'],
     emails: ['arch-bom@edx.org']
@@ -35,7 +39,7 @@ Map completion = [
     org: 'edx',
     repoName: 'completion',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [],
     githubTeamReviewers: ['masters-devs'],
     emails: ['masters-requirements-update@edx.opsgenie.net']
@@ -45,7 +49,7 @@ Map cookiecutterDjangoApp = [
     org: 'edx',
     repoName: 'cookiecutter-django-app',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [],
     githubTeamReviewers: ['arch-bom'],
     emails: ['arch-bom@edx.org']
@@ -55,7 +59,7 @@ Map courseDiscovery = [
     org: 'edx',
     repoName: 'course-discovery',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: ['mikix'],
     githubTeamReviewers: ['course-discovery-admins'],
     emails: ['mterry@edx.org']
@@ -65,7 +69,7 @@ Map credentialsRepo = [
     org: 'edx',
     repoName: 'credentials',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [],
     githubTeamReviewers: ['masters-devs'],
     emails: ['masters-requirements-update@edx.opsgenie.net']
@@ -75,7 +79,7 @@ Map devstack = [
     org: 'edx',
     repoName: 'devstack',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [],
     githubTeamReviewers: ['arch-bom'],
     emails: ['arch-bom@edx.org']
@@ -85,7 +89,7 @@ Map djangoConfigModels = [
     org: 'edx',
     repoName: 'django-config-models',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: ['feanil'],
     githubTeamReviewers: ['arch-bom'],
     emails: ['arch-bom@edx.org']
@@ -95,7 +99,7 @@ Map djangoUserTasks = [
     org: 'edx',
     repoName: 'django-user-tasks',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: ['jmbowman'],
     githubTeamReviewers: ['arch-bom'],
     emails: ['arch-bom@edx.org']
@@ -105,7 +109,7 @@ Map ecommerce = [
     org: 'edx',
     repoName: 'ecommerce',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [],
     githubTeamReviewers: ['ecommerce'],
     emails: ['revenue-squad-alert@edx.opsgenie.net']
@@ -115,7 +119,7 @@ Map edxAnalyticsDashboard = [
     org: 'edx',
     repoName: 'edx-analytics-dashboard',
     pythonVersion: '2.7',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [],
     githubTeamReviewers: ['edx-data-engineering'],
     emails: ['data-engineering@edx.org']
@@ -125,7 +129,7 @@ Map edxAnalyticsDataApi = [
     org: 'edx',
     repoName: 'edx-analytics-data-api',
     pythonVersion: '2.7',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [],
     githubTeamReviewers: ['edx-data-engineering'],
     emails: ['data-engineering@edx.org']
@@ -135,7 +139,7 @@ Map edxGomatic = [
     org: 'edx',
     repoName: 'edx-gomatic',
     pythonVersion: '2.7',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [],
     githubTeamReviewers: ['devops'],
     emails: ['devops@edx.org']
@@ -145,7 +149,7 @@ Map edxNotesApi = [
     org: 'edx',
     repoName: 'edx-notes-api',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [],
     githubTeamReviewers: ['devops'],
     emails: ['devops@edx.org']
@@ -155,7 +159,7 @@ Map edxOrganizations = [
     org: 'edx',
     repoName: 'edx-organizations',
     pythonVersion: '2.7',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [],
     githubTeamReviewers: ['arch-bom'],
     emails: ['arch-bom@edx.org']
@@ -175,7 +179,7 @@ Map edxProctoring = [
     org: 'edx',
     repoName: 'edx-proctoring',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: ['feanil'],
     githubTeamReviewers: ['masters-devs'],
     emails: ['masters-requirements-update@edx.opsgenie.net']
@@ -185,7 +189,7 @@ Map edxRestApiClient = [
     org: 'edx',
     repoName: 'edx-rest-api-client',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [''],
     githubTeamReviewers: ['arch-bom'],
     emails: ['arch-bom@edx.org']
@@ -195,7 +199,7 @@ Map edxSphinxTheme = [
     org: 'edx',
     repoName: 'edx-sphinx-theme',
     pythonVersion: '2.7',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [''],
     githubTeamReviewers: ['arch-bom'],
     emails: ['arch-bom@edx.org']
@@ -205,7 +209,7 @@ Map edxVal= [
     org: 'edx',
     repoName: 'edx-val',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [''],
     githubTeamReviewers: ['sustaining-vulcans'],
     emails: ['sustaining-vulcans@edx.org']
@@ -215,7 +219,7 @@ Map opaqueKeys = [
     org: 'edx',
     repoName: 'opaque-keys',
     pythonVersion: '2.7',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: ['cpennington'],
     githubTeamReviewers: ['platform-core', 'arch-bom'],
     emails: ['arch-bom@edx.org']
@@ -225,7 +229,7 @@ Map openEdxStats = [
     org: 'edx',
     repoName: 'openedxstats',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [''],
     githubTeamReviewers: ['teaching-and-learning'],
     emails: ['ned@edx.org']
@@ -235,7 +239,7 @@ Map portalDesigner = [
     org: 'edx',
     repoName: 'portal-designer',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [],
     githubTeamReviewers: ['masters-devs'],
     emails: ['masters-requirements-update@edx.opsgenie.net']
@@ -245,7 +249,7 @@ Map registrar = [
     org: 'edx',
     repoName: 'registrar',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [],
     githubTeamReviewers: ['masters-devs'],
     emails: ['masters-requirements-update@edx.opsgenie.net']
@@ -255,7 +259,7 @@ Map testengCI = [
     org: 'edx',
     repoName: 'testeng-ci',
     pythonVersion: '2.7',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [],
     githubTeamReviewers: ['devops'],
     emails: ['devops@edx.org']
@@ -265,7 +269,7 @@ Map xblock = [
     org: 'edx',
     repoName: 'XBlock',
     pythonVersion: '2.7',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: ['cpennington'],
     githubTeamReviewers: ['platform-core', 'arch-bom'],
     emails: ['arch-bom@edx.org']
@@ -275,7 +279,7 @@ Map xblockUtils = [
     org: 'edx',
     repoName: 'xblock-utils',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [],
     githubTeamReviewers: ['arch-bom'],
     emails: ['arch-bom@edx.org']
@@ -285,7 +289,7 @@ Map xqueue = [
     org: 'edx',
     repoName: 'xqueue',
     pythonVersion: '3.5',
-    cronValue: '@weekly',
+    cronValue: cronOffHoursBusinessWeek,
     githubUserReviewers: [],
     githubTeamReviewers: ['sustaining-team'],
     emails: ['sustaining-escalations@edx.org']

--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -257,8 +257,8 @@ Map testengCI = [
     pythonVersion: '2.7',
     cronValue: '@weekly',
     githubUserReviewers: [],
-    githubTeamReviewers: ['arch-bom'],
-    emails: ['arch-bom@edx.org']
+    githubTeamReviewers: ['devops'],
+    emails: ['devops@edx.org']
 ]
 
 Map xblock = [


### PR DESCRIPTION
Before merge:
- [x] Squash commits

This PR has two independent changes:
1. Move testeng-ci to devops.
2. Update the cronValues.

---------------

Switched cronValue from:
  `@weekly`
to:
  `* H(4-11) * * H(0-4)`

This will choose a random time between midnight-7:59am ET,
Sunday-Thursday, which will have this run mostly off hours (depending on
time zone), and new PRs should be available in the morning during the
week with sufficient time to merge and deploy.

Notes:
- The H symbol can be thought of as a random value over a range, but
it actually is a hash of the job name, not a random function, so that
the value remains stable for any given project.
- Times are in UTC.

For help text for Jenkins cron settings, see:
https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/triggers/TimerTrigger/help-spec.jelly