### PR TITLE
fixed syntax error

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeMetricCollection.groovy
+++ b/dataeng/jobs/analytics/SnowflakeMetricCollection.groovy
@@ -19,7 +19,7 @@ class SnowflakeCollectMetrics {
             CRON: "*/5 * * * *"
         ]
         List jobConfigs = [
-            SnowflakeWarehouseCreditConfig
+            SnowflakeWarehouseCreditConfig,
             SnowflakeQueueDepthConfig
         ]
 


### PR DESCRIPTION
The seed job on new Jenkins is failing due to a syntax error. This PR fixes that.