### PR TITLE
add a job to show jenkins plugin update path

### DIFF
--- a/testeng/jobs/showPluginUpgrade.groovy
+++ b/testeng/jobs/showPluginUpgrade.groovy
@@ -21,7 +21,7 @@ job('show-jenkins-plugin-updates') {
     logRotator JENKINS_PUBLIC_LOG_ROTATOR()
     label('coverage-worker')
 
-    scm {
+    multiscm {
         git {
             remote {
                 url('https://github.com/edx/configuration')

--- a/testeng/jobs/showPluginUpgrade.groovy
+++ b/testeng/jobs/showPluginUpgrade.groovy
@@ -1,0 +1,67 @@
+package testeng
+
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_TEAM_SECURITY
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.JENKINS_PUBLIC_LOG_ROTATOR
+
+job('show-jenkins-plugin-updates') {
+
+    description('compare the plugin installations between two branches of the configuration repo')
+
+    parameters {
+        stringParam('BASE_BRANCH', 'master',
+                    'Base branch of the configuration repo. This is used for comparing your changes to the existing state of Jenkins')
+        stringParam('TARGET_BRANCH', 'master',
+                    'Target branch of the configuration repo. This should contain your changes to the set of desired plugins')
+        stringParam('PLUGIN_CONFIG_FILE', 'playbooks/roles/jenkins_build/defaults/main.yml',
+                    'Path (relative to edx/configuration) to the file containig the list of plugins you are updating')
+        stringParam('PLUGIN_CONFIG_KEY', 'build_jenkins_plugins_list',
+                    'Key to the list of plugins within the PLUGIN_CONFIG file')
+    }
+
+    logRotator JENKINS_PUBLIC_LOG_ROTATOR()
+    label('coverage-worker')
+
+    scm {
+        git {
+            remote {
+                url('https://github.com/edx/configuration')
+            }
+            branch('\${BASE_BRANCH}')
+            browser()
+            extensions {
+                relativeTargetDirectory('configuration-base')
+            }
+        }
+        git {
+            remote {
+                url('https://github.com/edx/configuration')
+            }
+            branch('\${TARGET_BRANCH}')
+            browser()
+            extensions {
+                relativeTargetDirectory('configuration-target')
+            }
+        }
+        git {
+            remote {
+                url('https://github.com/edx/jenkins-configuration')
+            }
+            branch('master')
+            browser()
+        }
+    }
+
+    wrappers {
+        timeout {
+            absolute(10)
+            abortBuild()
+        }
+        timestamps()
+        colorizeOutput('xterm')
+    }
+
+    steps {
+        shell(readFileFromWorkspace('testeng/resources/show-jenkins-plugin-updates.sh'))
+    }
+
+}

--- a/testeng/resources/show-jenkins-plugin-updates.sh
+++ b/testeng/resources/show-jenkins-plugin-updates.sh
@@ -4,13 +4,13 @@ cd jenkins-configuration
 source local_env.sh.sample
 
 # Write the plugins installed by the base configuration branch to 'base_installed_plugins'
-export PLUGIN_CONFIG="../configuration-base/${PLUGIN_CONFIG_FILE}"
+export PLUGIN_CONFIG="${WORKSPACE}/configuration-base/${PLUGIN_CONFIG_FILE}"
 export PLUGIN_CONFIG_KEY="${PLUGIN_CONFIG_KEY}"
 make clean.ws plugins
 mv installed_plugins base_installed_plugins
 
 # Write the plugins installed by the target configuration branch to 'target_installed_plugins'
-export PLUGIN_CONFIG="../configuration-target/${PLUGIN_CONFIG_FILE}"
+export PLUGIN_CONFIG="${WORKSPACE}/configuration-target/${PLUGIN_CONFIG_FILE}"
 export PLUGIN_CONFIG_KEY="${PLUGIN_CONFIG_KEY}"
 make clean.ws plugins
 mv installed_plugins target_installed_plugins

--- a/testeng/resources/show-jenkins-plugin-updates.sh
+++ b/testeng/resources/show-jenkins-plugin-updates.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cd jenkins-configuration
+source local_env.sh.sample
+
+# Write the plugins installed by the base configuration branch to 'base_installed_plugins'
+export PLUGIN_CONFIG="../configuration-base/${PLUGIN_CONFIG_FILE}"
+export PLUGIN_CONFIG_KEY="${PLUGIN_CONFIG_KEY}"
+make clean.ws plugins
+mv installed_plugins base_installed_plugins
+
+# Write the plugins installed by the target configuration branch to 'target_installed_plugins'
+export PLUGIN_CONFIG="../configuration-target/${PLUGIN_CONFIG_FILE}"
+export PLUGIN_CONFIG_KEY="${PLUGIN_CONFIG_KEY}"
+make clean.ws plugins
+mv installed_plugins target_installed_plugins
+
+echo "***************************************************************"
+
+# Compare the two outputs of the above commands to see what changes between the two
+python scripts/compare_installed_plugins.py base_installed_plugins target_installed_plugins
+echo "Make sure to check the Changelog for any of the plugins mentioned above"


### PR DESCRIPTION
Add a job to run the script added in https://github.com/edx/jenkins-configuration/pull/146

Example output of script:
```
 python scripts/compare_installed_plugins.py before_upgrade.locked after_upgrade.locked 
The following plugins will be installed:
ghprb: 1.42.1
bouncycastle-api: 2.16.1

The following plugins will be removed:

The following plugins will be updated:
plain-credentials: 1.3 -> 1.4
github-api: 1.90 -> 1.92
```