### PR TITLE
Revert "Revert "ISRE-627 | Trying again to implement venvs for jenkins ansible jobs w…""

### DIFF
--- a/devops/jobs/RunAnsible.groovy
+++ b/devops/jobs/RunAnsible.groovy
@@ -120,12 +120,7 @@ class RunAnsible {
             }
 
             steps {
-                virtualenv {
-                    pythonName('System-CPython-3.6')
-                    name(jobName)
-                    nature('shell')
-                    command(dslFactory.readFileFromWorkspace('devops/resources/run-ansible.sh'))
-                }
+                shell(dslFactory.readFileFromWorkspace('devops/resources/run-ansible.sh'))
             }
 
             publishers {

--- a/devops/resources/run-ansible.sh
+++ b/devops/resources/run-ansible.sh
@@ -3,6 +3,12 @@
 set -ex
 
 cd $WORKSPACE/configuration
+
+. /edx/var/jenkins/jobvenvs/virtualenv_tools.sh
+# creates a venv with its location stored in variable "venvpath"
+create_virtualenv --python=python3.6 --clear
+. "$venvpath/bin/activate"
+
 pip install -r requirements.txt
 pip install awscli
 


### PR DESCRIPTION
Reverts edx/jenkins-job-dsl#1217

I am reverting the revert because I have merged a fix into create_virtualenv (in configuration) that will no longer run `set -u` while the script runs, meaning this change should be okay to be put back in.