### PR TITLE
[BD-6] Add pytest-repo-health to upgrade Python requirements job.

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -249,6 +249,16 @@ Map portalDesigner = [
     emails: ['masters-requirements-update@edx.opsgenie.net']
 ]
 
+Map pytestRepoHealth = [
+    org: 'edx',
+    repoName: 'pytest-repo-health',
+    pythonVersion: '3.5',
+    cronValue: cronOffHoursBusinessWeekday,
+    githubUserReviewers: ['jinder1s'],
+    githubTeamReviewers: ['arch-bom'],
+    emails: ['arch-bom@edx.org']
+]
+
 Map registrar = [
     org: 'edx',
     repoName: 'registrar',
@@ -324,6 +334,7 @@ List jobConfigs = [
     opaqueKeys,
     openEdxStats,
     portalDesigner,
+    pytestRepoHealth,
     registrar,
     testengCI,
     xblock,


### PR DESCRIPTION
Update job that upgrades Python Requirements periodically adding repo that already complies with OEP-18.

**Reviewers**
- [ ] @awais786 
- [x] @morenol