### PR TITLE
Stop mentionting Master's on upgrade PRs; OpsGenie alerts suffice

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -68,7 +68,7 @@ Map completion = [
     pythonVersion: '3.5',
     cronValue: cronOffHoursBusinessWeekday,
     githubUserReviewers: [],
-    githubTeamReviewers: ['masters-devs'],
+    githubTeamReviewers: [],  // Reviewer mention unnecessary due to Master's OpsGenie alert.
     emails: ['masters-requirements-update@edx.opsgenie.net'],
     alwaysNotify: true
 ]
@@ -101,7 +101,7 @@ Map credentialsRepo = [
     pythonVersion: '3.5',
     cronValue: cronOffHoursBusinessWeekday,
     githubUserReviewers: [],
-    githubTeamReviewers: ['masters-devs'],
+    githubTeamReviewers: [],  // Reviewer mention unnecessary due to Master's OpsGenie alert.
     emails: ['masters-requirements-update@edx.opsgenie.net'],
     alwaysNotify: true
 ]
@@ -258,7 +258,7 @@ Map edxProctoring = [
     pythonVersion: '3.5',
     cronValue: cronOffHoursBusinessWeekday,
     githubUserReviewers: [],
-    githubTeamReviewers: ['masters-devs'],
+    githubTeamReviewers: [],  // Reviewer mention unnecessary due to Master's OpsGenie alert.
     emails: ['masters-requirements-update@edx.opsgenie.net'],
     alwaysNotify: true
 ]
@@ -324,7 +324,7 @@ Map portalDesigner = [
     pythonVersion: '3.5',
     cronValue: cronOffHoursBusinessWeekday,
     githubUserReviewers: [],
-    githubTeamReviewers: ['masters-devs'],
+    githubTeamReviewers: [],  // Reviewer mention unnecessary due to Master's OpsGenie alert.
     emails: ['masters-requirements-update@edx.opsgenie.net'],
     alwaysNotify: true
 ]
@@ -335,7 +335,7 @@ Map registrar = [
     pythonVersion: '3.5',
     cronValue: cronOffHoursBusinessWeekday,
     githubUserReviewers: [],
-    githubTeamReviewers: ['masters-devs'],
+    githubTeamReviewers: [],  // Reviewer mention unnecessary due to Master's OpsGenie alert.
     emails: ['masters-requirements-update@edx.opsgenie.net'],
     alwaysNotify: true
 ]


### PR DESCRIPTION
I like relying on GitHub mentions for PR reviews, etc. But the upgrade PRs absolutely blow up my GitHub notifications, and they're unnecessary because the support engineers already get email notifications from OpsGenie about the upgrade PRs.

I imagine I'm not the only one who feels this way, so here's a PR to stop the @edx/masters-devs mentions.

Let me know if you oppose this. I won't be getting these emails much longer anyway, so I don't have much skin in the game :)