### PR TITLE
Update the email optin job to use the fixed mgmt command

### DIFF
--- a/dataeng/jobs/analytics/AnalyticsEmailOptin.groovy
+++ b/dataeng/jobs/analytics/AnalyticsEmailOptin.groovy
@@ -63,8 +63,17 @@ class AnalyticsEmailOptin {
                 stringParam('ORGS','*', 'Space separated list of organizations to process. Can use wildcards. e.g.: idbx HarvardX')
                 stringParam('EXPORTER_BRANCH','environment/production',
                         'Branch from the edx-analytics-exporter repository. For tags use tags/[tag-name]. Should be environment/production.')
-                stringParam('PLATFORM_BRANCH','tags/release-2020-09-17-15.06',
-                        'Branch from the edx-platform repository. For tags use tags/[tag-name]')
+
+                // Temporarily use a hash rather than a release tag because at the time of this DSL change the edxapp
+                // pipeline was stalled and could not create a release tag. The hash below IS ON MASTER and it
+                // corresponds to this PR: https://github.com/edx/edx-platform/pull/25011
+                //
+                // TODO: next week we should fetch the latest release tag and update that here and also in
+                // AnalyticsExporter.groovy.
+                //
+                //stringParam('PLATFORM_BRANCH','tags/release-2020-09-17-15.06', 'Branch from the edx-platform repository. For tags use tags/[tag-name]')
+                stringParam('PLATFORM_BRANCH','b111d05149945634ce60daccd984801a852a9d13', 'Branch from the edx-platform repository. For tags use tags/[tag-name]')
+
                 stringParam('EXPORTER_CONFIG_FILENAME','default.yaml', 'Name of configuration file in analytics-secure/analytics-exporter.')
                 stringParam('OUTPUT_BUCKET', allVars.get('EMAIL_OPTIN_OUTPUT_BUCKET'), 'Name of the bucket for the destination of the email opt-in data.')
                 stringParam('OUTPUT_PREFIX','email-opt-in-', 'Optional prefix to prepend to output filename.')


### PR DESCRIPTION
I just merged this edx-platform PR:

https://github.com/edx/edx-platform/pull/25011

which updates the email_opt_in_list.py management command to port the
changes in our analytics fork back upstream.  Not taking action will
result in a change in behavior of the analytics-email-optin job, which
is what we're trying to avoid.

I would normally use release tags created by the edxapp gocd pipeline,
but the pipeline is borked so I used a hash instead.

Testing
---

Successful. http://jenkins.analytics.edx.org/job/analytics-email-optin-worker/9619/console