### PR TITLE
Try freezing setuptools to fix user retirement jobs

### DIFF
--- a/platform/resources/user-retirement-collector.sh
+++ b/platform/resources/user-retirement-collector.sh
@@ -20,6 +20,8 @@ cp $USER_RETIREMENT_SECURE_DEFAULT $WORKSPACE/user-retirement-secure/secure-defa
 
 # prepare tubular
 cd $WORKSPACE/tubular
+# match versions of pip and setuptools installed as part of tubular CI.
+pip install 'pip==20.3.3' 'setuptools==50.3.2'
 pip install -r requirements.txt
 
 # Create the directory where we will populate properties files, one per

--- a/platform/resources/user-retirement-driver.sh
+++ b/platform/resources/user-retirement-driver.sh
@@ -20,6 +20,8 @@ cp $USER_RETIREMENT_SECURE_DEFAULT $WORKSPACE/user-retirement-secure/secure-defa
 
 # prepare tubular
 cd $WORKSPACE/tubular
+# match versions of pip and setuptools installed as part of tubular CI.
+pip install 'pip==20.3.3' 'setuptools==50.3.2'
 pip install -r requirements.txt
 
 # Call the script to retire one learner.  This assumes the following build


### PR DESCRIPTION
It seems that setuptools 51.3.0 was release just 1 hour ago, which
strongly correlates with when the collector job started failing due to a
syntax error.  This is a stop-gap to get the user retirement pipeline up
and running again.

https://opsg.in/a/t/edx/36
https://opsg.in/a/t/edx/37