### PR TITLE
Up the stitch validation window from 10 to 15 days

### DIFF
--- a/dataeng/resources/snowflake-validate-stitch.sh
+++ b/dataeng/resources/snowflake-validate-stitch.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -ex
 
-# Calculate the start of the validation window as 10 days prior to the end of the window.
+# Calculate the start of the validation window as 15 days prior to the end of the window.
 COMPARISON_END_TIME="${SQOOP_START_TIME}"
-COMPARISON_START_TIME=$(date --utc --iso=minutes -d "${COMPARISON_END_TIME} - 10 days")
+COMPARISON_START_TIME=$(date --utc --iso=minutes -d "${COMPARISON_END_TIME} - 15 days")
 
 # Tooling setup
 cd $WORKSPACE/analytics-tools/snowflake


### PR DESCRIPTION
Right now the validation window looks back 10 days from when a Sqoop load was run.  The job gets run roughly every week.  This means that if a problem is uncovered more than three days in the past, it won't be covered by the next run.  To more clearly determine which errors might be transient and which are real glitches in the Stitch integration, it would help to get coverage for two runs.  So this proposes looking back 15 days instead of 10.  
