### PR TITLE
Add dbt profile information to run-operation calls.

### DIFF
--- a/dataeng/resources/warehouse-transforms.sh
+++ b/dataeng/resources/warehouse-transforms.sh
@@ -78,7 +78,7 @@ then
 
     for (( i=0; i<${num_txfrs}; i++ ));
     do
-        dbt run-operation ${PROGRAMS_REPORTING_TRANSFERS[$i*2]} --args \'${PROGRAMS_REPORTING_TRANSFERS[$i*2+1]}\'
+        dbt run-operation ${PROGRAMS_REPORTING_TRANSFERS[$i*2]} --args \'${PROGRAMS_REPORTING_TRANSFERS[$i*2+1]}\' --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
     done
 
 fi
@@ -101,7 +101,7 @@ then
 
     for (( i=0; i<${num_txfrs}; i++ ));
     do
-        dbt run-operation ${ENTERPRISE_TRANSFERS[$i*2]} --args \'${ENTERPRISE_TRANSFERS[$i*2+1]}\'
+        dbt run-operation ${ENTERPRISE_TRANSFERS[$i*2]} --args \'${ENTERPRISE_TRANSFERS[$i*2+1]}\' --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/
     done
 
 fi


### PR DESCRIPTION
😦 Forgot the dbt profile information in the `dbt run-operation` calls.
😄 This will be the last fix?

Previous PRs:
https://github.com/edx/jenkins-job-dsl/pull/1247
https://github.com/edx/jenkins-job-dsl/pull/1256

Caused the error seen here: http://jenkins.analytics.edx.org/job/warehouse-transforms-daily/584/console