### PR TITLE
Add TEST_SOURCES_FIRST var for testing DBT sources before/after a run.

### DIFF
--- a/dataeng/jobs/analytics/WarehouseTransforms.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransforms.groovy
@@ -21,6 +21,7 @@ class WarehouseTransforms{
                     stringParam('DBT_PROJECT', env_config.get('DBT_PROJECT', allVars.get('DBT_PROJECT')), 'dbt project in warehouse-transforms to work on.')
                     stringParam('DBT_PROFILE', env_config.get('DBT_PROFILE', allVars.get('DBT_PROFILE')), 'dbt profile from analytics-secure to work on.')
                     stringParam('DBT_TARGET', env_config.get('DBT_TARGET', allVars.get('DBT_TARGET')), 'dbt target from analytics-secure to work on.')
+                    stringParam('TEST_SOURCES_FIRST', env_config.get('TEST_SOURCES_FIRST', 'true'), 'Set to \'true\' to perform source testing first. All other values test sources post-run.')
                     stringParam('NOTIFY', allVars.get('NOTIFY','$PAGER_NOTIFY'), 'Space separated list of emails to send notifications to.')
                 }
                 multiscm secure_scm(allVars) << {

--- a/dataeng/resources/warehouse-transforms.sh
+++ b/dataeng/resources/warehouse-transforms.sh
@@ -13,9 +13,21 @@ dbt clean
 dbt deps
 dbt seed --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
 
-# Run the source tests first, sadly not just the ones upstream from this tag
-dbt test --models source:* --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
+# Source testing *before* model-building can be enabled/disabled with this envvar.
+if [ $TEST_SOURCES_FIRST -eq 'true' ]
+then
+    # Run the source tests, sadly not just the ones upstream from this tag
+    dbt test --models source:* --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
+fi
+
+# Compile/build all models with this tag.
 dbt run --models tag:$MODEL_TAG --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
 
-# Run the tests for this tag, but exclude sources since we just tested them
-dbt test --models tag:$MODEL_TAG --exclude source:* --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
+if [ $TEST_SOURCES_FIRST -eq 'true' ]
+then
+    # Run the tests for this tag, but exclude sources since we just tested them
+    dbt test --models tag:$MODEL_TAG --exclude source:* --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
+else
+    # Run the tests for this tag, including sources.
+    dbt test --models tag:$MODEL_TAG --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
+fi


### PR DESCRIPTION
Some data conditions can cause our DBT runs to never occur due to failing source testing. This condition is a circular failure, as the `dbt run` model-building needs to occur before the source tests will ever pass.

Add the ability to run source tests either before (default) *or* after model building using the `TEST_SOURCES_FIRST` environment variable flag.

Currently happening here:
http://jenkins.analytics.edx.org/job/warehouse-transforms-daily/206/console