### PR TITLE
Fixup bash test builtin syntax for boolean OR

### DIFF
--- a/dataeng/resources/snowflake-replica-import.sh
+++ b/dataeng/resources/snowflake-replica-import.sh
@@ -9,7 +9,7 @@ env
 
 DAY_OF_WEEK=$(date +%u)
 MONDAY=1
-if [[ ${DAY_OF_WEEK} -eq ${MONDAY} -o ${FORCE} = "true" ]]; then
+if [[ ${DAY_OF_WEEK} -eq ${MONDAY} || ${FORCE} = "true" ]]; then
     # Prepare the downstream properties file:
     printf '' > "${WORKSPACE}/downstream.properties"  # Truncate the file first.
     echo "APP_NAME=${APP_NAME}" >> "${WORKSPACE}/downstream.properties"


### PR DESCRIPTION
DENG-359

Testing
---

```
tsankey@x1carbon:~$ if [[ true == true -o true = false ]]; then echo yes; fi
bash: syntax error in conditional expression
bash: syntax error near `-o'
tsankey@x1carbon:~$ if [[ true == true || true = false ]]; then echo yes; fi
yes
tsankey@x1carbon:~$ if [[ true == false || true = false ]]; then echo yes; fi
tsankey@x1carbon:~$ 
```