### PR TITLE
PortalDesigner upgrade job to use python38 venv

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -500,7 +500,7 @@ Map portalDesigner = [
     org: 'edx',
     repoName: 'portal-designer',
     targetBranch: "master",
-    pythonVersion: '3.5',
+    pythonVersion: '3.8',
     cronValue: cronOffHoursBusinessWeekdayTwiceMonthly,
     githubUserReviewers: [],
     githubTeamReviewers: [],  // Reviewer mention unnecessary due to Master's OpsGenie alert.


### PR DESCRIPTION
**Issue:** [BOM-2046](https://openedx.atlassian.net/browse/BOM-2046)

### Description
- Updated the upgrade job to use `python3.8` in the virtualenv for **portal-designer.**