### PR TITLE
[BD-6] Add django-lang-pref-middleware to upgrade Python requirements job.

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -99,6 +99,16 @@ Map djangoConfigModels = [
     emails: ['arch-bom@edx.org']
 ]
 
+Map djangoLangPrefMiddleware = [
+    org: 'edx',
+    repoName: 'django-lang-pref-middleware',
+    pythonVersion: '3.5',
+    cronValue: cronOffHoursBusinessWeekday,
+    githubUserReviewers: [],
+    githubTeamReviewers: ['arch-bom'],
+    emails: ['arch-bom@edx.org']
+]
+
 Map djangoUserTasks = [
     org: 'edx',
     repoName: 'django-user-tasks',
@@ -309,6 +319,7 @@ List jobConfigs = [
     credentialsRepo,
     devstack,
     djangoConfigModels,
+    djangoLangPrefMiddleware,
     djangoUserTasks,
     ecommerce,
     edxAnalyticsDashboard,


### PR DESCRIPTION
Update job that upgrades Python Requirements periodically adding repo that already complies with OEP-18.

**Reviewers**
- [ ] @awais786 
- [x] @morenol