### PR TITLE
MICROBA-184 | Setup OpsGenie alerts for coaching Jenkins job

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeMicrobachelorsITK.groovy
+++ b/dataeng/jobs/analytics/SnowflakeMicrobachelorsITK.groovy
@@ -23,6 +23,7 @@ class SnowflakeMicrobachelorsITK {
             parameters {
                 stringParam('ANALYTICS_TOOLS_URL', allVars.get('ANALYTICS_TOOLS_URL'), 'URL for the analytics tools repo.')
                 stringParam('ANALYTICS_TOOLS_BRANCH', allVars.get('ANALYTICS_TOOLS_BRANCH'), 'Branch of analytics tools repo to use.')
+                stringParam('NOTIFY', allVars.get('NOTIFY','$PAGER_NOTIFY_APERTURE'), 'Space separated list of emails to send notifications to.')
             }
             environmentVariables {
                 env('KEY_PATH', allVars.get('KEY_PATH'))
@@ -48,7 +49,7 @@ class SnowflakeMicrobachelorsITK {
                 }
             }
             triggers {
-                cron('0 6 * * 1-5')
+                cron('H 6 * * 1-5')
             }
             wrappers {
                 timestamps()
@@ -61,6 +62,7 @@ class SnowflakeMicrobachelorsITK {
                     defaultExcludes()
                 }
             }
+            publishers common_publishers(allVars)
             steps {
                 virtualenv {
                     pythonName('PYTHON_3.7')

--- a/dataeng/jobs/analytics/WarehouseTransforms.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransforms.groovy
@@ -22,7 +22,12 @@ class WarehouseTransforms{
                     stringParam('DBT_PROFILE', env_config.get('DBT_PROFILE', allVars.get('DBT_PROFILE')), 'dbt profile from analytics-secure to work on.')
                     stringParam('DBT_TARGET', env_config.get('DBT_TARGET', allVars.get('DBT_TARGET')), 'dbt target from analytics-secure to work on.')
                     stringParam('TEST_SOURCES_FIRST', env_config.get('TEST_SOURCES_FIRST', 'true'), 'Set to \'true\' to perform source testing first. All other values test sources post-run.')
-                    stringParam('NOTIFY', allVars.get('NOTIFY','$PAGER_NOTIFY'), 'Space separated list of emails to send notifications to.')
+                    if (environment.equalsIgnoreCase("microbachelors")) {
+                        // send alerts for the microbachelors data-mart warehouse-transforms job to aperture team first
+                        stringParam('NOTIFY', allVars.get('NOTIFY','$PAGER_NOTIFY_APERTURE'), 'Space separated list of emails to send notifications to.')
+                    } else {
+                        stringParam('NOTIFY', allVars.get('NOTIFY','$PAGER_NOTIFY'), 'Space separated list of emails to send notifications to.')
+                    }
                 }
                 multiscm secure_scm(allVars) << {
                     git {
@@ -55,4 +60,3 @@ class WarehouseTransforms{
         }
     }
 }
-


### PR DESCRIPTION
[MICROBA-184]
- Update coaching Jenkins job to send mails if the job fails to new Aperture mailing group/OpsGenie team
- Noticed a warning in the Jenkins configuration for building periodically settings. Adjusted cron schedule to follow the guidance
- Update default value of `$NOTIFY` for the warehouse-transforms MicroBachelors job to alert us first instead of the DE team
