### PR TITLE
Remove notifier from sandboxes and upgrade jobs DEPR-110

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -142,9 +142,6 @@ class CreateSandbox {
                 stringParam("ecommerce_version","master","")
                 booleanParam("ecommerce_decrypt_and_copy_config_enabled",true,"Checking this option will decrypt and copy ecommerce config file from configuration internal repo.")
 
-                booleanParam("notifier",false,"")
-                stringParam("notifier_version","master","")
-
                 booleanParam("xqueue",false,"")
                 stringParam("xqueue_version","master","")
 

--- a/devops/jobs/CreateSandboxCI.groovy
+++ b/devops/jobs/CreateSandboxCI.groovy
@@ -95,7 +95,6 @@ class CreateSandboxCI {
                   booleanParam("demo_test_course",false)
                   booleanParam("edx_demo_course",false)
                   booleanParam("forum",false)
-                  booleanParam("notifier",false)
                   booleanParam("xqueue",false)
                   booleanParam("ecommerce_worker",false)
                   booleanParam("certs",false)

--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -461,19 +461,6 @@ Map edxVal= [
     githubTeamReviewers: ['sustaining-vulcans'],
     emails: ['sustaining-vulcans@edx.org'],
     alwaysNotify: false
-]
-
-Map notifier = [
-    org: 'edx',
-    repoName: 'notifier',
-    targetBranch: "master",
-    pythonVersion: '3.5',
-    cronValue: cronOffHoursBusinessWeekdayLahore,
-    githubUserReviewers: [],
-    githubTeamReviewers: ['arbi-bom'],
-    emails: ['arbi-bom@edx.org'],
-    alwaysNotify: false
-]
 
 Map opaqueKeys = [
     org: 'edx',
@@ -669,7 +656,6 @@ List jobConfigs = [
     edxSphinxTheme,
     edxToggles,
     edxVal,
-    notifier,
     opaqueKeys,
     openEdxStats,
     portalDesigner,


### PR DESCRIPTION
Remove the option to include notifier in sandboxes, and stop seeding the job to update the notifier repo's Python package dependencies.  Part of the notifier service deprecation ([DEPR-106](https://openedx.atlassian.net/browse/DEPR-106)).