### PR TITLE
Remove team mention in review because we have opsgenie alerts

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -73,7 +73,7 @@ List jobConfigs = [
         pythonVersion: '3.8',
         cronValue: cronOffHoursBusinessWeekdayTwiceMonthlyEven,
         githubUserReviewers: [],
-        githubTeamReviewers: ['masters-devs-cosmonauts'],
+        githubTeamReviewers: [],  //Reviewer mention unnecessary due to Master's OpsGenie alert. 
         emails: ['masters-requirements-update@edx.opsgenie.net'],
     ],
     [


### PR DESCRIPTION
@matthugs Please help review. Just a simple change to move cc2olx together with other Cosmonauts owned repos.