### PR TITLE
reduce analytics exporter job concurrency

### DIFF
--- a/dataeng/jobs/analytics/AnalyticsExporter.groovy
+++ b/dataeng/jobs/analytics/AnalyticsExporter.groovy
@@ -121,8 +121,8 @@ class AnalyticsExporter {
             }
 
             throttleConcurrentBuilds {
-                maxPerNode(18)
-                maxTotal(18)
+                maxPerNode(15)
+                maxTotal(15)
             }
 
             concurrentBuild()


### PR DESCRIPTION
Jenkins has been very slow lately. I jumped on the box and often the exporter jobs are top resource users, aside from the Jenkins process.