### PR TITLE
MICROBA-374 Send data to ITK only if MB data-mart build is successful

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeMicrobachelorsITK.groovy
+++ b/dataeng/jobs/analytics/SnowflakeMicrobachelorsITK.groovy
@@ -51,7 +51,10 @@ class SnowflakeMicrobachelorsITK {
                 }
             }
             triggers {
-                cron('H 6 * * 1-5')
+                buildResult('H 6 * * 1-5') {
+                    combinedJobs()
+                    triggerInfo('warehouse-transforms-microbachelors', BuildResult.SUCCESS)
+                }
             }
             wrappers {
                 timestamps()


### PR DESCRIPTION
[MICROBA-374](https://openedx.atlassian.net/browse/MICROBA-374)

Here’s the documentation for `buildResult`, but it’s rather sparse!: https://jenkinsci.github.io/job-dsl-plugin/#path/job-triggers-buildResult

**Questions** (so many! I don’t know what I’m doing in here!)
- The docs say it "Requires BuildResultTrigger v0.17+"—https://plugins.jenkins.io/buildresult-trigger/#documentation. Uhh, do I need to install that?
- See questions in the comments on the diff