### PR TITLE
split stitch validation jobs into unique instances

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeReplicaImportFromS3.groovy
+++ b/dataeng/jobs/analytics/SnowflakeReplicaImportFromS3.groovy
@@ -73,7 +73,7 @@ class SnowflakeReplicaImportFromS3 {
                 publishers common_publishers(allVars)
                 publishers {
                     downstreamParameterized {
-                        trigger("snowflake-validate-stitch") {
+                        trigger("snowflake-validate-stitch-$APP_NAME") {
                             condition('SUCCESS')
                             parameters {
                                 // The contents of this file are generated as part of the script in the build step.

--- a/dataeng/jobs/analytics/SnowflakeValidateStitch.groovy
+++ b/dataeng/jobs/analytics/SnowflakeValidateStitch.groovy
@@ -9,54 +9,64 @@ import static org.edx.jenkins.dsl.AnalyticsConstants.secure_scm_parameters
 
 class SnowflakeValidateStitch {
     public static def job = { dslFactory, allVars ->
-        dslFactory.job('snowflake-validate-stitch') {
+        List apps = [
+            'CREDENTIALS',
+            'DISCOVERY',
+            'ECOMMERCE',
+            'LMS'
+        ]
+        apps.each { app ->
 
-            description(
-                'Validate application database tables loaded by Stitch by comparing them against the same ' +
-                'tables loaded by Sqoop.  This compares only tables that exist in both sets, and only the last ' +
-                '10 days of changed rows.'
-            )
+            dslFactory.job("snowflake-validate-stitch-$app") {
 
-            parameters secure_scm_parameters(allVars)
-            parameters {
-                stringParam('ANALYTICS_TOOLS_URL', allVars.get('ANALYTICS_TOOLS_URL'), 'URL for the analytics tools repo.')
-                stringParam('ANALYTICS_TOOLS_BRANCH', allVars.get('ANALYTICS_TOOLS_BRANCH'), 'Branch of analytics tools repo to use.')
-                stringParam('APP_NAME', '', 'Application name of tables to validate.')
-                stringParam('SQOOP_START_TIME', '', 'Application name of tables to validate.')
-                stringParam('SNOWFLAKE_USER', 'SNOWFLAKE_TASK_AUTOMATION_USER')
-                stringParam('SNOWFLAKE_ACCOUNT', 'edx.us-east-1')
-                stringParam('SNOWFLAKE_KEY_PATH', 'snowflake/rsa_key_snowflake_task_automation_user.p8', 'Path to the encrypted private key file that corresponds to the SNOWFLAKE_USER, relative to the root of analytics-secure.')
-                stringParam('SNOWFLAKE_PASSPHRASE_PATH', 'snowflake/rsa_key_passphrase_snowflake_task_automation_user', 'Path to the private key decryption passphrase file that corresponds to the SNOWFLAKE_USER, relative to the root of analytics-secure.')
-                stringParam('NOTIFY', allVars.get('NOTIFY','$PAGER_NOTIFY'), 'Space separated list of emails to send notifications to.')
-            }
-            logRotator common_log_rotator(allVars)
-            multiscm secure_scm(allVars) << {
-                git {
-                    remote {
-                        url('$ANALYTICS_TOOLS_URL')
-                        branch('$ANALYTICS_TOOLS_BRANCH')
-                        credentials('1')
-                    }
-                    extensions {
-                        relativeTargetDirectory('analytics-tools')
-                        pruneBranches()
-                        cleanAfterCheckout()
+                description(
+                    "Validate $app database tables loaded by Stitch by comparing them against the same " +
+                    "tables loaded by Sqoop.  This compares only tables that exist in both sets, and only the last " +
+                    "10 days of changed rows."
+                )
+
+                parameters secure_scm_parameters(allVars)
+                parameters {
+                    stringParam('ANALYTICS_TOOLS_URL', allVars.get('ANALYTICS_TOOLS_URL'), 'URL for the analytics tools repo.')
+                    stringParam('ANALYTICS_TOOLS_BRANCH', allVars.get('ANALYTICS_TOOLS_BRANCH'), 'Branch of analytics tools repo to use.')
+                    stringParam('SQOOP_START_TIME', '', 'Application name of tables to validate.')
+                    stringParam('SNOWFLAKE_USER', 'SNOWFLAKE_TASK_AUTOMATION_USER')
+                    stringParam('SNOWFLAKE_ACCOUNT', 'edx.us-east-1')
+                    stringParam('SNOWFLAKE_KEY_PATH', 'snowflake/rsa_key_snowflake_task_automation_user.p8', 'Path to the encrypted private key file that corresponds to the SNOWFLAKE_USER, relative to the root of analytics-secure.')
+                    stringParam('SNOWFLAKE_PASSPHRASE_PATH', 'snowflake/rsa_key_passphrase_snowflake_task_automation_user', 'Path to the private key decryption passphrase file that corresponds to the SNOWFLAKE_USER, relative to the root of analytics-secure.')
+                    stringParam('NOTIFY', allVars.get('NOTIFY','$PAGER_NOTIFY'), 'Space separated list of emails to send notifications to.')
+                }
+                environmentVariables {
+                    env('APP_NAME', app)
+                }
+                logRotator common_log_rotator(allVars)
+                multiscm secure_scm(allVars) << {
+                    git {
+                        remote {
+                            url('$ANALYTICS_TOOLS_URL')
+                            branch('$ANALYTICS_TOOLS_BRANCH')
+                            credentials('1')
+                        }
+                        extensions {
+                            relativeTargetDirectory('analytics-tools')
+                            pruneBranches()
+                            cleanAfterCheckout()
+                        }
                     }
                 }
-            }
-            wrappers {
-                timestamps()
-                buildName('#${BUILD_NUMBER} (${ENV,var="APP_NAME"})')
-            }
-            publishers common_publishers(allVars)
-            steps {
-                virtualenv {
-                    pythonName('PYTHON_3.7')
-                    nature("shell")
-                    systemSitePackages(false)
-                    command(
-                        dslFactory.readFileFromWorkspace('dataeng/resources/snowflake-validate-stitch.sh')
-                    )
+                wrappers {
+                    timestamps()
+                }
+                publishers common_publishers(allVars)
+                steps {
+                    virtualenv {
+                        pythonName('PYTHON_3.7')
+                        nature("shell")
+                        systemSitePackages(false)
+                        command(
+                            dslFactory.readFileFromWorkspace('dataeng/resources/snowflake-validate-stitch.sh')
+                        )
+                    }
                 }
             }
         }

--- a/dataeng/resources/snowflake-replica-import.sh
+++ b/dataeng/resources/snowflake-replica-import.sh
@@ -37,7 +37,6 @@ if [[ ${DAY_OF_WEEK} -eq ${MONDAY} || ${FORCE} = "true" ]]; then
     # All went well (we know that because of set -e), so we should generate a
     # downstream properties file which signals this job to invoke the downstream
     # job.
-    echo "APP_NAME=${APP_NAME}" >> "${DOWNSTREAM_PROPERTIES_FILE}"
     echo "SQOOP_START_TIME=${SQOOP_START_TIME}" >> "${DOWNSTREAM_PROPERTIES_FILE}"
 
 else


### PR DESCRIPTION
Currently the snowflake-validate-stitch job runs for multiple applications. A successful run using app X will close out the opsgenie alert for app Y, regardless of whether or not the issue was addressed. Similarly, a failure in app X should appear as a separate opsgenie alert from a failure for app Y.