### PR TITLE
update Python version to run pip-compile under for Registrar

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -509,7 +509,7 @@ List jobConfigs = [
         org: 'edx',
         repoName: 'registrar',
         defaultBranch: 'master',
-        pythonVersion: '3.5',
+        pythonVersion: '3.8',
         cronValue: cronOffHoursBusinessWeekdayTwiceMonthlyEven,
         githubUserReviewers: [],
         githubTeamReviewers: [],  // Reviewer mention unnecessary due to Master's OpsGenie alert.


### PR DESCRIPTION
Update the version of Python that `pip-compile` runs under for the Registrar Python Requirements Updates jobs that Jenkins runs. Registrar currently supports Python 3.8 and runs also Travis under Python 3.8.

A new [version](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-600154) of the `newrelic` Python agent does not support Python 3.5.