### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/edx/jenkins-job-dsl.svg?branch=master)](https://travis-ci.org/edx/jenkins-job-dsl)
+[![Build Status](https://travis-ci.com/edx/jenkins-job-dsl.svg?branch=master)](https://travis-ci.com/edx/jenkins-job-dsl)
 
 # jenkins-job-dsl
 


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089