### PR TITLE
cutover de admin jobs

### DIFF
--- a/dataeng/jobs/createJobs.groovy
+++ b/dataeng/jobs/createJobs.groovy
@@ -28,16 +28,11 @@ import static analytics.LoadEvents.load_events_to_vertica_job as LoadEventsToVer
 import static analytics.LoadEvents.load_json_events_to_s3_job as LoadJsonEventsToS3Job
 import static analytics.LoadEvents.load_json_events_to_bigquery_job as LoadJsonEventsToBigqueryJob
 import static analytics.VerticaReplicaImport.job as VerticaReplicaImportJob
-import static analytics.BackupVertica.job as BackupVerticaJob
 import static analytics.TotalEventsDailyReport.job as TotalEventsDailyReportJob
 import static analytics.JenkinsBackup.job as JenkinsBackupJob
 import static analytics.LoadCourseStructure.job as LoadCourseStructureJob
 import static analytics.Enterprise.job as EnterpriseJob
-import static analytics.VerticaDiskUsageMonitor.job as VerticaDiskUsageMonitorJob
-import static analytics.UpdateUsers.job as UpdateUsersJob
-import static analytics.TerminateCluster.job as TerminateClusterJob
 import static analytics.EnrollmentValidationEvents.job as EnrollmentValidationEventsJob
-import static analytics.DeployCluster.job as DeployClusterJob
 import static analytics.LoadInsightsToVertica.job as LoadInsightsToVerticaJob
 import static analytics.LoadGoogleAnalyticsPermissions.job as LoadGoogleAnalyticsPermissionsJob
 import static analytics.AggregateDailyTrackingLogs.job as AggregateDailyTrackingLogsJob
@@ -108,17 +103,12 @@ def taskMap = [
     LOAD_JSON_EVENTS_TO_BIGQUERY_JOB: LoadJsonEventsToBigqueryJob,
     SNOWFLAKE_SCHEMA_BUILDER_JOB: SnowflakeSchemaBuilderJob,
     VERTICA_REPLICA_IMPORT_JOB: VerticaReplicaImportJob,
-    BACKUP_VERTICA_JOB: BackupVerticaJob,
     TOTAL_EVENTS_DAILY_REPORT_JOB: TotalEventsDailyReportJob,
     JENKINS_BACKUP_JOB: JenkinsBackupJob,
     EVENT_EXPORT_INCREMENTAL_LARGE_JOB: EventExportIncrementalLargeJob,
     LOAD_COURSE_STRUCTURE_JOB: LoadCourseStructureJob,
     ENTERPRISE_JOB: EnterpriseJob,
-    TERMINATE_CLUSTER_JOB: TerminateClusterJob,
-    VERTICA_DISK_USAGE_MONITOR_JOB: VerticaDiskUsageMonitorJob,
-    UPDATE_USERS_JOB: UpdateUsersJob,
     ENROLLMENT_VALIDATION_EVENTS_JOB: EnrollmentValidationEventsJob,
-    DEPLOY_CLUSTER_JOB: DeployClusterJob,
     LOAD_INSIGHTS_TO_VERTICA_JOB: LoadInsightsToVerticaJob,
     LOAD_GOOGLE_ANALYTICS_PERMISSIONS_JOB: LoadGoogleAnalyticsPermissionsJob,
     AGGREGATE_DAILY_TRACKING_LOGS_JOB: AggregateDailyTrackingLogsJob,

--- a/dataeng/jobs/createJobsNew.groovy
+++ b/dataeng/jobs/createJobsNew.groovy
@@ -1,6 +1,11 @@
 import static analytics.EmrCostReporter.job as EmrCostReporterJob
 import static analytics.ExpireVerticaPassword.job as ExpireVerticaPasswordJob
 import static analytics.SnowflakeExpirePasswords.job as SnowflakeExpirePasswordsJob
+import static analytics.DeployCluster.job as DeployClusterJob
+import static analytics.TerminateCluster.job as TerminateClusterJob
+import static analytics.UpdateUsers.job as UpdateUsersJob
+import static analytics.VerticaDiskUsageMonitor.job as VerticaDiskUsageMonitorJob
+import static analytics.BackupVertica.job as BackupVerticaJob
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.DEFAULT_VIEW
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.error.YAMLException
@@ -26,6 +31,11 @@ def taskMap = [
     EMR_COST_REPORTER_JOB: EmrCostReporterJob,
     EXPIRE_VERTICA_PASSWORD_JOB: ExpireVerticaPasswordJob,
     SNOWFLAKE_EXPIRE_PASSWORDS_JOB: SnowflakeExpirePasswordsJob,
+    DEPLOY_CLUSTER_JOB: DeployClusterJob,
+    TERMINATE_CLUSTER_JOB: TerminateClusterJob,
+    BACKUP_VERTICA_JOB: BackupVerticaJob,
+    UPDATE_USERS_JOB: UpdateUsersJob,
+    VERTICA_DISK_USAGE_MONITOR_JOB: VerticaDiskUsageMonitorJob,
 ]
 
 for (task in taskMap) {


### PR DESCRIPTION
remove the admin jobs from old analytics jenkins to our new instance. These include jobs that are not part of long running pipelines or triggered by non-de people (think warehouse-transforms or sql-scripts).