### PR TITLE
Update demographics upgrade job to python38

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -150,7 +150,7 @@ Map demographics = [
     org: 'edx',
     repoName: 'demographics',
     targetBranch: "master",
-    pythonVersion: '3.6',
+    pythonVersion: '3.8',
     cronValue: cronOffHoursBusinessWeekday,
     githubUserReviewers: [],
     githubTeamReviewers: ['edx-aperture'],


### PR DESCRIPTION
**Issue:** [BOM-2052](https://openedx.atlassian.net/browse/BOM-2052)

### Description
- Updated the upgrade job to use `python3.8`.

Waiting for the https://github.com/edx/demographics/pull/85 to merge before deploying this change.