### PR TITLE
WT CI Removed re-basing, added master refspec, added concurrency

### DIFF
--- a/dataeng/jobs/analytics/WarehouseTransformsCI.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransformsCI.groovy
@@ -45,7 +45,7 @@ class WarehouseTransformsCI{
                 git {
                     remote {
                         url('$WAREHOUSE_TRANSFORMS_URL')
-                        refspec('+refs/heads/master:refs/remotes/origin/master','+refs/pull/*:refs/remotes/origin/pr/*')
+                        refspec('+refs/heads/master:refs/remotes/origin/master +refs/pull/*:refs/remotes/origin/pr/*')
                         credentials('1') 
                     }
                     branches('\${ghprbActualCommit}')

--- a/dataeng/jobs/analytics/WarehouseTransformsCI.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransformsCI.groovy
@@ -45,7 +45,7 @@ class WarehouseTransformsCI{
                 git {
                     remote {
                         url('$WAREHOUSE_TRANSFORMS_URL')
-                        refspec('+refs/pull/*:refs/remotes/origin/pr/*')
+                        refspec('+refs/heads/master:refs/remotes/origin/master','+refs/pull/*:refs/remotes/origin/pr/*')
                         credentials('1') 
                     }
                     branches('\${ghprbActualCommit}')
@@ -92,6 +92,10 @@ class WarehouseTransformsCI{
                 }
             }
             configure GHPRB_CANCEL_BUILDS_ON_UPDATE(false)
+            concurrentBuild(true)
+            throttleConcurrentBuilds {
+                maxTotal(5)
+            }            
             wrappers {
                 colorizeOutput('xterm')
             }

--- a/dataeng/resources/warehouse-transforms-ci.sh
+++ b/dataeng/resources/warehouse-transforms-ci.sh
@@ -48,11 +48,11 @@ then
     
     DBT_PROJECT_PATH='reporting'
     # This is a Slim CI syntax used to "run" only modified and downstream models
-    DBT_RUN_OPTIONS="-m state:modified+ @state:modified,1+test_type:data --defer --state $WORKSPACE/manifest" 
+    DBT_RUN_OPTIONS="-m state:modified+ @state:modified --defer --state $WORKSPACE/manifest"
     DBT_RUN_EXCLUDE='' ## TODO Add excluded models here
     # Will add --defer here when DBT version is upgraded
     # This is a Slim CI syntax used to "test" only modified and downstream models
-    DBT_TEST_OPTIONS="-m state:modified+ --state $WORKSPACE/manifest"
+    DBT_TEST_OPTIONS="-m state:modified+ --defer --state $WORKSPACE/manifest"
     DBT_TEST_EXCLUDE='--exclude test_name:relationships' 
 
     source $WORKSPACE/jenkins-job-dsl/dataeng/resources/warehouse-transforms-ci-dbt.sh

--- a/dataeng/resources/warehouse-transforms-ci.sh
+++ b/dataeng/resources/warehouse-transforms-ci.sh
@@ -49,8 +49,7 @@ then
     DBT_PROJECT_PATH='reporting'
     # This is a Slim CI syntax used to "run" only modified and downstream models
     DBT_RUN_OPTIONS="-m state:modified+ @state:modified --defer --state $WORKSPACE/manifest"
-    DBT_RUN_EXCLUDE='' ## TODO Add excluded models here
-    # Will add --defer here when DBT version is upgraded
+    DBT_RUN_EXCLUDE='' ## Add excluded models here if any
     # This is a Slim CI syntax used to "test" only modified and downstream models
     DBT_TEST_OPTIONS="-m state:modified+ --defer --state $WORKSPACE/manifest"
     DBT_TEST_EXCLUDE='--exclude test_name:relationships' 

--- a/dataeng/resources/warehouse-transforms-ci.sh
+++ b/dataeng/resources/warehouse-transforms-ci.sh
@@ -15,23 +15,18 @@ aws s3 cp s3://edx-dbt-docs/manifest.json ${WORKSPACE}/manifest
 # Setup to run dbt commands
 cd $WORKSPACE/warehouse-transforms
 
-# Pull the origin master code to latest branch which will be used to compare the diff
-git pull -f origin master:latest
+BRANCH_POINT=$(git merge-base origin/master ${ghprbActualCommit})
+git diff $BRANCH_POINT --name-only
 
-# Put back the head at PR commit
-git checkout ${ghprbActualCommit}
-
-git rebase latest
-
-git diff latest --name-only
+git diff origin/master --name-only
 
 # Finding the project names which has changed in this PR. Using git diff latest to compare this branch from master
 # It returns all the files name with full path. Searching through it using egrep to find which project(s) the changing files belong.
 # It might happen one PR may be changing files in different projects.
-if git diff latest --name-only | egrep "projects/reporting" -q; then isReporting="true"; else isReporting="false"; fi
-if git diff latest --name-only | egrep "projects/automated/applications" -q; then isApplications="true"; else isApplications="false"; fi
-if git diff latest --name-only | egrep "projects/automated/raw_to_source" -q; then isRawToSource="true"; else isRawToSource="false"; fi
-if git diff latest --name-only | egrep "projects/automated/telemetry" -q; then isTelemetry="true"; else isTelemetry="false"; fi
+if git diff $BRANCH_POINT --name-only | egrep "projects/reporting" -q; then isReporting="true"; else isReporting="false"; fi
+if git diff $BRANCH_POINT --name-only | egrep "projects/automated/applications" -q; then isApplications="true"; else isApplications="false"; fi
+if git diff $BRANCH_POINT --name-only | egrep "projects/automated/raw_to_source" -q; then isRawToSource="true"; else isRawToSource="false"; fi
+if git diff $BRANCH_POINT --name-only | egrep "projects/automated/telemetry" -q; then isTelemetry="true"; else isTelemetry="false"; fi
 
 
 # Setup to run dbt commands


### PR DESCRIPTION
- Re-basing inside shell script was causing issues with merge conflicts so removed that
- Re-basing was helping us to determine the delta (names of files and projects changes in the said PR) by which we determine which project(s) to run CI on, in-order to do it without re-basing I tried multiple ways the currently implemented adding refspec master branch and git merge-base approach seems to be working
- Added concurrency and throttle limit to 5
- Added --defer test state from manifest.json file (Newly introduced feature with v0.19.0) 