### PR TITLE
Moving dbt jobs to new jenkins

### DIFF
--- a/dataeng/jobs/createJobs.groovy
+++ b/dataeng/jobs/createJobs.groovy
@@ -21,7 +21,6 @@ import static analytics.StitchSnowflakeLagMonitor.job as StitchSnowflakeLagMonit
 import static analytics.UserActivity.job as UserActivityJob
 import static analytics.UserLocationByCourse.job as UserLocationByCourseJob
 import static analytics.VideoTimeline.job as VideoTimelineJob
-import static analytics.ModelTransfers.job as ModelTransfersJob
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.DEFAULT_VIEW
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.error.YAMLException
@@ -66,7 +65,6 @@ def taskMap = [
     USER_ACTIVITY_JOB: UserActivityJob,
     USER_LOCATION_BY_COURSE_JOB: UserLocationByCourseJob,
     VIDEO_TIMELINE_JOB: VideoTimelineJob,
-    MODEL_TRANSFERS_JOB: ModelTransfersJob,
 ]
 
 for (task in taskMap) {

--- a/dataeng/jobs/createJobs.groovy
+++ b/dataeng/jobs/createJobs.groovy
@@ -2,9 +2,6 @@ import static analytics.AggregateDailyTrackingLogs.job as AggregateDailyTracking
 import static analytics.AnalyticsEmailOptin.job as AnalyticsEmailOptinJob
 import static analytics.AnalyticsExporter.job as AnalyticsExporterJob
 import static analytics.AnswerDistribution.job as AnswerDistributionJob
-import static analytics.DBTDocs.job as DBTDocsJob
-import static analytics.DBTManual.job as DBTManualJob
-import static analytics.DBTSourceFreshness.job as DBTSourceFreshnessJob
 import static analytics.DatabaseExportCoursewareStudentmodule.job as DatabaseExportCoursewareStudentmoduleJob
 import static analytics.Enrollment.job as EnrollmentJob
 import static analytics.EnrollmentValidationEvents.job as EnrollmentValidationEventsJob
@@ -24,7 +21,6 @@ import static analytics.StitchSnowflakeLagMonitor.job as StitchSnowflakeLagMonit
 import static analytics.UserActivity.job as UserActivityJob
 import static analytics.UserLocationByCourse.job as UserLocationByCourseJob
 import static analytics.VideoTimeline.job as VideoTimelineJob
-import static analytics.WarehouseTransforms.job as WarehouseTransformsJob
 import static analytics.ModelTransfers.job as ModelTransfersJob
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.DEFAULT_VIEW
 import org.yaml.snakeyaml.Yaml
@@ -52,9 +48,6 @@ def taskMap = [
     ANALYTICS_EXPORTER_JOB: AnalyticsExporterJob,
     ANSWER_DISTRIBUTION_JOB: AnswerDistributionJob,
     DATABASE_EXPORT_COURSEWARE_STUDENTMODULE_JOB: DatabaseExportCoursewareStudentmoduleJob,
-    DBT_DOCS_JOB: DBTDocsJob,
-    DBT_MANUAL_JOB: DBTManualJob,
-    DBT_SOURCE_FRESHNESS_JOB: DBTSourceFreshnessJob,
     ENROLLMENT_JOB: EnrollmentJob,
     ENROLLMENT_VALIDATION_EVENTS_JOB: EnrollmentValidationEventsJob,
     ENTERPRISE_JOB: EnterpriseJob,
@@ -73,7 +66,6 @@ def taskMap = [
     USER_ACTIVITY_JOB: UserActivityJob,
     USER_LOCATION_BY_COURSE_JOB: UserLocationByCourseJob,
     VIDEO_TIMELINE_JOB: VideoTimelineJob,
-    WAREHOUSE_TRANSFORMS_JOB: WarehouseTransformsJob,
     MODEL_TRANSFERS_JOB: ModelTransfersJob,
 ]
 

--- a/dataeng/jobs/createJobsNew.groovy
+++ b/dataeng/jobs/createJobsNew.groovy
@@ -5,6 +5,7 @@ import static analytics.EmrCostReporter.job as EmrCostReporterJob
 import static analytics.SnowflakeExpirePasswords.job as SnowflakeExpirePasswordsJob
 import static analytics.SnowflakeCollectMetrics.job as SnowflakeCollectMetricsJob
 import static analytics.DeployCluster.job as DeployClusterJob
+import static analytics.ModelTransfers.job as ModelTransfersJob
 import static analytics.TerminateCluster.job as TerminateClusterJob
 import static analytics.UpdateUsers.job as UpdateUsersJob
 import static analytics.SnowflakeSchemaBuilder.job as SnowflakeSchemaBuilderJob
@@ -39,6 +40,7 @@ def taskMap = [
     SNOWFLAKE_EXPIRE_PASSWORDS_JOB: SnowflakeExpirePasswordsJob,
     SNOWFLAKE_COLLECT_METRICS_JOB: SnowflakeCollectMetricsJob,
     DEPLOY_CLUSTER_JOB: DeployClusterJob,
+    MODEL_TRANSFERS_JOB: ModelTransfersJob,
     TERMINATE_CLUSTER_JOB: TerminateClusterJob,
     UPDATE_USERS_JOB: UpdateUsersJob,
     SNOWFLAKE_SCHEMA_BUILDER_JOB: SnowflakeSchemaBuilderJob,

--- a/dataeng/jobs/createJobsNew.groovy
+++ b/dataeng/jobs/createJobsNew.groovy
@@ -1,3 +1,6 @@
+import static analytics.DBTDocs.job as DBTDocsJob
+import static analytics.DBTManual.job as DBTManualJob
+import static analytics.DBTSourceFreshness.job as DBTSourceFreshnessJob
 import static analytics.EmrCostReporter.job as EmrCostReporterJob
 import static analytics.SnowflakeExpirePasswords.job as SnowflakeExpirePasswordsJob
 import static analytics.SnowflakeCollectMetrics.job as SnowflakeCollectMetricsJob
@@ -5,6 +8,7 @@ import static analytics.DeployCluster.job as DeployClusterJob
 import static analytics.TerminateCluster.job as TerminateClusterJob
 import static analytics.UpdateUsers.job as UpdateUsersJob
 import static analytics.SnowflakeSchemaBuilder.job as SnowflakeSchemaBuilderJob
+import static analytics.WarehouseTransforms.job as WarehouseTransformsJob
 import static analytics.WarehouseTransformsCI.job as WarehouseTransformsCIJob
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.DEFAULT_VIEW
 import org.yaml.snakeyaml.Yaml
@@ -28,6 +32,9 @@ try {
 
 def taskMap = [
     // Add jobs here as they are ported from the old analytics Jenkins server.
+    DBT_DOCS_JOB: DBTDocsJob,
+    DBT_MANUAL_JOB: DBTManualJob,
+    DBT_SOURCE_FRESHNESS_JOB: DBTSourceFreshnessJob,
     EMR_COST_REPORTER_JOB: EmrCostReporterJob,
     SNOWFLAKE_EXPIRE_PASSWORDS_JOB: SnowflakeExpirePasswordsJob,
     SNOWFLAKE_COLLECT_METRICS_JOB: SnowflakeCollectMetricsJob,
@@ -35,6 +42,7 @@ def taskMap = [
     TERMINATE_CLUSTER_JOB: TerminateClusterJob,
     UPDATE_USERS_JOB: UpdateUsersJob,
     SNOWFLAKE_SCHEMA_BUILDER_JOB: SnowflakeSchemaBuilderJob,
+    WAREHOUSE_TRANSFORMS_JOB: WarehouseTransformsJob,
     WAREHOUSE_TRANSFORMS_CI_JOB: WarehouseTransformsCIJob,
 ]
 


### PR DESCRIPTION
We decided to move dbt jobs from analytics jenkins to new analytics jenkins, the following PR will seed jobs to new jenkins and I will disable and added DEPRECATED prefix on these jobs in analytics jenkins manually as this document suggets
https://openedx.atlassian.net/wiki/spaces/DE/pages/1454932631/Jenkins+Cutover+Process