### PR TITLE
[BD-6] Use python 3 in upgrade jobs

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -32,7 +32,7 @@ Map apiDocTools = [
 Map bokchoy = [
     org: 'edx',
     repoName: 'bok-choy',
-    pythonVersion: '2.7',
+    pythonVersion: '3.5',
     cronValue: cronOffHoursBusinessWeekday,
     githubUserReviewers: [],
     githubTeamReviewers: ['arch-bom'],
@@ -212,7 +212,7 @@ Map edxRestApiClient = [
 Map edxSphinxTheme = [
     org: 'edx',
     repoName: 'edx-sphinx-theme',
-    pythonVersion: '2.7',
+    pythonVersion: '3.5',
     cronValue: cronOffHoursBusinessWeekday,
     githubUserReviewers: [''],
     githubTeamReviewers: ['arch-bom'],


### PR DESCRIPTION
Change version of python in upgrade jobs.

Note that we still need to do the change for:
 - [ ] edx-gomatic
 - [ ] testeng-ci
