### PR TITLE
Remove single quotes to make command runnable.

### DIFF
--- a/dataeng/resources/warehouse-transforms.sh
+++ b/dataeng/resources/warehouse-transforms.sh
@@ -36,7 +36,7 @@ then
     if [ "$TEST_SOURCES_FIRST" = 'true' ]
     then
         # Exclude the sources from testing, since they were already tested pre-'dbt run'.
-        exclude_models="$exclude_models 'source:*'"
+        exclude_models="$exclude_models source:*"
     fi
 
     if [ "$MODEL_TAG" = 'daily' ]


### PR DESCRIPTION
I've tested this new bash code locally and it appears to work. The single quotes weren't needed - but were being expanded weirdly, like this:
```
18:05:10 + '[' false '!=' true ']'
18:05:10 + exclude_models=
18:05:10 + exclude_param=
18:05:10 + '[' true = true ']'
18:05:10 + exclude_models=' '\''source:*'\'''
18:05:10 + '[' daily = daily ']'
18:05:10 + exclude_models=' '\''source:*'\'' finrep_map_organization_course_courserun finrep_report_royalty_dimension'
18:05:10 + '[' ' '\''source:*'\'' finrep_map_organization_course_courserun finrep_report_royalty_dimension' '!=' '' ']'
18:05:10 + exclude_param='--exclude  '\''source:*'\'' finrep_map_organization_course_courserun finrep_report_royalty_dimension'
18:05:10 + dbt test --models tag:daily --exclude ''\''source:*'\''' finrep_map_organization_course_courserun finrep_report_royalty_dimension --profile warehouse_transforms --target prod --profiles-dir /var/lib/jenkins/workspace/warehouse-transforms-daily/analytics-secure/warehouse-transforms/
```