### PR TITLE
Remove org from upgrader job names

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -620,11 +620,17 @@ List jobConfigs = [
     ],
 ]
 
+seenRepoNames = []
 
 /* Iterate over the job configurations */
 jobConfigs.each { jobConfig ->
 
-    job("${jobConfig.org}-${jobConfig.repoName}-upgrade-python-requirements") {
+    if (jobConfig.repoName in seenRepoNames) {
+        throw new IllegalArgumentException("Repo ${jobConfig.repoName} specified twice in upgrades list")
+    }
+    seenRepoNames.add(jobConfig.repoName)
+
+    job("${jobConfig.repoName}-upgrade-python-requirements") {
 
         parameters {
             stringParam('TARGET_BRANCH', jobConfig.defaultBranch, 'Target branch to run make upgrade in')


### PR DESCRIPTION
This reverts one of the changes made in PR #1203/commit 17e2757b50.

Including the org name made it harder to read the listing, and it's
unlikely that we'll have repos of the same name in different orgs that
we also run the upgrader on.

Just in case, add a validator so that we don't end up overwriting a job
if this does happen.