### PR TITLE
disable pipeline jobs for insights update

### DIFF
--- a/dataeng/jobs/analytics/AnswerDistribution.groovy
+++ b/dataeng/jobs/analytics/AnswerDistribution.groovy
@@ -10,6 +10,11 @@ class AnswerDistribution {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("answer-distribution-$environment") {
+                // As part of the MySQL upgrade for Insights/Data API, we need to disable the jobs that
+                // interface with the resultstore.
+                // TODO: once the upgrade is complete for both prod and edge environments, remove this line
+                disabled(env_config.get('JOB_DISABLED'))
+
                 logRotator common_log_rotator(allVars, env_config)
                 multiscm common_multiscm(allVars)
                 triggers common_triggers(allVars, env_config)

--- a/dataeng/jobs/analytics/Enrollment.groovy
+++ b/dataeng/jobs/analytics/Enrollment.groovy
@@ -12,6 +12,11 @@ class Enrollment {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("enrollment-$environment") {
+                // As part of the MySQL upgrade for Insights/Data API, we need to disable the jobs that
+                // interface with the resultstore.
+                // TODO: once the upgrade is complete for both prod and edge environments, remove this line
+                disabled(env_config.get('JOB_DISABLED'))
+
                 logRotator common_log_rotator(allVars)
                 multiscm common_multiscm(allVars)
                 triggers common_triggers(allVars, env_config)

--- a/dataeng/jobs/analytics/EnrollmentValidationEvents.groovy
+++ b/dataeng/jobs/analytics/EnrollmentValidationEvents.groovy
@@ -12,6 +12,11 @@ class EnrollmentValidationEvents {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("enrollment-validation-events-$environment") {
+                // As part of the MySQL upgrade for Insights/Data API, we need to disable the jobs that
+                // interface with the resultstore.
+                // TODO: once the upgrade is complete for both prod and edge environments, remove this line
+                disabled(env_config.get('JOB_DISABLED'))
+
                 logRotator common_log_rotator(allVars)
                 parameters common_parameters(allVars, env_config)
                 parameters from_date_interval_parameter(allVars)

--- a/dataeng/jobs/analytics/Enterprise.groovy
+++ b/dataeng/jobs/analytics/Enterprise.groovy
@@ -11,6 +11,11 @@ class Enterprise {
     public static def job = { dslFactory, allVars ->
         allVars.get('JOBS').each { job, job_config ->
             dslFactory.job("enterprise-$job") {
+                // As part of the MySQL upgrade for Insights/Data API, we need to disable the jobs that
+                // interface with the resultstore.
+                // TODO: once the upgrade is complete for both prod and edge environments, remove this line
+                disabled(job_config.get('JOB_DISABLED'))
+
                 authorization common_authorization(allVars)
                 logRotator common_log_rotator(allVars)
                 parameters common_parameters(allVars, job_config)

--- a/dataeng/jobs/analytics/ModuleEngagement.groovy
+++ b/dataeng/jobs/analytics/ModuleEngagement.groovy
@@ -10,6 +10,11 @@ class ModuleEngagement {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("module-engagement-$environment") {
+                // As part of the MySQL upgrade for Insights/Data API, we need to disable the jobs that
+                // interface with the resultstore.
+                // TODO: once the upgrade is complete for both prod and edge environments, remove this line
+                disabled(env_config.get('JOB_DISABLED'))
+
                 logRotator common_log_rotator(allVars)
                 multiscm common_multiscm(allVars)
                 publishers common_publishers(allVars)

--- a/dataeng/jobs/analytics/TotalEventsDailyReport.groovy
+++ b/dataeng/jobs/analytics/TotalEventsDailyReport.groovy
@@ -9,6 +9,11 @@ import static org.edx.jenkins.dsl.AnalyticsConstants.common_triggers
 class TotalEventsDailyReport {
     public static def job = { dslFactory, allVars ->
         dslFactory.job("total-events-daily-report") {
+            // As part of the MySQL upgrade for Insights/Data API, we need to disable the jobs that
+            // interface with the resultstore.
+            // TODO: once the upgrade is complete for both prod and edge environments, remove this line
+            disabled(allVars.get('JOB_DISABLED'))
+
             logRotator common_log_rotator(allVars)
             parameters common_parameters(allVars)
             parameters {

--- a/dataeng/jobs/analytics/UserActivity.groovy
+++ b/dataeng/jobs/analytics/UserActivity.groovy
@@ -11,6 +11,11 @@ class UserActivity {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("user-activity-$environment") {
+                // As part of the MySQL upgrade for Insights/Data API, we need to disable the jobs that
+                // interface with the resultstore.
+                // TODO: once the upgrade is complete for both prod and edge environments, remove this line
+                disabled(env_config.get('JOB_DISABLED'))
+
                 logRotator common_log_rotator(allVars, env_config)
                 parameters common_parameters(allVars, env_config)
                 parameters to_date_interval_parameter(allVars)

--- a/dataeng/jobs/analytics/UserLocationByCourse.groovy
+++ b/dataeng/jobs/analytics/UserLocationByCourse.groovy
@@ -11,6 +11,11 @@ class UserLocationByCourse {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("user-location-by-course-$environment") {
+                // As part of the MySQL upgrade for Insights/Data API, we need to disable the jobs that
+                // interface with the resultstore.
+                // TODO: once the upgrade is complete for both prod and edge environments, remove this line
+                disabled(env_config.get('JOB_DISABLED'))
+
                 logRotator common_log_rotator(allVars, env_config)
                 multiscm common_multiscm(allVars)
                 triggers common_triggers(allVars, env_config)

--- a/dataeng/jobs/analytics/VideoTimeline.groovy
+++ b/dataeng/jobs/analytics/VideoTimeline.groovy
@@ -12,6 +12,11 @@ class VideoTimeline {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("video-timeline-$environment") {
+                // As part of the MySQL upgrade for Insights/Data API, we need to disable the jobs that
+                // interface with the resultstore.
+                // TODO: once the upgrade is complete for both prod and edge environments, remove this line
+                disabled(env_config.get('JOB_DISABLED'))
+
                 logRotator common_log_rotator(allVars, env_config)
                 multiscm common_multiscm(allVars)
                 triggers common_triggers(allVars, env_config)


### PR DESCRIPTION
I have added an option to disable the jobs that will be impacted by the insights mysql upgrade, depending on the environment. See: https://openedx.atlassian.net/wiki/spaces/SRE/pages/2122350900/Production+Analytics+MySQL+5.6+to+Aurora+MySQL+5.7+Upgrade+Runbook#F%3A-Cutover-Prep for more information