### PR TITLE
Add set command to shell scripts to show execution.

### DIFF
--- a/dataeng/resources/opsgenie-disable-heartbeat.sh
+++ b/dataeng/resources/opsgenie-disable-heartbeat.sh
@@ -9,11 +9,16 @@
 # OPSGENIE_HEARTBEAT_NAME: Name of the already-created Opsgenie heartbeat.
 # OPSGENIE_HEARTBEAT_CONFIG_KEY: API key provided by Opsgenie which is authorized to modify heartbeat configuration.
 
+set -ex
+
+env
 
 OPSGENIE_HEARTBEAT_API_URL="https://api.opsgenie.com/v2/heartbeats"
 
 if [ -n "$OPSGENIE_HEARTBEAT_NAME" ] && \
    [ -n "$OPSGENIE_HEARTBEAT_CONFIG_KEY" ]; then
+
+    echo "Disabling Opsgenie heartbeat for $OPSGENIE_HEARTBEAT_NAME"
 
     AUTH_HEADER="Authorization: GenieKey $OPSGENIE_HEARTBEAT_CONFIG_KEY"
     POST_URL="$OPSGENIE_HEARTBEAT_API_URL/$OPSGENIE_HEARTBEAT_NAME/disable"

--- a/dataeng/resources/opsgenie-enable-heartbeat.sh
+++ b/dataeng/resources/opsgenie-enable-heartbeat.sh
@@ -11,6 +11,9 @@
 # OPSGENIE_HEARTBEAT_DURATION_NUM: Specifies how often a heartbeat message should be expected.
 # OPSGENIE_HEARTBEAT_DURATION_UNIT: Interval specified as minutes, hours or days.
 
+set -ex
+
+env
 
 OPSGENIE_HEARTBEAT_API_URL="https://api.opsgenie.com/v2/heartbeats"
 
@@ -18,6 +21,8 @@ if [ -n "$OPSGENIE_HEARTBEAT_NAME" ] && \
    [ -n "$OPSGENIE_HEARTBEAT_CONFIG_KEY" ] &&  \
    [ -n "$OPSGENIE_HEARTBEAT_DURATION_NUM" ] && \
    [ -n "$OPSGENIE_HEARTBEAT_DURATION_UNIT" ]; then
+
+    echo "Enabling Opsgenie heartbeat for $OPSGENIE_HEARTBEAT_NAME"
 
     AUTH_HEADER="Authorization: GenieKey $OPSGENIE_HEARTBEAT_CONFIG_KEY"
     JSON_HEADER="Content-Type: application/json"


### PR DESCRIPTION
The Opsgenie heartbeat scripts I've added to sandwich some of the jobs isn't actually working, as in this job:
http://jenkins.analytics.edx.org/job/lms-read-replica-export-to-s3/configure

This change will give some visibility into why by showing the script execution.