### PR TITLE
Fix two issues with replica jobs

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeReplicaImportFromS3.groovy
+++ b/dataeng/jobs/analytics/SnowflakeReplicaImportFromS3.groovy
@@ -23,7 +23,7 @@ class SnowflakeReplicaImportFromS3 {
                 SCRATCH_SCHEMA: 'LMS_SCRATCH_LOADING',
                 DATABASE: 'wwc',
                 INCLUDE: '',
-                EXCLUDE: '--exclude ["student_passwordhistory",".*courseware_studentmodule.*","oauth.*","shoppingcart_orderitem","certificates_certificateinvalidation","certificates_certificategenerationhistory","enterprise_enterprisecustomerreportingconfiguration","social_auth_partial"]',
+                EXCLUDE: '--exclude [\\"student_passwordhistory\\",\\".*courseware_studentmodule.*\\",\\"oauth.*\\",\\"shoppingcart_orderitem\\",\\"certificates_certificateinvalidation\\",\\"certificates_certificategenerationhistory\\",\\"enterprise_enterprisecustomerreportingconfiguration\\",\\"social_auth_partial\\"]',
             ],
             DISCOVERY: [
                 CLUSTER_NAME: 'ImportDiscoveryReadReplicaSnowflakeFromS3',
@@ -31,7 +31,7 @@ class SnowflakeReplicaImportFromS3 {
                 SCRATCH_SCHEMA: 'DISCOVERY_SCRATCH_LOADING',
                 DATABASE: 'discovery',
                 INCLUDE: '',
-                EXCLUDE: '--exclude ["auth_.*","core_.*","django_.*","social_auth_.*","waffle_.*"]',
+                EXCLUDE: '--exclude [\\"auth_.*\\",\\"core_.*\\",\\"django_.*\\",\\"social_auth_.*\\",\\"waffle_.*\\"]',
             ],
             ECOMMERCE: [
                 CLUSTER_NAME: 'ImportEcommerceReadReplicaSnowflakeFromS3',

--- a/dataeng/resources/read-replica-export.sh
+++ b/dataeng/resources/read-replica-export.sh
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
 
+set -ex
+
 env
 
-# Truncate downstream properties file:
-printf '' > "${WORKSPACE}/downstream.properties"
+# Cleanup downstream properties file first:
+DOWNSTREAM_PROPERTIES_FILE="${WORKSPACE}/downstream.properties"
+rm "${DOWNSTREAM_PROPERTIES_FILE}" || true
 
 # Keep track of the start time to feed into downstream validation scripts.
-echo "SQOOP_START_TIME=$(date --utc --iso=minutes)" >> "${WORKSPACE}/downstream.properties"
+echo "SQOOP_START_TIME=$(date --utc --iso=minutes)" >> "${DOWNSTREAM_PROPERTIES_FILE}"
 
 # Interpolate the RUN_DATE now so that the downstream job is guaranteed to use
 # the same exact date as this job. Otherwise, if this job runs over a date
 # boundary, the downstream job would re-interpolate the value of 'yesterday' on
 # a different date.
 INTERPOLATED_RUN_DATE="$(date +%Y-%m-%d -d "$TO_DATE")"
-echo "RUN_DATE=${INTERPOLATED_RUN_DATE}" > "${WORKSPACE}/downstream.properties"
+echo "RUN_DATE=${INTERPOLATED_RUN_DATE}" >> "${DOWNSTREAM_PROPERTIES_FILE}"
 
 ${WORKSPACE}/analytics-configuration/automation/run-automated-task.sh \
  ExportMysqlDatabaseToS3Task --local-scheduler \


### PR DESCRIPTION
1. In one job the downstream properties file gets clobbered on accident,
   so avoid that by appending instead of truncating.

2. Regarding the --exclude parameter, somewhere along the
   groovy->jenkins->bash->luigi code path we are apparently missing
   backslash escape charaters for double quotes.  This commit adds them
   back.

DENG-359

Testing
---

The old shell argument that worked:
```bash
--exclude '[\"student_passwordhistory\",\".*courseware_studentmodule.*\",\"oauth.*\",\"shoppingcart_orderitem\",\"certificates_certificateinvalidation\",\"certificates_certificategenerationhistory\",\"enterprise_enterprisecustomerreportingconfiguration\",\"social_auth_partial\"]'
```

The new shell argument that is throwing JSON parse errors:
```bash
--exclude '["student_passwordhistory",".*courseware_studentmodule.*","oauth.*","shoppingcart_orderitem","certificates_certificateinvalidation","certificates_certificategenerationhistory","enterprise_enterprisecustomerreportingconfiguration","social_auth_partial"]'
```

It appears that the string literal that we need to pass into Luigi params needs the backslashes.  Using the jenkins /script endpoint, I was able to test how groovy evaluates the string literal:

```groovy
// Baseline test, the current behavior:
String test = '[\"student_passwordhistory\"]'
Result: ["student_passwordhistory"]

// Test with only ONE backslash:
String test = '[\"student_passwordhistory\"]'
Result: ["student_passwordhistory"]

// Test with two backslashes results in the desired behavior of inserting a
// literal backslash in the string:
String test = '[\\"student_passwordhistory\\"]'
Result: [\"student_passwordhistory\"]
```

In conclusion, my fix is to double-backslash all the double quotes in the --exclude statement.  Here's what the parameter looks like after I seeded the job:

![image](https://user-images.githubusercontent.com/85151/89794619-4ce2dc00-daf5-11ea-9100-d40dac4b6baa.png)
