### PR TITLE
Bump edx-platform version in Analytics Exporter jobs

### DIFF
--- a/dataeng/jobs/analytics/AnalyticsEmailOptin.groovy
+++ b/dataeng/jobs/analytics/AnalyticsEmailOptin.groovy
@@ -63,7 +63,7 @@ class AnalyticsEmailOptin {
                 stringParam('ORGS','*', 'Space separated list of organizations to process. Can use wildcards. e.g.: idbx HarvardX')
                 stringParam('EXPORTER_BRANCH','environment/production',
                         'Branch from the edx-analytics-exporter repository. For tags use tags/[tag-name]. Should be environment/production.')
-                stringParam('PLATFORM_BRANCH','tags/release-2020-09-08-16.55',
+                stringParam('PLATFORM_BRANCH','tags/release-2020-09-17-15.06',
                         'Branch from the edx-platform repository. For tags use tags/[tag-name]')
                 stringParam('EXPORTER_CONFIG_FILENAME','default.yaml', 'Name of configuration file in analytics-secure/analytics-exporter.')
                 stringParam('OUTPUT_BUCKET', allVars.get('EMAIL_OPTIN_OUTPUT_BUCKET'), 'Name of the bucket for the destination of the email opt-in data.')

--- a/dataeng/jobs/analytics/AnalyticsExporter.groovy
+++ b/dataeng/jobs/analytics/AnalyticsExporter.groovy
@@ -10,7 +10,7 @@ class AnalyticsExporter {
             parameters {
                 stringParam('COURSES', '', 'Space separated list of courses to process. E.g. --course=course-v1:BerkleeX+BMPR365_3x+1T2015')
                 stringParam('EXPORTER_BRANCH', 'environment/production', 'Branch from the analytics-exporter repository. For tags use tags/[tag-name].')
-                stringParam('PLATFORM_BRANCH', 'tags/release-2020-09-08-16.55', 'Branch from the exporter repository. For tags use tags/[tag-name].')
+                stringParam('PLATFORM_BRANCH', 'tags/release-2020-09-17-15.06', 'Branch from the exporter repository. For tags use tags/[tag-name].')
                 stringParam('EXPORTER_CONFIG_FILENAME', 'course_exporter.yaml', 'Name of configuration file in analytics-secure/analytics-exporter.')
                 stringParam('OUTPUT_BUCKET', '', 'Name of the bucket for the destination of the export data. Can use a path. (eg. export-data/test).')
                 stringParam('NOTIFY', '', 'Space separated list of emails to notify in case of failure.')
@@ -137,7 +137,7 @@ class AnalyticsExporter {
             parameters {
                 stringParam('ORGS', '*', 'Space separated list of organizations to process. Can use wildcards. e.g.: idbx HarvardX')
                 stringParam('EXPORTER_BRANCH', 'environment/production', 'Branch from the edx-analytics-exporter repository. For tags use tags/[tag-name].')
-                stringParam('PLATFORM_BRANCH', 'tags/release-2020-09-08-16.55', 'Branch from the edx-platform repository. For tags use tags/[tag-name].')
+                stringParam('PLATFORM_BRANCH', 'tags/release-2020-09-17-15.06', 'Branch from the edx-platform repository. For tags use tags/[tag-name].')
                 stringParam('EXPORTER_CONFIG_FILENAME', 'default.yaml', 'Name of configuration file in analytics-secure/analytics-exporter.')
                 stringParam('OUTPUT_BUCKET', allVars.get('EXPORTER_OUTPUT_BUCKET'), 'Name of the bucket for the destination of the export data. Can use a path. (eg. export-data/test).')
                 stringParam('NOTIFY', allVars.get('ANALYTICS_EXPORTER_NOTIFY_LIST'), 'Space separated list of emails to notify in case of failure.')

--- a/dataeng/resources/run-course-exporter.sh
+++ b/dataeng/resources/run-course-exporter.sh
@@ -4,6 +4,7 @@ mkdir -p ${WORKING_DIRECTORY}/course-data
 
 # Install requirements into this (exporter) virtual environment
 pushd analytics-exporter/
+pip install 'setuptools<45'
 pip install -r github_requirements.txt
 pip install mysql-connector-python -e .
 popd


### PR DESCRIPTION
This is required because edx-platform pins all requirements using exact
(==) versions, but since I tested this last week one of the hundreds of
pinned packages disappeared from pypi.  Given how many packages we
install, I would expect this to happen literally every time we wipe out
the workspace on any of the exporter jobs.

---

Also, I added a second commit:

```
Fix analytics-exporter-course job to work with python 2 again

We havne't installed requirements for this job in so long that now
installs a version of setuptools that is incompatible with python 2.
Pin it here just like in the analytics-exporter-* jobs.
```