### PR TITLE
Allow splitting of repo names with space in cleanup job (allow `, `)

### DIFF
--- a/testeng/jobs/cleanupPythonCode.groovy
+++ b/testeng/jobs/cleanupPythonCode.groovy
@@ -7,7 +7,7 @@ githubTeamReviewers = ['arbi-bom']
 job('cleanup-python-code') {
 
     parameters {
-        stringParam('repoNames', null, 'Comma separated list of names of (public) target repositories in $org org')
+        stringParam('repoNames', null, 'Comma or space separated list of names of (public) target repositories in $org org')
         choiceParam('pythonVersion', ['3.8', '3.5', '2.7'], 'Version of python to use')
         stringParam('packages', '', 'Comma or space separated list of packages to install')
         stringParam('scripts', '', 'Bash script to run (can separate commands with semicolons)')

--- a/testeng/resources/cleanup-python-code-create-pr.sh
+++ b/testeng/resources/cleanup-python-code-create-pr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-IFS=',' read -ra REPOS <<<"$REPO_NAMES"
+IFS=', ' read -ra REPOS <<<"$REPO_NAMES"
 
 failed_repos=()
 


### PR DESCRIPTION
This allows repo names to be specified in the same way as packages,
with more flexible and natural delimiters.