### PR TITLE
Have enrollment job pass date to module engagement

### DIFF
--- a/dataeng/jobs/analytics/Enrollment.groovy
+++ b/dataeng/jobs/analytics/Enrollment.groovy
@@ -21,7 +21,15 @@ class Enrollment {
                 wrappers common_wrappers(allVars)
                 publishers common_publishers(allVars)
                 publishers {
-                    downstream("module-engagement-$environment", 'SUCCESS')
+                    downstreamParameterized {
+                        trigger("module-engagement-$environment") {
+                            condition('SUCCESS')
+                            parameters {
+                                // The contents of this file are generated as part of the script in the build step.
+                                propertiesFile('${WORKSPACE}/downstream.properties')
+                            }
+                        }
+                    }
                 }
                 steps {
                     shell(dslFactory.readFileFromWorkspace('dataeng/resources/enrollment.sh'))

--- a/dataeng/resources/enrollment.sh
+++ b/dataeng/resources/enrollment.sh
@@ -6,6 +6,13 @@ fi
 
 env
 
+# Interpolate the TO_DATE now so that the downstream job is guaranteed to use
+# the same exact date as this job. Otherwise, if this job runs over a date
+# boundary, the downstream job would re-interpolate the value of 'yesterday' on
+# a different date.
+INTERPOLATED_TO_DATE="$(date +%Y-%m-%d -d "$TO_DATE")"
+echo "TO_DATE=${INTERPOLATED_TO_DATE}" > "${WORKSPACE}/downstream.properties"
+
 ${WORKSPACE}/analytics-configuration/automation/run-automated-task.sh \
   ImportEnrollmentsIntoMysql --local-scheduler \
   --interval $(date +%Y-%m-%d -d "$FROM_DATE")-$(date +%Y-%m-%d -d "$TO_DATE") \


### PR DESCRIPTION
To avoid module engagement jobs running and not finding enrollment data for the requested (new) day.  