### PR TITLE
Replace cookiecutter requirements job.

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -79,9 +79,9 @@ Map completion = [
     alwaysNotify: true
 ]
 
-Map cookiecutterDjangoApp = [
+Map cookiecutters = [
     org: 'edx',
-    repoName: 'cookiecutter-django-app',
+    repoName: 'edx-cookiecutters',
     targetBranch: "master",
     pythonVersion: '3.5',
     cronValue: cronOffHoursBusinessWeekday,
@@ -457,7 +457,7 @@ List jobConfigs = [
     coachingPlugin,
     completion,
     configuration,
-    cookiecutterDjangoApp,
+    cookiecutters,
     courseDiscovery,
     credentialsRepo,
     demographics,


### PR DESCRIPTION
The django app cookiecutter was merged into the new edx-cookiecutters
repo along with many others.