### PR TITLE
Fix reference name for Python 3.5

### DIFF
--- a/README-Hacking.md
+++ b/README-Hacking.md
@@ -129,11 +129,11 @@ An example error might look like:
 
     FATAL: failed to find the Python installation to use from its name: System-CPython-3.5 (was it deleted?)
 
-You need to set the python installations.
+You need to set the python installations, or make sure you have the correct name for an existing one.
 
-Manage Jenkins -> Configure System -> Python installations
+Manage Jenkins -> Global Tool Configuration -> Python -> Python installations
 
-    Name = System-CPython-3.5
+    Name = PYTHON_3.5
 
     Home or executable = /usr/bin/python3.5
 

--- a/testeng/jobs/backupJenkins.groovy
+++ b/testeng/jobs/backupJenkins.groovy
@@ -113,7 +113,7 @@ secretMap.each { jobConfigs ->
             virtualenv {
                 clear()
                 name('venv')
-                pythonName('System-CPython-3.5')
+                pythonName('PYTHON_3.5')
                 nature('shell')
                 command(script)
             }

--- a/testeng/jobs/oep2Report.groovy
+++ b/testeng/jobs/oep2Report.groovy
@@ -35,7 +35,7 @@ job('oep2-report') {
     steps {
         virtualenv {
             name('oep-venv')
-            pythonName('System-CPython-3.5')
+            pythonName('PYTHON_3.5')
             nature('shell')
             clear(true)
             command(readFileFromWorkspace('testeng/resources/create-oep-report.sh'))


### PR DESCRIPTION
When I updated these from 2.7, I had trouble checking the name of the Python 3.5 installation because the instructions in README-Hacking were incorrect.  I presumed it matched the pattern we used for 2.7 (which was recommended by the ShiningPanda Jenkins plugin), but apparently not.  I found the correct place in the configuration settings, updated the README, and fixed the broken references.  This should get the backup job working again (the OEP-2 checker is currently disabled for other reasons).