### PR TITLE
Drop edx-platform Python 3.5 testing BOM-2048

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -37,7 +37,7 @@ Map publicJobConfig = [
     context: 'jenkins/a11y',
     refSpec : '+refs/heads/master:refs/remotes/origin/master',
     defaultBranch : 'master',
-    pythonVersion: '3.5',
+    pythonVersion: '3.8',
 ]
 
 Map privateJobConfig = [
@@ -48,7 +48,7 @@ Map privateJobConfig = [
     context: 'jenkins/a11y',
     refSpec : '+refs/heads/security-release:refs/remotes/origin/security-release',
     defaultBranch : 'security-release',
-    pythonVersion: '3.5',
+    pythonVersion: '3.8',
 ]
 
 Map ironwoodJobConfig = [

--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -48,17 +48,6 @@ Map publicJobConfig = [
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/a11y',
     triggerPhrase: /.*jenkins\W+run\W+a11y.*/,
-    pythonVersion: '3.5',
-]
-
-Map python38JobConfig = [
-    open: true,
-    jobName: 'edx-platform-python-3.8-accessibility-pr',
-    repoName: 'edx-platform',
-    workerLabel: 'js-worker',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/python-3.8/a11y',
-    triggerPhrase: /.*jenkins\W+run\W+py38\W+a11y.*/,
     pythonVersion: '3.8',
 ]
 
@@ -83,7 +72,7 @@ Map privateJobConfig = [
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/a11y',
     triggerPhrase: /.*jenkins\W+run\W+a11y.*/,
-    pythonVersion: '3.5',
+    pythonVersion: '3.8',
 ]
 
 Map publicIronwoodJobConfig = [
@@ -118,7 +107,6 @@ Map publicJuniperJobConfig = [
 
 List jobConfigs = [
     publicJobConfig,
-    python38JobConfig,
     django30JobConfig,
     privateJobConfig,
     publicIronwoodJobConfig,

--- a/platform/jobs/edxPlatformJsMaster.groovy
+++ b/platform/jobs/edxPlatformJsMaster.groovy
@@ -40,7 +40,7 @@ Map publicJobConfig = [
     context: 'jenkins/js',
     refSpec : '+refs/heads/master:refs/remotes/origin/master',
     defaultBranch : 'master',
-    pythonVersion: '3.5',
+    pythonVersion: '3.8',
 ]
 
 Map privateJobConfig = [
@@ -51,7 +51,7 @@ Map privateJobConfig = [
     context: 'jenkins/js',
     refSpec : '+refs/heads/security-release:refs/remotes/origin/security-release',
     defaultBranch : 'security-release',
-    pythonVersion: '3.5',
+    pythonVersion: '3.8',
 ]
 
 Map ironwoodJobConfig = [

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -57,17 +57,6 @@ Map publicJobConfig = [
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/js',
     triggerPhrase: /.*jenkins\W+run\W+js.*/,
-    pythonVersion: '3.5',
-]
-
-Map python38JobConfig = [
-    open: true,
-    jobName: 'edx-platform-python-3.8-js-pr',
-    repoName: 'edx-platform',
-    workerLabel: 'js-worker',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/python-3.8/js',
-    triggerPhrase: /.*jenkins\W+run\W+py38\W+js.*/,
     pythonVersion: '3.8',
 ]
 
@@ -92,7 +81,7 @@ Map privateJobConfig = [
     whitelistBranchRegex: /^((?!open-release\/).)*$/,
     context: 'jenkins/js',
     triggerPhrase: /.*jenkins\W+run\W+js.*/,
-    pythonVersion: '3.5',
+    pythonVersion: '3.8',
 ]
 
 Map publicIronwoodJobConfig = [
@@ -127,7 +116,6 @@ Map publicJuniperJobConfig = [
 
 List jobConfigs = [
     publicJobConfig,
-    python38JobConfig,
     django30JobConfig,
     privateJobConfig,
     publicIronwoodJobConfig,

--- a/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
@@ -33,7 +33,7 @@ Map publicPythonJobConfig = [
     jenkinsFileName: 'python',
     branch: 'master',
     context: 'jenkins/python',
-    pythonVersion: '3.5',
+    pythonVersion: '3.8',
 ]
 
 Map privatePythonJobConfig = [
@@ -44,7 +44,7 @@ Map privatePythonJobConfig = [
     jenkinsFileName: 'python',
     branch: 'security-release',
     context: 'jenkins/python',
-    pythonVersion: '3.5',
+    pythonVersion: '3.8',
 ]
 
 Map ironwoodPythonJobConfig = [
@@ -66,7 +66,7 @@ Map publicQualityJobConfig = [
     jenkinsFileName: 'quality',
     branch: 'master',
     context: 'jenkins/quality',
-    pythonVersion: '3.5',
+    pythonVersion: '3.8',
 ]
 
 Map privateQualityJobConfig = [
@@ -77,7 +77,7 @@ Map privateQualityJobConfig = [
     jenkinsFileName: 'quality',
     branch: 'security-release',
     context: 'jenkins/quality',
-    pythonVersion: '3.5',
+    pythonVersion: '3.8',
 ]
 
 Map ironwoodQualityJobConfig = [

--- a/platform/jobs/pipelines/edxPlatformPipelineMasterWTWNightly.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelineMasterWTWNightly.groovy
@@ -10,7 +10,7 @@ Map wtwPythonJobConfig = [
     jenkinsFileName: 'python',
     branch: 'master',
     context: 'jenkins/python-contexts',
-    pythonVersion: '3.5',
+    pythonVersion: '3.8',
 ]
 
 List jobConfigs = [

--- a/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
@@ -88,18 +88,6 @@ Map publicPythonJobConfig = [
     triggerPhrase: /.*jenkins\W+run\W+python.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'python',
-    pythonVersion: '3.5',
-]
-
-Map python38PythonJobConfig = [
-    open: true,
-    jobName: 'edx-platform-python-3.8-python-pipeline-pr',
-    repoName: 'edx-platform',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/python-3.8/python',
-    triggerPhrase: /.*jenkins\W+run\W+py38\W+python.*/,
-    jenkinsFileDir: 'scripts/Jenkinsfiles',
-    jenkinsFileName: 'python',
     pythonVersion: '3.8',
 ]
 
@@ -127,7 +115,7 @@ Map privatePythonJobConfig = [
     triggerPhrase: /.*jenkins\W+run\W+python.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'python',
-    pythonVersion: '3.5',
+    pythonVersion: '3.8',
 ]
 
 Map publicPythonIronwoodJobConfig = [
@@ -179,18 +167,6 @@ Map publicQualityJobConfig = [
     triggerPhrase: /.*jenkins\W+run\W+quality.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'quality',
-    pythonVersion: '3.5',
-]
-
-Map python38QualityJobConfig = [
-    open: true,
-    jobName: 'edx-platform-python-3.8-quality-pipeline-pr',
-    repoName: 'edx-platform',
-    whitelistBranchRegex: /^((?!open-release\/).)*$/,
-    context: 'jenkins/python-3.8/quality',
-    triggerPhrase: /.*jenkins\W+run\W+py38\W+quality.*/,
-    jenkinsFileDir: 'scripts/Jenkinsfiles',
-    jenkinsFileName: 'quality',
     pythonVersion: '3.8',
 ]
 
@@ -218,7 +194,7 @@ Map privateQualityJobConfig = [
     triggerPhrase: /.*jenkins\W+run\W+quality.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'quality',
-    pythonVersion: '3.5',
+    pythonVersion: '3.8',
 ]
 
 Map publicQualityIronwoodJobConfig = [
@@ -266,14 +242,12 @@ List jobConfigs = [
     publicLettuceIronwoodJobConfig,
     privateLettuceIronwoodJobConfig,
     publicPythonJobConfig,
-    python38PythonJobConfig,
     django30PythonJobConfig,
     privatePythonJobConfig,
     publicPythonIronwoodJobConfig,
     privatePythonIronwoodJobConfig,
     publicPythonJuniperJobConfig,
     publicQualityJobConfig,
-    python38QualityJobConfig,
     django30QualityJobConfig,
     privateQualityJobConfig,
     publicQualityIronwoodJobConfig,

--- a/platform/jobs/pipelines/edxPlatformPipelinePrWTW.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePrWTW.groovy
@@ -36,7 +36,7 @@ Map publicPythonJobConfig = [
     triggerPhrase: /.*jenkins\W+run\W+wtw\W+python.*/,
     jenkinsFileDir: 'scripts/Jenkinsfiles',
     jenkinsFileName: 'python',
-    pythonVersion: '3.5',
+    pythonVersion: '3.8',
 ]
 
 List jobConfigs = [

--- a/testeng/jobs/bokchoyDbCacheUploader.groovy
+++ b/testeng/jobs/bokchoyDbCacheUploader.groovy
@@ -119,7 +119,7 @@ secretMap.each { jobConfigs ->
 
         environmentVariables {
             env('AWS_DEFAULT_REGION', jobConfig['region'])
-            env('PYTHON_VERSION', '3.5')
+            env('PYTHON_VERSION', '3.8')
         }
 
         wrappers {

--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -344,7 +344,7 @@ List jobConfigs = [
         org: 'edx',
         repoName: 'edx-platform',
         targetBranch: "master",
-        pythonVersion: '3.5',
+        pythonVersion: '3.8',
         cronValue: cronOffHoursBusinessDailyLahore,
         githubUserReviewers: [],
         githubTeamReviewers: ['arbi-bom'],


### PR DESCRIPTION
Switch the default edx-platform Jenkins test jobs to use Python 3.8 instead of 3.5, and stop seeding the separate 3.8 test jobs (we'll stop those manually after seeding these).  Also switch the bok-choy DB cache updater and `make upgrade` job to run in 3.8 instead of 3.5.