### PR TITLE
Remove broken feature to email build user

### DIFF
--- a/src/main/groovy/org/edx/jenkins/dsl/AnalyticsConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/AnalyticsConstants.groovy
@@ -159,34 +159,26 @@ This text may reference other parameters in the task as shell variables, e.g.  $
         return {
             sshAgent('1')
             timestamps()
-            buildUserVars()
         }
     }
 
     // Send email notifications on job failures.
-    // * If the failed build was triggered by a human, that user will be emailed.  For this feature to work, you must
-    //   either include common_wrappers() or enable buildUserVars() in wrappers{}.
     // * If you need to notify a predefined email address(es), you must either include `common_parameters()` or manually
     //   include a `NOTIFY` parameter.
     public static def common_publishers = { allVars ->
         return {
             flexiblePublish {
+                // Optionally send emails to the addresses in the $NOTIFY parameter.
                 conditionalAction {
                     condition {
                         not {
                             // method signature
                             // stringsMatch(String arg1, String arg2, boolean ignoreCase)
-                            //
-                            // We cannot simply use $BUILD_USER_EMAIL because when the build is automated, or when the
-                            // buildUserVars plugin is not enabled for the job, it will be undefined and flexiblePublish
-                            // will throw an exception.  Therefore we use the weird groovy(?) syntax of
-                            // ${ENV,var="BUILD_USER_EMAIL"}
-                            stringsMatch('$NOTIFY ${ENV,var="BUILD_USER_EMAIL"}', ' ', false)
+                            stringsMatch('$NOTIFY', '', false)
                         }
                     }
                     publishers {
-                        // This string, however, must NOT use the weird groovy syntax, simply $BUILD_USER_EMAIL.
-                        mailer('$NOTIFY $BUILD_USER_EMAIL')
+                        mailer('$NOTIFY')
                     }
                 }
             }


### PR DESCRIPTION
Before this commit, when $NOTIFY is non-empty but $BUILD_USER_EMAIL is
empty, then the mailer plugin attempts to send emails to the string
literal "$BUILD_USER_EMAIL@edx.org" which results in a bounce.

I'm at my wit's end here.  I've evaluated several different combinations
of jenkins plugins and features, groovy scripts, etc.  So, I give up!