### PR TITLE
Stop using shiningpanda for user retirement jobs

### DIFF
--- a/platform/jobs/RetirementJobs.groovy
+++ b/platform/jobs/RetirementJobs.groovy
@@ -170,12 +170,7 @@ job('user-retirement-driver') {
     }
 
     steps {
-        virtualenv {
-            name('user-retirement-driver')
-            nature('shell')
-            command(readFileFromWorkspace('platform/resources/user-retirement-driver.sh'))
-            pythonName('PYTHON_3.5')
-        }
+        shell(readFileFromWorkspace('platform/resources/user-retirement-driver.sh'))
     }
 
     publishers {
@@ -306,12 +301,7 @@ job('user-retirement-collector') {
         // This step calls out to the LMS and collects a list of learners to
         // retire.  The output is several generated properties files, one per
         // learner.
-        virtualenv {
-            name('user-retirement-collector')
-            nature('shell')
-            command(readFileFromWorkspace('platform/resources/user-retirement-collector.sh'))
-            pythonName('PYTHON_3.5')
-        }
+        shell(readFileFromWorkspace('platform/resources/user-retirement-collector.sh'))
         // This takes as input the properties files created in the previous
         // step, and triggers user-retirement-driver jobs per file.
         downstreamParameterized {
@@ -470,12 +460,7 @@ job('retirement-partner-reporter') {
     }
 
     steps {
-        virtualenv {
-            name('retirement-partner-reporter')
-            nature('shell')
-            command(readFileFromWorkspace('platform/resources/retirement-partner-reporter.sh'))
-            pythonName('PYTHON_3.5')
-        }
+        shell(readFileFromWorkspace('platform/resources/retirement-partner-reporter.sh'))
     }
 
     publishers {
@@ -598,12 +583,7 @@ job('retirement-partner-report-cleanup') {
     }
 
     steps {
-        virtualenv {
-            name('retirement-partner-report-cleanup')
-            nature('shell')
-            command(readFileFromWorkspace('platform/resources/retirement-partner-report-cleanup.sh'))
-            pythonName('PYTHON_3.5')
-        }
+        shell(readFileFromWorkspace('platform/resources/retirement-partner-report-cleanup.sh'))
     }
 
     publishers {
@@ -722,12 +702,7 @@ job('user-retirement-bulk-status') {
 
     steps {
         // This step calls the shell script which talks to LMS
-        virtualenv {
-            name('user-retirement-bulk-status')
-            nature('shell')
-            command(readFileFromWorkspace('platform/resources/user-retirement-bulk-status.sh'))
-            pythonName('PYTHON_3.5')
-        }
+        shell(readFileFromWorkspace('platform/resources/user-retirement-bulk-status.sh'))
     }
     publishers {
         // After all the build steps have completed, cleanup the workspace in

--- a/platform/resources/retirement-partner-report-cleanup.sh
+++ b/platform/resources/retirement-partner-report-cleanup.sh
@@ -2,14 +2,21 @@
 
 set -ex
 
+# Create and activate a virtualenv.  In case we ever change the concurrency
+# setting on the jenkins worker, it would be safest to keep the builds from
+# clobbering each other's virtualenvs.
+VENV="venv-${BUILD_NUMBER}"
+virtualenv --python=python3.8 --clear "${VENV}"
+source "${VENV}/bin/activate"
+
 # prepare credentials
 mkdir -p $WORKSPACE/user-retirement-secure
 cp $USER_RETIREMENT_SECURE_DEFAULT $WORKSPACE/user-retirement-secure/secure-default.yml
 
 # prepare tubular
 cd $WORKSPACE/tubular
-# match versions of pip and setuptools installed as part of tubular CI.
-pip install 'pip==20.3.3' 'setuptools==50.3.2'
+# snapshot the current latest versions of pip and setuptools.
+pip install 'pip==21.0.1' 'setuptools==53.0.0'
 pip install -r requirements.txt
 
 # Call the script to cleanup the reports

--- a/platform/resources/retirement-partner-reporter.sh
+++ b/platform/resources/retirement-partner-reporter.sh
@@ -8,6 +8,13 @@ set -ex
 # just stores a filename in the environment (rather than the content).
 env
 
+# Create and activate a virtualenv.  In case we ever change the concurrency
+# setting on the jenkins worker, it would be safest to keep the builds from
+# clobbering each other's virtualenvs.
+VENV="venv-${BUILD_NUMBER}"
+virtualenv --python=python3.8 --clear "${VENV}"
+source "${VENV}/bin/activate"
+
 # Make sure that when we try to write unicode to the console, it
 # correctly encodes to UTF-8 rather than exiting with a UnicodeEncode
 # error.
@@ -20,8 +27,8 @@ cp $USER_RETIREMENT_SECURE_DEFAULT $WORKSPACE/user-retirement-secure/secure-defa
 
 # prepare tubular
 cd $WORKSPACE/tubular
-# match versions of pip and setuptools installed as part of tubular CI.
-pip install 'pip==20.3.3' 'setuptools==50.3.2'
+# snapshot the current latest versions of pip and setuptools.
+pip install 'pip==21.0.1' 'setuptools==53.0.0'
 pip install -r requirements.txt
 
 # Create the directory where we will store reports, one per partner

--- a/platform/resources/user-retirement-bulk-status.sh
+++ b/platform/resources/user-retirement-bulk-status.sh
@@ -8,6 +8,13 @@ set -ex
 # just stores a filename in the environment (rather than the content).
 env
 
+# Create and activate a virtualenv.  In case we ever change the concurrency
+# setting on the jenkins worker, it would be safest to keep the builds from
+# clobbering each other's virtualenvs.
+VENV="venv-${BUILD_NUMBER}"
+virtualenv --python=python3.8 --clear "${VENV}"
+source "${VENV}/bin/activate"
+
 # Make sure that when we try to write unicode to the console, it
 # correctly encodes to UTF-8 rather than exiting with a UnicodeEncode
 # error.
@@ -20,8 +27,8 @@ cp $USER_RETIREMENT_SECURE_DEFAULT $WORKSPACE/user-retirement-secure/secure-defa
 
 # prepare tubular
 cd $WORKSPACE/tubular
-# match versions of pip and setuptools installed as part of tubular CI.
-pip install 'pip==20.3.3' 'setuptools==50.3.2'
+# snapshot the current latest versions of pip and setuptools.
+pip install 'pip==21.0.1' 'setuptools==53.0.0'
 pip install -r requirements.txt
 
 # Call the script to collect the list of learners that are to be retired.

--- a/platform/resources/user-retirement-collector.sh
+++ b/platform/resources/user-retirement-collector.sh
@@ -8,6 +8,13 @@ set -ex
 # just stores a filename in the environment (rather than the content).
 env
 
+# Create and activate a virtualenv.  In case we ever change the concurrency
+# setting on the jenkins worker, it would be safest to keep the builds from
+# clobbering each other's virtualenvs.
+VENV="venv-${BUILD_NUMBER}"
+virtualenv --python=python3.8 --clear "${VENV}"
+source "${VENV}/bin/activate"
+
 # Make sure that when we try to write unicode to the console, it
 # correctly encodes to UTF-8 rather than exiting with a UnicodeEncode
 # error.
@@ -20,8 +27,8 @@ cp $USER_RETIREMENT_SECURE_DEFAULT $WORKSPACE/user-retirement-secure/secure-defa
 
 # prepare tubular
 cd $WORKSPACE/tubular
-# match versions of pip and setuptools installed as part of tubular CI.
-pip install 'pip==20.3.3' 'setuptools==50.3.2'
+# snapshot the current latest versions of pip and setuptools.
+pip install 'pip==21.0.1' 'setuptools==53.0.0'
 pip install -r requirements.txt
 
 # Create the directory where we will populate properties files, one per

--- a/platform/resources/user-retirement-driver.sh
+++ b/platform/resources/user-retirement-driver.sh
@@ -8,6 +8,13 @@ set -ex
 # just stores a filename in the environment (rather than the content).
 env
 
+# Create and activate a virtualenv.  In case we ever change the concurrency
+# setting on the jenkins worker, it would be safest to keep the builds from
+# clobbering each other's virtualenvs.
+VENV="venv-${BUILD_NUMBER}"
+virtualenv --python=python3.8 --clear "${VENV}"
+source "${VENV}/bin/activate"
+
 # Make sure that when we try to write unicode to the console, it
 # correctly encodes to UTF-8 rather than exiting with a UnicodeEncode
 # error.
@@ -20,8 +27,8 @@ cp $USER_RETIREMENT_SECURE_DEFAULT $WORKSPACE/user-retirement-secure/secure-defa
 
 # prepare tubular
 cd $WORKSPACE/tubular
-# match versions of pip and setuptools installed as part of tubular CI.
-pip install 'pip==20.3.3' 'setuptools==50.3.2'
+# snapshot the current latest versions of pip and setuptools.
+pip install 'pip==21.0.1' 'setuptools==53.0.0'
 pip install -r requirements.txt
 
 # Call the script to retire one learner.  This assumes the following build


### PR DESCRIPTION
Shiningpanda was creating an impossible situation for python 3.5 because
it seems to be hard-coded to upgrade pip, but the latest pip (21) has
dropped python 3.5 support.  Also, shiningpanda is no longer supported
upstream, supposedly, so the rest of the edx org has moved away from it.

Additionally, I have changed the python version for these jobs from 3.5
to 3.8.

---
Manually tested in https://build.testeng.edx.org/view/user-retirement-jobs/job/user-retirement-collector/39665/console