### PR TITLE
Remove Django 2 upgrade jobs

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -40,18 +40,6 @@ Map publicJobConfig = [
     pythonVersion: '3.5',
 ]
 
-Map django22JobConfig = [
-    open: true,
-    jobName: 'edx-platform-django-2.2-accessibility-master',
-    repoName: 'edx-platform',
-    workerLabel: 'js-worker',
-    context: 'jenkins/django-2.2/a11y',
-    refSpec : '+refs/heads/master:refs/remotes/origin/master',
-    defaultBranch : 'master',
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django22',
-]
-
 Map privateJobConfig = [
     open: false,
     jobName: 'edx-platform-accessibility-master_private',
@@ -75,7 +63,6 @@ Map ironwoodJobConfig = [
 
 List jobConfigs = [
     publicJobConfig,
-    django22JobConfig,
     privateJobConfig,
     ironwoodJobConfig
 ]

--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -51,43 +51,29 @@ Map publicJobConfig = [
     pythonVersion: '3.5',
 ]
 
-Map django20JobConfig = [
+Map python38JobConfig = [
     open: true,
-    jobName: 'edx-platform-django-2.0-accessibility-pr',
+    jobName: 'edx-platform-python-3.8-accessibility-pr',
     repoName: 'edx-platform',
     workerLabel: 'js-worker',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-2.0/a11y',
+    context: 'jenkins/python-3.8/a11y',
     onlyTriggerPhrase: true,
-    triggerPhrase: /.*jenkins\W+run\W+django20\W+a11y.*/,
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django20',
+    triggerPhrase: /.*jenkins\W+run\W+python38\W+a11y.*/,
+    pythonVersion: '3.8',
 ]
 
-Map django21JobConfig = [
+Map django30JobConfig = [
     open: true,
-    jobName: 'edx-platform-django-2.1-accessibility-pr',
+    jobName: 'edx-platform-django-3.0-accessibility-pr',
     repoName: 'edx-platform',
     workerLabel: 'js-worker',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-2.1/a11y',
+    context: 'jenkins/django-3.0/a11y',
     onlyTriggerPhrase: true,
-    triggerPhrase: /.*jenkins\W+run\W+django21\W+a11y.*/,
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django21',
-]
-
-Map django22JobConfig = [
-    open: true,
-    jobName: 'edx-platform-django-2.2-accessibility-pr',
-    repoName: 'edx-platform',
-    workerLabel: 'js-worker',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-2.2/a11y',
-    onlyTriggerPhrase: false,
-    triggerPhrase: /.*jenkins\W+run\W+django22\W+a11y.*/,
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django22',
+    triggerPhrase: /.*jenkins\W+run\W+django30\W+a11y.*/,
+    pythonVersion: '3.8',
+    toxEnv: 'py38-django30',
 ]
 
 Map privateJobConfig = [
@@ -123,9 +109,8 @@ Map privateIronwoodJobConfig = [
 
 List jobConfigs = [
     publicJobConfig,
-    django20JobConfig,
-    django21JobConfig,
-    django22JobConfig,
+    python38JobConfig,
+    django30JobConfig,
     privateJobConfig,
     publicIronwoodJobConfig,
     privateIronwoodJobConfig

--- a/platform/jobs/edxPlatformJsMaster.groovy
+++ b/platform/jobs/edxPlatformJsMaster.groovy
@@ -43,18 +43,6 @@ Map publicJobConfig = [
     pythonVersion: '3.5',
 ]
 
-Map django22JobConfig = [
-    open: true,
-    jobName: 'edx-platform-django-2.2-js-master',
-    repoName: 'edx-platform',
-    workerLabel: 'js-worker',
-    context: 'jenkins/django-2.2/js',
-    refSpec : '+refs/heads/master:refs/remotes/origin/master',
-    defaultBranch : 'master',
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django22',
-]
-
 Map privateJobConfig = [
     open: false,
     jobName: 'edx-platform-js-master_private',
@@ -78,7 +66,6 @@ Map ironwoodJobConfig = [
 
 List jobConfigs = [
     publicJobConfig,
-    django22JobConfig,
     privateJobConfig,
     ironwoodJobConfig
 ]

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -60,43 +60,29 @@ Map publicJobConfig = [
     pythonVersion: '3.5',
 ]
 
-Map django20JobConfig = [
+Map python38JobConfig = [
     open: true,
-    jobName: 'edx-platform-django-2.0-js-pr',
+    jobName: 'edx-platform-python-3.8-js-pr',
     repoName: 'edx-platform',
     workerLabel: 'js-worker',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-2.0/js',
+    context: 'jenkins/python-3.8/js',
     onlyTriggerPhrase: true,
-    triggerPhrase: /.*jenkins\W+run\W+django20\W+js.*/,
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django20',
+    triggerPhrase: /.*jenkins\W+run\W+python38\W+js.*/,
+    pythonVersion: '3.8',
 ]
 
-Map django21JobConfig = [
+Map django30JobConfig = [
     open: true,
-    jobName: 'edx-platform-django-2.1-js-pr',
+    jobName: 'edx-platform-django-3.0-js-pr',
     repoName: 'edx-platform',
     workerLabel: 'js-worker',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-2.1/js',
+    context: 'jenkins/django-3.0/js',
     onlyTriggerPhrase: true,
-    triggerPhrase: /.*jenkins\W+run\W+django21\W+js.*/,
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django21',
-]
-
-Map django22JobConfig = [
-    open: true,
-    jobName: 'edx-platform-django-2.2-js-pr',
-    repoName: 'edx-platform',
-    workerLabel: 'js-worker',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-2.2/js',
-    onlyTriggerPhrase: false,
-    triggerPhrase: /.*jenkins\W+run\W+django22\W+js.*/,
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django22',
+    triggerPhrase: /.*jenkins\W+run\W+django30\W+js.*/,
+    pythonVersion: '3.8',
+    toxEnv: 'py38-django30',
 ]
 
 Map privateJobConfig = [
@@ -132,9 +118,8 @@ Map privateIronwoodJobConfig = [
 
 List jobConfigs = [
     publicJobConfig,
-    django20JobConfig,
-    django21JobConfig,
-    django22JobConfig,
+    python38JobConfig,
+    django30JobConfig,
     privateJobConfig,
     publicIronwoodJobConfig,
     privateIronwoodJobConfig

--- a/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
@@ -58,18 +58,6 @@ Map publicPythonJobConfig = [
     pythonVersion: '3.5',
 ]
 
-Map django22PythonJobConfig = [
-    open: true,
-    jobName: 'edx-platform-django-2.2-python-pipeline-master',
-    repoName: 'edx-platform',
-    jenkinsFileDir: 'scripts/Jenkinsfiles',
-    jenkinsFileName: 'python',
-    branch: 'master',
-    context: 'jenkins/django-2.2/python',
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django22',
-]
-
 Map privatePythonJobConfig = [
     open: false,
     jobName: 'edx-platform-python-pipeline-master_private',
@@ -103,18 +91,6 @@ Map publicQualityJobConfig = [
     pythonVersion: '3.5',
 ]
 
-Map django22QualityJobConfig = [
-    open: true,
-    jobName: 'edx-platform-django-2.2-quality-pipeline-master',
-    repoName: 'edx-platform',
-    jenkinsFileDir: 'scripts/Jenkinsfiles',
-    jenkinsFileName: 'quality',
-    branch: 'master',
-    context: 'jenkins/django-2.2/quality',
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django22',
-]
-
 Map privateQualityJobConfig = [
     open: false,
     jobName: 'edx-platform-quality-pipeline-master_private',
@@ -143,11 +119,9 @@ List jobConfigs = [
     ironwoodBokchoyJobConfig,
     ironwoodLettuceJobConfig,
     publicPythonJobConfig,
-    django22PythonJobConfig,
     privatePythonJobConfig,
     ironwoodPythonJobConfig,
     publicQualityJobConfig,
-    django22QualityJobConfig,
     privateQualityJobConfig,
     ironwoodQualityJobConfig
 ]

--- a/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
@@ -39,46 +39,32 @@ Map publicBokchoyJobConfig = [
     pythonVersion: '3.5',
 ]
 
-Map django20BokchoyJobConfig = [
+Map python38BokchoyJobConfig = [
     open: true,
-    jobName: 'edx-platform-django-2.0-bokchoy-pipeline-pr',
+    jobName: 'edx-platform-python-3.8-bokchoy-pipeline-pr',
     repoName: 'edx-platform',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-2.0/bokchoy',
+    context: 'jenkins/python-3.8/bokchoy',
     onlyTriggerPhrase: true,
-    triggerPhrase: /.*jenkins\W+run\W+django20\W+bokchoy.*/,
+    triggerPhrase: /.*jenkins\W+run\W+python38\W+bokchoy.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'bokchoy',
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django20',
+    pythonVersion: '3.8',
+    toxEnv: 'py38-django22',
 ]
 
-Map django21BokchoyJobConfig = [
+Map django30BokchoyJobConfig = [
     open: true,
-    jobName: 'edx-platform-django-2.1-bokchoy-pipeline-pr',
+    jobName: 'edx-platform-django-3.0-bokchoy-pipeline-pr',
     repoName: 'edx-platform',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-2.1/bokchoy',
+    context: 'jenkins/django-3.0/bokchoy',
     onlyTriggerPhrase: true,
-    triggerPhrase: /.*jenkins\W+run\W+django21\W+bokchoy.*/,
+    triggerPhrase: /.*jenkins\W+run\W+django30\W+bokchoy.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'bokchoy',
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django21',
-]
-
-Map django22BokchoyJobConfig = [
-    open: true,
-    jobName: 'edx-platform-django-2.2-bokchoy-pipeline-pr',
-    repoName: 'edx-platform',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-2.2/bokchoy',
-    onlyTriggerPhrase: true,
-    triggerPhrase: /.*jenkins\W+run\W+django22\W+bokchoy.*/,
-    jenkinsFileDir: 'scripts/Jenkinsfiles',
-    jenkinsFileName: 'bokchoy',
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django22',
+    pythonVersion: '3.8',
+    toxEnv: 'py38-django30',
 ]
 
 Map privateBokchoyJobConfig = [
@@ -159,46 +145,31 @@ Map publicPythonJobConfig = [
     pythonVersion: '3.5',
 ]
 
-Map django20PythonJobConfig = [
+Map python38PythonJobConfig = [
     open: true,
-    jobName: 'edx-platform-django-2.0-python-pipeline-pr',
+    jobName: 'edx-platform-python-3.8-python-pipeline-pr',
     repoName: 'edx-platform',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-2.0/python',
+    context: 'jenkins/python-3.8/python',
     onlyTriggerPhrase: true,
-    triggerPhrase: /.*jenkins\W+run\W+django20\W+python.*/,
+    triggerPhrase: /.*jenkins\W+run\W+python38\W+python.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'python',
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django20',
+    pythonVersion: '3.8',
 ]
 
-Map django21PythonJobConfig = [
+Map django30PythonJobConfig = [
     open: true,
-    jobName: 'edx-platform-django-2.1-python-pipeline-pr',
+    jobName: 'edx-platform-django-3.0-python-pipeline-pr',
     repoName: 'edx-platform',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-2.1/python',
+    context: 'jenkins/django-3.0/python',
     onlyTriggerPhrase: true,
-    triggerPhrase: /.*jenkins\W+run\W+django21\W+python.*/,
+    triggerPhrase: /.*jenkins\W+run\W+django30\W+python.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'python',
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django21',
-]
-
-Map django22PythonJobConfig = [
-    open: true,
-    jobName: 'edx-platform-django-2.2-python-pipeline-pr',
-    repoName: 'edx-platform',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-2.2/python',
-    onlyTriggerPhrase: false,
-    triggerPhrase: /.*jenkins\W+run\W+django22\W+python.*/,
-    jenkinsFileDir: 'scripts/Jenkinsfiles',
-    jenkinsFileName: 'python',
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django22',
+    pythonVersion: '3.8',
+    toxEnv: 'py38-django30',
 ]
 
 Map privatePythonJobConfig = [
@@ -253,46 +224,31 @@ Map publicQualityJobConfig = [
     pythonVersion: '3.5',
 ]
 
-Map django20QualityJobConfig = [
+Map python38QualityJobConfig = [
     open: true,
-    jobName: 'edx-platform-django-2.0-quality-pipeline-pr',
+    jobName: 'edx-platform-python-3.8-quality-pipeline-pr',
     repoName: 'edx-platform',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-2.0/quality',
+    context: 'jenkins/python-3.8/quality',
     onlyTriggerPhrase: true,
-    triggerPhrase: /.*jenkins\W+run\W+django20\W+quality.*/,
+    triggerPhrase: /.*jenkins\W+run\W+python38\W+quality.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'quality',
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django20',
+    pythonVersion: '3.8',
 ]
 
-Map django21QualityJobConfig = [
+Map django30QualityJobConfig = [
     open: true,
-    jobName: 'edx-platform-django-2.1-quality-pipeline-pr',
+    jobName: 'edx-platform-django-3.0-quality-pipeline-pr',
     repoName: 'edx-platform',
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-2.1/quality',
+    context: 'jenkins/django-3.0/quality',
     onlyTriggerPhrase: true,
-    triggerPhrase: /.*jenkins\W+run\W+django21\W+quality.*/,
+    triggerPhrase: /.*jenkins\W+run\W+django30\W+quality.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'quality',
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django21',
-]
-
-Map django22QualityJobConfig = [
-    open: true,
-    jobName: 'edx-platform-django-2.2-quality-pipeline-pr',
-    repoName: 'edx-platform',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/django-2.2/quality',
-    onlyTriggerPhrase: false,
-    triggerPhrase: /.*jenkins\W+run\W+django22\W+quality.*/,
-    jenkinsFileDir: 'scripts/Jenkinsfiles',
-    jenkinsFileName: 'quality',
-    pythonVersion: '3.5',
-    toxEnv: 'py35-django22',
+    pythonVersion: '3.8',
+    toxEnv: 'py38-django30',
 ]
 
 Map privateQualityJobConfig = [
@@ -336,25 +292,22 @@ Map privateQualityIronwoodJobConfig = [
 
 List jobConfigs = [
     publicBokchoyJobConfig,
-    django20BokchoyJobConfig,
-    django21BokchoyJobConfig,
-    django22BokchoyJobConfig,
+    python38BokchoyJobConfig,
+    django30BokchoyJobConfig,
     privateBokchoyJobConfig,
     publicBokchoyIronwoodJobConfig,
     privateBokchoyIronwoodJobConfig,
     publicLettuceIronwoodJobConfig,
     privateLettuceIronwoodJobConfig,
     publicPythonJobConfig,
-    django20PythonJobConfig,
-    django21PythonJobConfig,
-    django22PythonJobConfig,
+    python38PythonJobConfig,
+    django30PythonJobConfig,
     privatePythonJobConfig,
     publicPythonIronwoodJobConfig,
     privatePythonIronwoodJobConfig,
     publicQualityJobConfig,
-    django20QualityJobConfig,
-    django21QualityJobConfig,
-    django22QualityJobConfig,
+    python38QualityJobConfig,
+    django30QualityJobConfig,
     privateQualityJobConfig,
     publicQualityIronwoodJobConfig,
     privateQualityIronwoodJobConfig

--- a/src/test/groovy/platform/edxPlatformMasterSpec.groovy
+++ b/src/test/groovy/platform/edxPlatformMasterSpec.groovy
@@ -44,7 +44,7 @@ class edxPlatformMasterJobSpec extends Specification {
 
         where:
         dslFile                                   | numJobs
-        'edxPlatformAccessibilityMaster.groovy'   | 4
-        'edxPlatformJsMaster.groovy'              | 4
+        'edxPlatformAccessibilityMaster.groovy'   | 3
+        'edxPlatformJsMaster.groovy'              | 3
     }
 }

--- a/src/test/groovy/platform/pipelines/edxPlatformPipelinesMasterSpec.groovy
+++ b/src/test/groovy/platform/pipelines/edxPlatformPipelinesMasterSpec.groovy
@@ -44,6 +44,6 @@ class edxPlatformPipelinesMasterJobSpec extends Specification {
 
         where:
         dslFile                                   | numJobs
-        'edxPlatformPipelineMaster.groovy'        | 12
+        'edxPlatformPipelineMaster.groovy'        | 10
     }
 }


### PR DESCRIPTION
Now that the default test jobs use Django 2.2, remove the upgrade jobs for testing Django 2.x.  I've also and added jobs or testing Python 3.8 and then Django 3.0.  They won't work until we make some updates to the Jenkins worker AMIs (installing Python 3.8 and creating an edx-platform virtualenv using it), but just having them here should be mostly harmless; they'll just fail if intentionally triggered by a PR comment.  The Python 3.8 jobs don't need tox (since they'll have their own virtualenv on the images using that version), but the Django 3.0 ones do in order to tweak the dependencies.