### PR TITLE
Bugfix: Fix error handling in cleanup job with `set -e` in subshell

### DIFF
--- a/testeng/resources/cleanup-python-code-create-pr.sh
+++ b/testeng/resources/cleanup-python-code-create-pr.sh
@@ -35,7 +35,11 @@ do_one_repo () {
 
   echo "Running cleanup scripts..."
   cd "$repo_dir"
-  bash -c "$SCRIPTS"
+  # Run in a subshell for isolation, and enable same error/exit
+  # handling (-eu -o pipefail) so that a failing command in a sequence
+  # still marks the iteration as a failure. Turn on command echoing
+  # (-x) for better debugging.
+  bash -c "set -eu -o pipefail -x; $SCRIPTS"
 
   echo "Running script to create PR..."
   cd "$WORKSPACE/testeng-ci"


### PR DESCRIPTION
Without this, a script like `broken_call; working_call` where `broken_call`
has a non-zero exit would not mark the repo cleanup as failing. This
regression was introduced for multi-command scripts in dcb0514569/PR #1201.