### PR TITLE
MICROBA-105 | Update logRotator in Coaching job

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeMicrobachelorsITK.groovy
+++ b/dataeng/jobs/analytics/SnowflakeMicrobachelorsITK.groovy
@@ -5,7 +5,6 @@ that queries Snowflake for MicroBachelors learner data and transmits it to edX's
 
 package analytics
 
-import static org.edx.jenkins.dsl.DevopsConstants.common_logrotator
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_publishers
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_triggers
 import static org.edx.jenkins.dsl.AnalyticsConstants.secure_scm
@@ -17,7 +16,10 @@ class SnowflakeMicrobachelorsITK {
 
     public static def job = { dslFactory, allVars ->
         dslFactory.job('snowflake-microbachelors-send-coaching-data-itk') {
-            logRotator common_logrotator
+            logRotator {
+                daysToKeep(30)
+                artifactDaysToKeep(7)
+            }
             authorization common_authorization(allVars)
             parameters secure_scm_parameters(allVars)
             parameters {


### PR DESCRIPTION
[MICROBA-105]
- Update logRotator definition to keep records of the past 30 days of job execution
- Specify to only keep one week of reports as job artifacts (5 business days, job only runs M-F)