### PR TITLE
Update Python version for testeng-ci

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -556,7 +556,7 @@ List jobConfigs = [
         org: 'edx',
         repoName: 'testeng-ci',
         targetBranch: "master",
-        pythonVersion: '2.7',
+        pythonVersion: '3.5',
         cronValue: cronOffHoursBusinessWeekday,
         githubUserReviewers: [],
         githubTeamReviewers: ['devops'],


### PR DESCRIPTION
testeng-ci has dropped support for Python 2.7 , so changing it's Python versions for `make upgrade` job.