### PR TITLE
Use python 3.8 for cc2olx repository

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -70,7 +70,7 @@ List jobConfigs = [
         org: 'edx',
         repoName: 'cc2olx',
         defaultBranch: 'master',
-        pythonVersion: '3.5',
+        pythonVersion: '3.8',
         cronValue: cronOffHoursBusinessWeekdayTwiceMonthlyEven,
         githubUserReviewers: [],
         githubTeamReviewers: ['masters-devs-cosmonauts'],


### PR DESCRIPTION
Use python 3.5 instead of python 3.8
Python 3.5 causes `make upgrade` failure for the library `black` no longer supports python 3.5.