### PR TITLE
Let edx-platform pipeline jobs omit onlyTriggerPhrase

### DIFF
--- a/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
@@ -279,7 +279,9 @@ jobConfigs.each { jobConfig ->
                     admins(ghprbMap['admin'])
                     useGitHubHooks()
                     triggerPhrase(jobConfig.triggerPhrase)
-                    onlyTriggerPhrase(jobConfig.onlyTriggerPhrase)
+                    if (jobConfig.onlyTriggerPhrase) {
+                        onlyTriggerPhrase(true)
+                    }
                     userWhitelist(ghprbMap['userWhiteList'])
                     orgWhitelist(ghprbMap['orgWhiteList'])
                     whiteListTargetBranches([jobConfig.whitelistBranchRegex])


### PR DESCRIPTION
The a11y and JS jobs allow `onlyTriggerPhrase` to be omitted (in which case it takes the default `false` value), but this one was requiring it.  Change it to match the other two so we don't get tripped up again trying to change this in all the files the same way.