### PR TITLE
removed docstring (DE-269)

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeQueueDepth.groovy
+++ b/dataeng/jobs/analytics/SnowflakeQueueDepth.groovy
@@ -7,9 +7,7 @@ import static org.edx.jenkins.dsl.AnalyticsConstants.secure_scm_parameters
 
 
 class SnowflakeQueueDepth {
-"""
-This job runs every 5 minutes using the Snowflake task automation user.
-"""
+
     public static def job = { dslFactory, allVars ->
 
         dslFactory.job("collect-queue-depth") {


### PR DESCRIPTION
Removed the docstring from SnowflakeQueueDepth.groovy due to (a) it not being proper groovy syntax for commenting, and (b) it may potentially cause confusion if the job changes frequency.

This is related to DE-269