### PR TITLE
Revert "Stop mentionting Master's on upgrade PRs; OpsGenie alerts suffice"

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -74,7 +74,7 @@ Map completion = [
     pythonVersion: '3.5',
     cronValue: cronOffHoursBusinessWeekday,
     githubUserReviewers: [],
-    githubTeamReviewers: [],  // Reviewer mention unnecessary due to Master's OpsGenie alert.
+    githubTeamReviewers: ['masters-devs'],
     emails: ['masters-requirements-update@edx.opsgenie.net'],
     alwaysNotify: true
 ]
@@ -110,7 +110,7 @@ Map credentialsRepo = [
     pythonVersion: '3.5',
     cronValue: cronOffHoursBusinessWeekday,
     githubUserReviewers: [],
-    githubTeamReviewers: [],  // Reviewer mention unnecessary due to Master's OpsGenie alert.
+    githubTeamReviewers: ['masters-devs'],
     emails: ['masters-requirements-update@edx.opsgenie.net'],
     alwaysNotify: true
 ]
@@ -282,7 +282,7 @@ Map edxProctoring = [
     pythonVersion: '3.5',
     cronValue: cronOffHoursBusinessWeekday,
     githubUserReviewers: [],
-    githubTeamReviewers: [],  // Reviewer mention unnecessary due to Master's OpsGenie alert.
+    githubTeamReviewers: ['masters-devs'],
     emails: ['masters-requirements-update@edx.opsgenie.net'],
     alwaysNotify: true
 ]
@@ -354,7 +354,7 @@ Map portalDesigner = [
     pythonVersion: '3.5',
     cronValue: cronOffHoursBusinessWeekday,
     githubUserReviewers: [],
-    githubTeamReviewers: [],  // Reviewer mention unnecessary due to Master's OpsGenie alert.
+    githubTeamReviewers: ['masters-devs'],
     emails: ['masters-requirements-update@edx.opsgenie.net'],
     alwaysNotify: true
 ]
@@ -366,7 +366,7 @@ Map registrar = [
     pythonVersion: '3.5',
     cronValue: cronOffHoursBusinessWeekday,
     githubUserReviewers: [],
-    githubTeamReviewers: [],  // Reviewer mention unnecessary due to Master's OpsGenie alert.
+    githubTeamReviewers: ['masters-devs'],
     emails: ['masters-requirements-update@edx.opsgenie.net'],
     alwaysNotify: true
 ]


### PR DESCRIPTION
Reverts edx/jenkins-job-dsl#1007
This pr is causing errors in jenkin:

> 10:00:31 github.GithubException.GithubException: 422 {"message": "Invalid request.\n\nNo subschema in \"anyOf\" matched.\n\"reviewers\" wasn't supplied.\n\"team_reviewers\" wasn't supplied.", "documentation_url": "https://developer.github.com/v3/pulls/review_requests/#create-a-review-request"}
because `githubTeamReviewers` can not be null. Need to revert it and come up with a better way.

