### PR TITLE
Enable builds for Koa master branch & PRs

### DIFF
--- a/platform/jobs/edxPlatformAccessibilityMaster.groovy
+++ b/platform/jobs/edxPlatformAccessibilityMaster.groovy
@@ -61,10 +61,22 @@ Map ironwoodJobConfig = [
     defaultBranch : 'refs/heads/open-release/ironwood.master'
 ]
 
+Map koaJobConfig = [
+    open: true,
+    jobName: 'koa-accessibility-master',
+    repoName: 'edx-platform',
+    workerLabel: 'koa-jenkins-worker',
+    context: 'jenkins/koa/a11y',
+    refSpec : '+refs/heads/open-release/koa.master:refs/remotes/origin/open-release/koa.master',
+    defaultBranch : 'refs/heads/open-release/koa.master',
+    pythonVersion: '3.8',
+]
+
 List jobConfigs = [
     publicJobConfig,
     privateJobConfig,
-    ironwoodJobConfig
+    ironwoodJobConfig,
+    koaJobConfig
 ]
 
 jobConfigs.each { jobConfig ->

--- a/platform/jobs/edxPlatformAccessibilityPr.groovy
+++ b/platform/jobs/edxPlatformAccessibilityPr.groovy
@@ -116,6 +116,17 @@ Map publicJuniperJobConfig = [
     triggerPhrase: /.*juniper\W+run\W+a11y.*/
 ]
 
+Map publicKoaJobConfig = [
+    open: true,
+    jobName: 'koa-accessibility-pr',
+    repoName: 'edx-platform',
+    workerLabel: 'koa-jenkins-worker',
+    whitelistBranchRegex: /open-release\/koa.master/,
+    context: 'jenkins/koa/a11y',
+    triggerPhrase: /.*koa\W+run\W+a11y.*/,
+    pythonVersion: '3.8'
+]
+
 List jobConfigs = [
     publicJobConfig,
     python38JobConfig,
@@ -124,6 +135,7 @@ List jobConfigs = [
     publicIronwoodJobConfig,
     privateIronwoodJobConfig,
     publicJuniperJobConfig,
+    publicKoaJobConfig,
 ]
 
 /* Iterate over the job configurations */

--- a/platform/jobs/edxPlatformJsMaster.groovy
+++ b/platform/jobs/edxPlatformJsMaster.groovy
@@ -64,10 +64,22 @@ Map ironwoodJobConfig = [
     defaultBranch : 'refs/heads/open-release/ironwood.master'
 ]
 
+Map koaJobConfig = [
+    open: true,
+    jobName: 'koa-js-master',
+    repoName: 'edx-platform',
+    workerLabel: 'koa-jenkins-worker',
+    context: 'jenkins/koa/js',
+    refSpec : '+refs/heads/open-release/koa.master:refs/remotes/origin/open-release/koa.master',
+    defaultBranch : 'refs/heads/open-release/koa.master',
+    pythonVersion: '3.8',
+]
+
 List jobConfigs = [
     publicJobConfig,
     privateJobConfig,
-    ironwoodJobConfig
+    ironwoodJobConfig,
+    koaJobConfig
 ]
 
 /* Iterate over the job configurations */

--- a/platform/jobs/edxPlatformJsPr.groovy
+++ b/platform/jobs/edxPlatformJsPr.groovy
@@ -125,6 +125,17 @@ Map publicJuniperJobConfig = [
     triggerPhrase: /.*juniper\W+run\W+js.*/
 ]
 
+Map publicKoaJobConfig = [
+    open: true,
+    jobName: 'koa-js-pr',
+    repoName: 'edx-platform',
+    workerLabel: 'koa-jenkins-worker',
+    whitelistBranchRegex: /open-release\/koa.master/,
+    context: 'jenkins/koa/js',
+    triggerPhrase: /.*koa\W+run\W+js.*/,
+    pythonVersion: '3.8'
+]
+
 List jobConfigs = [
     publicJobConfig,
     python38JobConfig,
@@ -133,6 +144,7 @@ List jobConfigs = [
     publicIronwoodJobConfig,
     privateIronwoodJobConfig,
     publicJuniperJobConfig,
+    publicKoaJobConfig,
 ]
 
 /* Iterate over the job configurations */

--- a/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelineMaster.groovy
@@ -58,6 +58,17 @@ Map ironwoodPythonJobConfig = [
     pythonVersion: '2.7',
 ]
 
+Map koaPythonJobConfig = [
+    open: true,
+    jobName: 'koa-python-pipeline-master',
+    repoName: 'edx-platform',
+    jenkinsFileDir: 'scripts/Jenkinsfiles',
+    jenkinsFileName: 'python',
+    branch: 'open-release/koa.master',
+    context: 'jenkins/koa/python',
+    pythonVersion: '3.8',
+]
+
 Map publicQualityJobConfig = [
     open: true,
     jobName: 'edx-platform-quality-pipeline-master',
@@ -91,15 +102,28 @@ Map ironwoodQualityJobConfig = [
     pythonVersion: '2.7',
 ]
 
+Map koaQualityJobConfig = [
+    open: true,
+    jobName: 'koa-quality-pipeline-master',
+    repoName: 'edx-platform',
+    jenkinsFileDir: 'scripts/Jenkinsfiles',
+    jenkinsFileName: 'quality',
+    branch: 'open-release/koa.master',
+    context: 'jenkins/koa/quality',
+    pythonVersion: '3.8',
+]
+
 List jobConfigs = [
     ironwoodBokchoyJobConfig,
     ironwoodLettuceJobConfig,
     publicPythonJobConfig,
     privatePythonJobConfig,
     ironwoodPythonJobConfig,
+    koaPythonJobConfig,
     publicQualityJobConfig,
     privateQualityJobConfig,
-    ironwoodQualityJobConfig
+    ironwoodQualityJobConfig,
+    koaQualityJobConfig
 ]
 
 /* Iterate over the job configurations */

--- a/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
@@ -169,6 +169,19 @@ Map publicPythonJuniperJobConfig = [
     pythonVersion: '3.5',
 ]
 
+Map publicPythonKoaJobConfig = [
+    open: true,
+    jobName: 'koa-python-pipeline-pr',
+    repoName: 'edx-platform',
+    whitelistBranchRegex: /open-release\/koa.master/,
+    context: 'jenkins/koa/python',
+    onlyTriggerPhrase: false,
+    triggerPhrase: /.*koa\W+run\W+python.*/,
+    jenkinsFileDir: 'scripts/Jenkinsfiles',
+    jenkinsFileName: 'python',
+    pythonVersion: '3.8',
+]
+
 Map publicQualityJobConfig = [
     open: true,
     jobName: 'edx-platform-quality-pipeline-pr',
@@ -260,6 +273,19 @@ Map publicQualityJuniperJobConfig = [
     pythonVersion: '3.5',
 ]
 
+Map publicQualityKoaJobConfig = [
+    open: true,
+    jobName: 'koa-quality-pipeline-pr',
+    repoName: 'edx-platform',
+    whitelistBranchRegex: /open-release\/koa.master/,
+    context: 'jenkins/koa/quality',
+    onlyTriggerPhrase: false,
+    triggerPhrase: /.*koa\W+run\W+quality.*/,
+    jenkinsFileDir: 'scripts/Jenkinsfiles',
+    jenkinsFileName: 'quality',
+    pythonVersion: '3.8',
+]
+
 List jobConfigs = [
     publicBokchoyIronwoodJobConfig,
     privateBokchoyIronwoodJobConfig,
@@ -272,6 +298,7 @@ List jobConfigs = [
     publicPythonIronwoodJobConfig,
     privatePythonIronwoodJobConfig,
     publicPythonJuniperJobConfig,
+    publicPythonKoaJobConfig,
     publicQualityJobConfig,
     python38QualityJobConfig,
     django30QualityJobConfig,
@@ -279,6 +306,7 @@ List jobConfigs = [
     publicQualityIronwoodJobConfig,
     privateQualityIronwoodJobConfig,
     publicQualityJuniperJobConfig,
+    publicQualityKoaJobConfig,
 ]
 
 /* Iterate over the job configurations */

--- a/platform/views/platformViews.groovy
+++ b/platform/views/platformViews.groovy
@@ -5,6 +5,7 @@ import static org.edx.jenkins.dsl.JenkinsPublicConstants.DEFAULT_VIEW
 List<String> branchList = [ "edx-platform", // Represents all non-release testing
                             "ironwood",
                             "juniper",
+                            "koa",
                             ]
 
 branchList.each { branch ->

--- a/src/test/groovy/platform/edxPlatformMasterSpec.groovy
+++ b/src/test/groovy/platform/edxPlatformMasterSpec.groovy
@@ -44,7 +44,7 @@ class edxPlatformMasterJobSpec extends Specification {
 
         where:
         dslFile                                   | numJobs
-        'edxPlatformAccessibilityMaster.groovy'   | 3
-        'edxPlatformJsMaster.groovy'              | 3
+        'edxPlatformAccessibilityMaster.groovy'   | 4
+        'edxPlatformJsMaster.groovy'              | 4
     }
 }

--- a/src/test/groovy/platform/pipelines/edxPlatformPipelinesMasterSpec.groovy
+++ b/src/test/groovy/platform/pipelines/edxPlatformPipelinesMasterSpec.groovy
@@ -44,6 +44,6 @@ class edxPlatformPipelinesMasterJobSpec extends Specification {
 
         where:
         dslFile                                   | numJobs
-        'edxPlatformPipelineMaster.groovy'        | 8
+        'edxPlatformPipelineMaster.groovy'        | 10
     }
 }


### PR DESCRIPTION
This is my best attempt at enabling Jenkins CI builds on PRs against Koa branches as well as the `open-release/koa.master` branch.

I believe there are SRE actions that'll need to happen to enable the builds; I'm not sure exactly what, though. At the very least, a new worker `koa-jenkins-worker` will be needed.

SRE review ticket: https://openedx.atlassian.net/servicedesk/customer/portal/15/DOS-1798