### PR TITLE
Add env command to heartbeat shell script invocation.

### DIFF
--- a/dataeng/resources/opsgenie-disable-heartbeat.sh
+++ b/dataeng/resources/opsgenie-disable-heartbeat.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Disables an Opsgenie Heartbeat.
 #
 # Assumes that the heartbeat is already created in the Opsgenie settings here:

--- a/dataeng/resources/opsgenie-enable-heartbeat.sh
+++ b/dataeng/resources/opsgenie-enable-heartbeat.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Enables an Opsgenie Heartbeat, while also setting the expected duration.
 #
 # Assumes that the heartbeat is already created in the Opsgenie settings here:


### PR DESCRIPTION
Without this shebang, the environment variables aren't carried into the shell scripts, which is currently causing these scripts to do nothing because of the environment var conditionals.