### PR TITLE
Fix GNU date formatting, should use ISO format

### DIFF
--- a/dataeng/resources/snowflake-validate-stitch.sh
+++ b/dataeng/resources/snowflake-validate-stitch.sh
@@ -3,7 +3,7 @@ set -ex
 
 # Calculate the start of the validation window as 10 days prior to the end of the window.
 COMPARISON_END_TIME="${SQOOP_START_TIME}"
-COMPARISON_START_TIME=$(date -d "${COMPARISON_END_TIME} - 10 days")
+COMPARISON_START_TIME=$(date --utc --iso=minutes -d "${COMPARISON_END_TIME} - 10 days")
 
 # Tooling setup
 cd $WORKSPACE/analytics-tools/snowflake


### PR DESCRIPTION
Before this change, this is what jenkins tried to invoke:

```
19:19:48 + python stitch_vs_sqoop_validation.py --key_path null --passphrase_path null --user null --account null --schema ECOMMERCE --begin_datetime Thu Jul 23 20:38:00 UTC 2020 --end_datetime 2020-08-02T20:38:00Z
```