### PR TITLE
WS-1421 (fix): set prospectus sandbox to reconfigure, not recreate

### DIFF
--- a/devops/jobs/CreateSandboxCI.groovy
+++ b/devops/jobs/CreateSandboxCI.groovy
@@ -111,7 +111,7 @@ class CreateSandboxCI {
                   predefinedProp('name_tag','edx-rebrand')
 
                   predefinedProp('server_type', 'full_edx_installation_from_scratch')
-                  booleanParam('recreate', true)
+                  booleanParam('reconfigure', true)
                   booleanParam('edxapp', false)
                   booleanParam('testcourses', false)
                   booleanParam('performance_course', false)


### PR DESCRIPTION
Recreate terminates the existing instance, whereas reconfigure re-runs ansible against the existing container which is still up.