### PR TITLE
Added a jenkins job for python code cleanup

### DIFF
--- a/testeng/jobs/cleanupPythonCode.groovy
+++ b/testeng/jobs/cleanupPythonCode.groovy
@@ -1,0 +1,74 @@
+defaultBranch = 'master'
+
+org = 'edx'
+
+githubUserReviewers = ['']
+
+githubTeamReviewers = ['arbi-bom']
+
+emails = ['arbi-bom@edx.org']
+
+
+job('cleanup-python-code') {
+
+    parameters {
+            stringParam('repoName', null, 'Name of the target repository')
+            choiceParam('pythonVersion',['3.5', '2.7'], 'Version of python to use')
+            stringParam('packages', '', 'Comma separated list of packages to install')
+            stringParam('scripts', '', 'Comma separated list of scripts to run')
+        }
+
+        repoName = '$repoName'
+        pythonVersion = '$pythonVersion'
+        packagesToInstall = '$packages'
+        scriptsToRun = '$scripts'
+
+        environmentVariables(
+              REPO_NAME: repoName,
+              ORG: org,
+              PACKAGES: packagesToInstall,
+              SCRIPTS: scriptsToRun,
+              PYTHON_VERSION: pythonVersion,
+              PR_USER_REVIEWERS: githubUserReviewers.join(','),
+              PR_TEAM_REVIEWERS: githubTeamReviewers.join(',')
+         )
+
+        multiscm {
+            git {
+                remote {
+                    credentials('jenkins-worker')
+                    url("git@github.com:edx/${repoName}.git")
+                }
+                branch('master')
+                extensions {
+                    cleanBeforeCheckout()
+                    relativeTargetDirectory(repoName)
+                }
+            }
+            git {
+                remote {
+                    url('https://github.com/edx/testeng-ci.git')
+                }
+                branch('master')
+                extensions {
+                    cleanBeforeCheckout()
+                    relativeTargetDirectory('testeng-ci')
+                }
+            }
+        }
+
+        wrappers {
+            timeout {
+                absolute(30)
+            }
+            credentialsBinding {
+                string('GITHUB_TOKEN', 'GITHUB_REQUIREMENTS_BOT_TOKEN')
+                string('GITHUB_USER_EMAIL', 'GITHUB_REQUIREMENTS_BOT_EMAIL')
+            }
+            timestamps()
+        }
+
+        steps {
+            shell(readFileFromWorkspace('testeng/resources/cleanup-python-code-create-pr.sh'))
+        }
+}

--- a/testeng/resources/cleanup-python-code-create-pr.sh
+++ b/testeng/resources/cleanup-python-code-create-pr.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+rm -rf code_cleanup_venv
+virtualenv --python=python$PYTHON_VERSION code_cleanup_venv -q
+source code_cleanup_venv/bin/activate
+
+echo "Upgrading pip..."
+pip install pip==20.0.2
+
+echo "Getting current sha..."
+cd $REPO_NAME
+export CURRENT_SHA=$(git rev-parse HEAD)
+
+echo "Running cleanup..."
+
+PACKAGESTOINSTALL=`echo $PACKAGES | tr , " "`
+
+pip install $PACKAGESTOINSTALL
+
+IFS=',' read -ra SCRIPTSTORUN <<< "$SCRIPTS"
+for element in "${SCRIPTSTORUN[@]}"; do
+  `echo $element`
+done
+
+echo "Running script to create PR..."
+cd ../testeng-ci
+pip install -r requirements/base.txt
+python -m jenkins.cleanup_python_code --sha=$CURRENT_SHA --repo_root="../$REPO_NAME" --user_reviewers=$PR_USER_REVIEWERS --team_reviewers=$PR_TEAM_REVIEWERS --packages="$PACKAGES" --scripts="$SCRIPTS"
+
+deactivate
+cd ..
+rm -rf code_cleanup_venv
+


### PR DESCRIPTION
this PR intends to add a job to automate running cleanup scripts for python codebase like `isort`, `2to3`, `pyupgrade` and `black` etc.
Relevant JIRA issue [here](https://openedx.atlassian.net/browse/BOM-1771).