### PR TITLE
Add code to pull global credential & set envvars for Opsgenie heartbeats

### DIFF
--- a/dataeng/jobs/analytics/AnswerDistribution.groovy
+++ b/dataeng/jobs/analytics/AnswerDistribution.groovy
@@ -11,6 +11,9 @@ class AnswerDistribution {
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("answer-distribution-$environment") {
                 logRotator common_log_rotator(allVars, env_config)
+                multiscm common_multiscm(allVars)
+                triggers common_triggers(allVars, env_config)
+                publishers common_publishers(allVars)
                 parameters {
                     stringParam('SOURCES', env_config.get('SOURCES', allVars.get('SOURCES')), '')
                     stringParam('DESTINATION_PREFIX', env_config.get('DESTINATION_PREFIX', allVars.get('DESTINATION_PREFIX')), '')
@@ -19,10 +22,17 @@ class AnswerDistribution {
                     stringParam('LIB_JAR', env_config.get('LIB_JAR', allVars.get('LIB_JAR')), '')
                 }
                 parameters common_parameters(allVars, env_config)
-                multiscm common_multiscm(allVars)
-                triggers common_triggers(allVars, env_config)
+                environmentVariables {
+                    env('OPSGENIE_HEARTBEAT_NAME', env_config.get('OPSGENIE_HEARTBEAT_NAME'))
+                    env('OPSGENIE_HEARTBEAT_DURATION_NUM', env_config.get('OPSGENIE_HEARTBEAT_DURATION_NUM'))
+                    env('OPSGENIE_HEARTBEAT_DURATION_UNIT', env_config.get('OPSGENIE_HEARTBEAT_DURATION_UNIT'))
+                }
                 wrappers common_wrappers(allVars)
-                publishers common_publishers(allVars)
+                wrappers {
+                    credentialsBinding {
+                        string('OPSGENIE_HEARTBEAT_CONFIG_KEY', 'opsgenie_heartbeat_config_key')
+                    }
+                }
                 steps {
                     shell(dslFactory.readFileFromWorkspace('dataeng/resources/opsgenie-enable-heartbeat.sh'))
                     shell(dslFactory.readFileFromWorkspace('dataeng/resources/answer-distribution.sh'))

--- a/dataeng/jobs/analytics/BackupVertica.groovy
+++ b/dataeng/jobs/analytics/BackupVertica.groovy
@@ -9,12 +9,22 @@ class BackupVertica {
         allVars.get('VERTICA_BACKUPS').each { backup, backup_config ->
             dslFactory.job("backup-vertica-$backup") {
                 logRotator common_log_rotator(backup_config)
-                wrappers common_wrappers(backup_config)
                 publishers common_publishers(backup_config)
                 triggers common_triggers(backup_config)
                 parameters {
                     textParam('BACKUP_CMD', backup_config.get('VERTICA_BACKUP_CMD'), '')
                     stringParam('NOTIFY', '$PAGER_NOTIFY', 'Space separated list of emails to send notifications to.')
+                }
+                environmentVariables {
+                    env('OPSGENIE_HEARTBEAT_NAME', env_config.get('OPSGENIE_HEARTBEAT_NAME'))
+                    env('OPSGENIE_HEARTBEAT_DURATION_NUM', env_config.get('OPSGENIE_HEARTBEAT_DURATION_NUM'))
+                    env('OPSGENIE_HEARTBEAT_DURATION_UNIT', env_config.get('OPSGENIE_HEARTBEAT_DURATION_UNIT'))
+                }
+                wrappers common_wrappers(backup_config)
+                wrappers {
+                    credentialsBinding {
+                        string('OPSGENIE_HEARTBEAT_CONFIG_KEY', 'opsgenie_heartbeat_config_key')
+                    }
                 }
                 steps {
                     shell(dslFactory.readFileFromWorkspace('dataeng/resources/opsgenie-enable-heartbeat.sh'))

--- a/dataeng/jobs/analytics/DatabaseExportCoursewareStudentmodule.groovy
+++ b/dataeng/jobs/analytics/DatabaseExportCoursewareStudentmodule.groovy
@@ -11,6 +11,9 @@ class DatabaseExportCoursewareStudentmodule {
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("database-export-courseware-studentmodule-$environment") {
                 logRotator common_log_rotator(allVars, env_config)
+                multiscm common_multiscm(allVars)
+                triggers common_triggers(allVars, env_config)
+                publishers common_publishers(allVars)
                 parameters {
                     stringParam('BASE_OUTPUT_URL', env_config.get('BASE_OUTPUT_URL', allVars.get('BASE_OUTPUT_URL')), '')
                     stringParam('OUTPUT_DIR', env_config.get('OUTPUT_DIR', allVars.get('OUTPUT_DIR')), '')
@@ -18,10 +21,17 @@ class DatabaseExportCoursewareStudentmodule {
                     stringParam('CREDENTIALS', env_config.get('CREDENTIALS', allVars.get('CREDENTIALS')), '')
                 }
                 parameters common_parameters(allVars, env_config)
-                multiscm common_multiscm(allVars)
-                triggers common_triggers(allVars, env_config)
+                environmentVariables {
+                    env('OPSGENIE_HEARTBEAT_NAME', env_config.get('OPSGENIE_HEARTBEAT_NAME'))
+                    env('OPSGENIE_HEARTBEAT_DURATION_NUM', env_config.get('OPSGENIE_HEARTBEAT_DURATION_NUM'))
+                    env('OPSGENIE_HEARTBEAT_DURATION_UNIT', env_config.get('OPSGENIE_HEARTBEAT_DURATION_UNIT'))
+                }
                 wrappers common_wrappers(allVars)
-                publishers common_publishers(allVars)
+                wrappers {
+                    credentialsBinding {
+                        string('OPSGENIE_HEARTBEAT_CONFIG_KEY', 'opsgenie_heartbeat_config_key')
+                    }
+                }
                 steps {
                     shell(dslFactory.readFileFromWorkspace('dataeng/resources/opsgenie-enable-heartbeat.sh'))
                     shell(dslFactory.readFileFromWorkspace('dataeng/resources/database-export-courseware-studentmodule.sh'))

--- a/dataeng/jobs/analytics/Enrollment.groovy
+++ b/dataeng/jobs/analytics/Enrollment.groovy
@@ -13,12 +13,8 @@ class Enrollment {
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("enrollment-$environment") {
                 logRotator common_log_rotator(allVars)
-                parameters common_parameters(allVars, env_config)
-                parameters from_date_interval_parameter(allVars)
-                parameters to_date_interval_parameter(allVars)
                 multiscm common_multiscm(allVars)
                 triggers common_triggers(allVars, env_config)
-                wrappers common_wrappers(allVars)
                 publishers common_publishers(allVars)
                 publishers {
                     downstreamParameterized {
@@ -29,6 +25,20 @@ class Enrollment {
                                 propertiesFile('${WORKSPACE}/downstream.properties')
                             }
                         }
+                    }
+                }
+                parameters common_parameters(allVars, env_config)
+                parameters from_date_interval_parameter(allVars)
+                parameters to_date_interval_parameter(allVars)
+                environmentVariables {
+                    env('OPSGENIE_HEARTBEAT_NAME', env_config.get('OPSGENIE_HEARTBEAT_NAME'))
+                    env('OPSGENIE_HEARTBEAT_DURATION_NUM', env_config.get('OPSGENIE_HEARTBEAT_DURATION_NUM'))
+                    env('OPSGENIE_HEARTBEAT_DURATION_UNIT', env_config.get('OPSGENIE_HEARTBEAT_DURATION_UNIT'))
+                }
+                wrappers common_wrappers(allVars)
+                wrappers {
+                    credentialsBinding {
+                        string('OPSGENIE_HEARTBEAT_CONFIG_KEY', 'opsgenie_heartbeat_config_key')
                     }
                 }
                 steps {

--- a/dataeng/jobs/analytics/EventExportIncremental.groovy
+++ b/dataeng/jobs/analytics/EventExportIncremental.groovy
@@ -37,9 +37,7 @@ class EventExportIncremental {
                 }
                 publishers common_publishers(allVars)
                 steps {
-                    shell(dslFactory.readFileFromWorkspace('dataeng/resources/opsgenie-enable-heartbeat.sh'))
                     shell(dslFactory.readFileFromWorkspace('dataeng/resources/event-export-incremental.sh'))
-                    shell(dslFactory.readFileFromWorkspace('dataeng/resources/opsgenie-disable-heartbeat.sh'))
                 }
             }
         }

--- a/dataeng/jobs/analytics/ModuleEngagement.groovy
+++ b/dataeng/jobs/analytics/ModuleEngagement.groovy
@@ -11,11 +11,21 @@ class ModuleEngagement {
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("module-engagement-$environment") {
                 logRotator common_log_rotator(allVars)
+                multiscm common_multiscm(allVars)
+                publishers common_publishers(allVars)
                 parameters common_parameters(allVars, env_config)
                 parameters to_date_interval_parameter(allVars)
-                multiscm common_multiscm(allVars)
+                environmentVariables {
+                    env('OPSGENIE_HEARTBEAT_NAME', env_config.get('OPSGENIE_HEARTBEAT_NAME'))
+                    env('OPSGENIE_HEARTBEAT_DURATION_NUM', env_config.get('OPSGENIE_HEARTBEAT_DURATION_NUM'))
+                    env('OPSGENIE_HEARTBEAT_DURATION_UNIT', env_config.get('OPSGENIE_HEARTBEAT_DURATION_UNIT'))
+                }
                 wrappers common_wrappers(allVars)
-                publishers common_publishers(allVars)
+                wrappers {
+                    credentialsBinding {
+                        string('OPSGENIE_HEARTBEAT_CONFIG_KEY', 'opsgenie_heartbeat_config_key')
+                    }
+                }
                 steps {
                     shell(dslFactory.readFileFromWorkspace('dataeng/resources/opsgenie-enable-heartbeat.sh'))
                     shell(dslFactory.readFileFromWorkspace('dataeng/resources/module-engagement.sh'))

--- a/dataeng/jobs/analytics/ReadReplicaExportToS3.groovy
+++ b/dataeng/jobs/analytics/ReadReplicaExportToS3.groovy
@@ -51,8 +51,18 @@ class ReadReplicaExportToS3 {
                     )
                 }
                 parameters to_date_interval_parameter(allVars)
+                environmentVariables {
+                    env('OPSGENIE_HEARTBEAT_NAME', env_config.get('OPSGENIE_HEARTBEAT_NAME'))
+                    env('OPSGENIE_HEARTBEAT_DURATION_NUM', env_config.get('OPSGENIE_HEARTBEAT_DURATION_NUM'))
+                    env('OPSGENIE_HEARTBEAT_DURATION_UNIT', env_config.get('OPSGENIE_HEARTBEAT_DURATION_UNIT'))
+                }
                 multiscm common_multiscm(allVars)
                 wrappers common_wrappers(allVars)
+                wrappers {
+                    credentialsBinding {
+                        string('OPSGENIE_HEARTBEAT_CONFIG_KEY', 'opsgenie_heartbeat_config_key')
+                    }
+                }
                 publishers common_publishers(allVars)
                 publishers {
                     downstreamParameterized {

--- a/dataeng/jobs/analytics/UserLocationByCourse.groovy
+++ b/dataeng/jobs/analytics/UserLocationByCourse.groovy
@@ -12,12 +12,22 @@ class UserLocationByCourse {
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("user-location-by-course-$environment") {
                 logRotator common_log_rotator(allVars, env_config)
-                parameters common_parameters(allVars, env_config)
-                parameters to_date_interval_parameter(allVars)
                 multiscm common_multiscm(allVars)
                 triggers common_triggers(allVars, env_config)
-                wrappers common_wrappers(allVars)
                 publishers common_publishers(allVars)
+                parameters common_parameters(allVars, env_config)
+                parameters to_date_interval_parameter(allVars)
+                environmentVariables {
+                    env('OPSGENIE_HEARTBEAT_NAME', env_config.get('OPSGENIE_HEARTBEAT_NAME'))
+                    env('OPSGENIE_HEARTBEAT_DURATION_NUM', env_config.get('OPSGENIE_HEARTBEAT_DURATION_NUM'))
+                    env('OPSGENIE_HEARTBEAT_DURATION_UNIT', env_config.get('OPSGENIE_HEARTBEAT_DURATION_UNIT'))
+                }
+                wrappers common_wrappers(allVars)
+                wrappers {
+                    credentialsBinding {
+                        string('OPSGENIE_HEARTBEAT_CONFIG_KEY', 'opsgenie_heartbeat_config_key')
+                    }
+                }
                 steps {
                     shell(dslFactory.readFileFromWorkspace('dataeng/resources/opsgenie-enable-heartbeat.sh'))
                     shell(dslFactory.readFileFromWorkspace('dataeng/resources/user-location-by-course.sh'))

--- a/dataeng/jobs/analytics/VideoTimeline.groovy
+++ b/dataeng/jobs/analytics/VideoTimeline.groovy
@@ -13,13 +13,23 @@ class VideoTimeline {
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("video-timeline-$environment") {
                 logRotator common_log_rotator(allVars, env_config)
+                multiscm common_multiscm(allVars)
+                triggers common_triggers(allVars, env_config)
+                publishers common_publishers(allVars)
                 parameters common_parameters(allVars, env_config)
                 parameters from_date_interval_parameter(allVars)
                 parameters to_date_interval_parameter(allVars)
-                multiscm common_multiscm(allVars)
-                triggers common_triggers(allVars, env_config)
+                environmentVariables {
+                    env('OPSGENIE_HEARTBEAT_NAME', env_config.get('OPSGENIE_HEARTBEAT_NAME'))
+                    env('OPSGENIE_HEARTBEAT_DURATION_NUM', env_config.get('OPSGENIE_HEARTBEAT_DURATION_NUM'))
+                    env('OPSGENIE_HEARTBEAT_DURATION_UNIT', env_config.get('OPSGENIE_HEARTBEAT_DURATION_UNIT'))
+                }
                 wrappers common_wrappers(allVars)
-                publishers common_publishers(allVars)
+                wrappers {
+                    credentialsBinding {
+                        string('OPSGENIE_HEARTBEAT_CONFIG_KEY', 'opsgenie_heartbeat_config_key')
+                    }
+                }
                 steps {
                     shell(dslFactory.readFileFromWorkspace('dataeng/resources/opsgenie-enable-heartbeat.sh'))
                     shell(dslFactory.readFileFromWorkspace('dataeng/resources/video-timeline.sh'))


### PR DESCRIPTION
Another try to enable Opsgenie heartbeat detection of stuck Jenkins jobs - here's the heartbeats:

https://edx.app.opsgenie.com/settings/heartbeat

The new global credential named "opsgenie_heartbeat_config_key" can be seen here:

http://jenkins.analytics.edx.org/credentials/

This PR pulls that global credential into all relevant jobs, along with three public environment variables, so that the OpsGenie API can be successfully called to enable/ping/disable each heartbeat.