### PR TITLE
Re-order the generated date for branch and PR names.

### DIFF
--- a/dataeng/resources/snowflake-schema-builder.sh
+++ b/dataeng/resources/snowflake-schema-builder.sh
@@ -15,7 +15,7 @@ dbt clean --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ --pro
 cd $WORKSPACE/warehouse-transforms
 
 # Create a new git branch
-now=$(date +%d_%m_%Y_%H_%M_%S)
+now=$(date +%Y_%m_%d_%H_%M_%S)
 branchname="builder_$now"
 git checkout -b "$branchname"
 


### PR DESCRIPTION
Change the current date ordering of:
`18_02_2021_14_34_45`
to:
`2021_02_18_14_34_45`
which is in order of least granular component to most granular component. It could be only me - but I find this ordering easier to read.