### PR TITLE
Add option to build specific Jenkins worker for user retirement.

### DIFF
--- a/testeng/jobs/buildPackerAMIjob.groovy
+++ b/testeng/jobs/buildPackerAMIjob.groovy
@@ -20,7 +20,8 @@ job('build-packer-ami') {
                       'webpagetest.json',
                       'jenkins_worker_simple.json',
                       'jenkins_worker_android.json',
-                      'jenkins_worker_codejail.json'
+                      'jenkins_worker_codejail.json',
+                      'jenkins_worker_user_retire.json'
                     ],
                     'Json file (in util/packer) specifying how to build ' +
                     'the new AMI.')


### PR DESCRIPTION
Companion PR to: https://github.com/edx/configuration/pull/6265

Adds the option to build a Jenkins worker intended solely for use in the user retirement process. The worker contains less dependencies than other workers, bypassing current failures when building a new Jenkins worker.

The reason for all this:
Our user retirement process is currently broken due to the configuration of the Jenkins worker nodes at build.testeng.edx.org. Over the weekend, a new version of pip was released (v21.0) which removed support for Python 3.5. The workers seem to have both a Python3.5 venv installed with a pip version of 21.0, because if the job attempts to run pip, it immediately errors with a stack trace containing code from the v21.0 release. What's needed is likely logic to pin the pip version, at least for the Python3.5 venvs.