### PR TITLE
upgrade django-config-models requirements upgrade job to python38

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -73,7 +73,7 @@ List jobConfigs = [
         pythonVersion: '3.8',
         cronValue: cronOffHoursBusinessWeekdayTwiceMonthlyEven,
         githubUserReviewers: [],
-        githubTeamReviewers: [],  //Reviewer mention unnecessary due to Master's OpsGenie alert. 
+        githubTeamReviewers: [],  //Reviewer mention unnecessary due to Master's OpsGenie alert.
         emails: ['masters-requirements-update@edx.opsgenie.net'],
     ],
     [
@@ -165,7 +165,7 @@ List jobConfigs = [
         org: 'edx',
         repoName: 'django-config-models',
         defaultBranch: 'master',
-        pythonVersion: '3.5',
+        pythonVersion: '3.8',
         cronValue: cronOffHoursBusinessWeekdayLahore,
         githubUserReviewers: [],
         githubTeamReviewers: ['arbi-bom'],


### PR DESCRIPTION
**Issue:** [BOM-2240](https://openedx.atlassian.net/browse/BOM-2240)
