### PR TITLE
[BD-6] Run travis counts with python 3.5

### DIFF
--- a/testeng/jobs/travisCounts.groovy
+++ b/testeng/jobs/travisCounts.groovy
@@ -25,6 +25,11 @@ job('travis-counts') {
         timestamps()
     }
 
+
+    environmentVariables {
+        env('PYTHON_VERSION', '3.5')
+    }
+
     steps {
        shell(readFileFromWorkspace('testeng/resources/travis-counts.sh'))
      }

--- a/testeng/jobs/travisJobCounts.groovy
+++ b/testeng/jobs/travisJobCounts.groovy
@@ -25,6 +25,10 @@ job('travis-job-counts') {
         timestamps()
     }
 
+    environmentVariables {
+        env('PYTHON_VERSION', '3.5')
+    }
+
     steps {
        shell(readFileFromWorkspace('testeng/resources/travis-job-counts.sh'))
      }

--- a/testeng/resources/travis-counts.sh
+++ b/testeng/resources/travis-counts.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-virtualenv venv
+virtualenv --python=python$PYTHON_VERSION venv
 . venv/bin/activate
 
 echo "Installing python requirements..."

--- a/testeng/resources/travis-job-counts.sh
+++ b/testeng/resources/travis-job-counts.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-virtualenv venv
+virtualenv --python=python$PYTHON_VERSION venv
 . venv/bin/activate
 
 echo "Installing requirements..."


### PR DESCRIPTION
Force travis count job to run with python3.5 

Related to https://github.com/edx/testeng-ci/pull/227

## Reviewers
 - [ ] @awais786 
 - [ ] @ericfab179 