### PR TITLE
Upgrade coaching py upgrade job to 3.8

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -80,7 +80,7 @@ List jobConfigs = [
         org: 'edx',
         repoName: 'platform-plugin-coaching',
         defaultBranch: 'master',
-        pythonVersion: '3.5',
+        pythonVersion: '3.8',
         cronValue: cronOffHoursBusinessWeekday,
         githubUserReviewers: [],
         githubTeamReviewers: ['edx-aperture'],


### PR DESCRIPTION
Now that edx-platform is on py 3.8, we can move the plugin to 3.8