### PR TITLE
move backup vertica job to older jenkins

### DIFF
--- a/dataeng/jobs/createJobs.groovy
+++ b/dataeng/jobs/createJobs.groovy
@@ -53,6 +53,7 @@ import static analytics.ProgramEnrollmentReports.job as ProgramEnrollmentReports
 import static analytics.SnowflakeMicrobachelorsITK.job as SnowflakeMicrobachelorsITKJob
 import static analytics.StitchSnowflakeLagMonitor.job as StitchSnowflakeLagMonitorJob
 import static analytics.SnowflakePublicGrantsCleaner.job as SnowflakePublicGrantsCleanerJob
+import static analytics.BackupVertica.job as BackupVerticaJob
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.DEFAULT_VIEW
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.error.YAMLException
@@ -129,6 +130,7 @@ def taskMap = [
     SNOWFLAKE_MICROBACHELORS_ITK_JOB: SnowflakeMicrobachelorsITKJob,
     STITCH_SNOWFLAKE_LAG_MONITOR_JOB: StitchSnowflakeLagMonitorJob,
     SNOWFLAKE_PUBLIC_GRANTS_CLEANER_JOB: SnowflakePublicGrantsCleanerJob,
+    BACKUP_VERTICA_JOB: BackupVerticaJob,
 ]
 
 for (task in taskMap) {

--- a/dataeng/jobs/createJobsNew.groovy
+++ b/dataeng/jobs/createJobsNew.groovy
@@ -5,7 +5,6 @@ import static analytics.DeployCluster.job as DeployClusterJob
 import static analytics.TerminateCluster.job as TerminateClusterJob
 import static analytics.UpdateUsers.job as UpdateUsersJob
 import static analytics.VerticaDiskUsageMonitor.job as VerticaDiskUsageMonitorJob
-import static analytics.BackupVertica.job as BackupVerticaJob
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.DEFAULT_VIEW
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.error.YAMLException
@@ -33,7 +32,6 @@ def taskMap = [
     SNOWFLAKE_EXPIRE_PASSWORDS_JOB: SnowflakeExpirePasswordsJob,
     DEPLOY_CLUSTER_JOB: DeployClusterJob,
     TERMINATE_CLUSTER_JOB: TerminateClusterJob,
-    BACKUP_VERTICA_JOB: BackupVerticaJob,
     UPDATE_USERS_JOB: UpdateUsersJob,
     VERTICA_DISK_USAGE_MONITOR_JOB: VerticaDiskUsageMonitorJob,
 ]


### PR DESCRIPTION
For some bizarre reason, when the backup vertica job is run on the new Jenkins, it can connect to the serer, but the vertica cli tool can't tell if the vertica process is running. @HassanJaveed84 and I are unsure what is going on here, so in an effort to get this job to stop failing, I am temporarily porting it back to the old box until I have more time to figure it out.