### PR TITLE
Update ecommerce notifications ownership to Jira routing revenue-tasks email

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -185,7 +185,7 @@ Map ecommerce = [
     cronValue: cronOffHoursBusinessWeekday,
     githubUserReviewers: [],
     githubTeamReviewers: ['ecommerce'],
-    emails: ['revenue-squad-alert@edx.opsgenie.net']
+    emails: ['revenue-tasks@edx.org']
 ]
 
 Map edxAce = [


### PR DESCRIPTION
[REV-1200](https://openedx.atlassian.net/browse/REV-1200). 

Revenue squad has created the email revenue-tasks@edx.org to route notifications to Jira, updating the ownership contact for ecommerce here. 