### PR TITLE
Bump travis count jobs to python3.8

### DIFF
--- a/testeng/jobs/travisCounts.groovy
+++ b/testeng/jobs/travisCounts.groovy
@@ -26,7 +26,7 @@ job('travis-counts') {
     }
 
     environmentVariables {
-        env('PYTHON_VERSION', '3.5')
+        env('PYTHON_VERSION', '3.8')
     }
 
     steps {

--- a/testeng/jobs/travisJobCounts.groovy
+++ b/testeng/jobs/travisJobCounts.groovy
@@ -26,7 +26,7 @@ job('travis-job-counts') {
     }
 
     environmentVariables {
-        env('PYTHON_VERSION', '3.5')
+        env('PYTHON_VERSION', '3.8')
     }
 
     steps {


### PR DESCRIPTION
Bumped the following jobs to run using `Python3.8`:
- testeng/jobs/travisCounts.groovy
- testeng/jobs/travisJobCounts.groovy