### PR TITLE
Estute/deng 210

### DIFF
--- a/dataeng/jobs/createJobs.groovy
+++ b/dataeng/jobs/createJobs.groovy
@@ -253,3 +253,24 @@ listView('dbt') {
     }
     columns DEFAULT_VIEW.call()
 }
+
+listView('Deprecated') {
+    jobs {
+        regex('DEPRECATED-.*')
+    }
+    columns DEFAULT_VIEW.call()
+}
+
+listView('Current') {
+    jobs {
+        regex('(?!DEPRECATED-).*')
+    }
+    columns DEFAULT_VIEW.call()
+}
+
+// Manually add jobs that are not captured in DSL to this view
+listView('Custom') {
+    jobs {
+    }
+    columns DEFAULT_VIEW.call()
+}


### PR DESCRIPTION
As part of the cutover process from the old DE jenkins server to the new one, I have created a new seed job. This should be run on the new server as jobs are ported. Additionally, there are three new views added to the old seed job, which will help us organize which jobs have been ported, which still need to be, and which ones are custom jobs, not codified in DSL.