### PR TITLE
fail update users job if no hosts found

### DIFF
--- a/dataeng/jobs/analytics/UpdateUsers.groovy
+++ b/dataeng/jobs/analytics/UpdateUsers.groovy
@@ -21,6 +21,11 @@ class UpdateUsers {
                     command('cd analytics-configuration && make users.update')
                 }
             }
+            publishers {
+                postBuildTask {
+                    task('skipping: no hosts matched', 'exit 1', true, true)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The update-users job currently passes if no hosts are found that match user input. This is essentially a noop and should be brought to the users attention.