### PR TITLE
[BD] Use python 3.5 for edx-analytics-data-api

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -132,7 +132,7 @@ Map edxAnalyticsDashboard = [
 Map edxAnalyticsDataApi = [
     org: 'edx',
     repoName: 'edx-analytics-data-api',
-    pythonVersion: '2.7',
+    pythonVersion: '3.5',
     cronValue: cronOffHoursBusinessWeekday,
     githubUserReviewers: [],
     githubTeamReviewers: ['edx-data-engineering'],


### PR DESCRIPTION
## Description

Change python version for analytics data api.

**Note**:  Do not merge until this PR gets merged https://github.com/edx/edx-analytics-data-api/pull/344

- [ ] @jmbowman 
