### PR TITLE
Use pip 20.0.2 when updating dependencies

### DIFF
--- a/testeng/resources/upgrade-python-requirements.sh
+++ b/testeng/resources/upgrade-python-requirements.sh
@@ -5,6 +5,9 @@ rm -rf upgrade_venv
 virtualenv --python=python$PYTHON_VERSION upgrade_venv -q
 source upgrade_venv/bin/activate
 
+echo "Upgrading pip..."
+pip install pip==20.0.2
+
 echo "Getting current sha..."
 cd $REPO_NAME
 export CURRENT_SHA=$(git rev-parse HEAD)


### PR DESCRIPTION
The pip-tools 5.0.0 only supports pip>=20, and the previous release won't work with the upcoming pip 20.1.  Explicitly install the current pip release to make this upgrade smoother and start gaining confidence that we can safely upgrade to this pip version more broadly.  This pip release has been the current one for about 3 months, so it seems unlikely to have any critical bugs.