### PR TITLE
WT CI Manual Job

### DIFF
--- a/dataeng/jobs/analytics/WarehouseTransformsCIManual.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransformsCIManual.groovy
@@ -1,0 +1,103 @@
+package analytics
+import static org.edx.jenkins.dsl.AnalyticsConstants.secure_scm
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_log_rotator
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_wrappers
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_publishers
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_triggers
+import static org.edx.jenkins.dsl.AnalyticsConstants.secure_scm_parameters
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_authorization
+import static org.edx.jenkins.dsl.JenkinsPublicConstants.GHPRB_CANCEL_BUILDS_ON_UPDATE
+
+class WarehouseTransformsCIManual{
+    public static def job = { dslFactory, allVars ->
+        dslFactory.job("warehouse-transforms-ci-manual"){
+            authorization common_authorization(allVars)
+            logRotator common_log_rotator(allVars)
+            parameters secure_scm_parameters(allVars)
+            parameters {
+                stringParam('WAREHOUSE_TRANSFORMS_URL', allVars.get('WAREHOUSE_TRANSFORMS_URL'), 'URL for the warehouse-transforms repository.')
+                stringParam('WAREHOUSE_TRANSFORMS_BRANCH', '', 'Must specify branch of warehouse-transforms repository to use.')
+                stringParam('GITHUB_PR_ID', '', 'Must specify Github Pull Request Id')
+                stringParam('DBT_TARGET', allVars.get('DBT_TARGET'), 'DBT target from profiles.yml in analytics-secure.')
+                stringParam('DBT_PROFILE', allVars.get('DBT_PROFILE'), 'DBT profile from profiles.yml in analytics-secure.')
+                stringParam('DBT_PROJECT_PATH', allVars.get('DBT_PROJECT_PATH'), 'Path in warehouse-transforms to use as the dbt project, relative to "projects" (usually automated/applications or reporting).')
+                stringParam('RUN_DBT_TESTS_ONLY', allVars.get('RUN_DBT_TESTS_ONLY'), 'Mark it as false if you want to run dbt models')
+                stringParam('DBT_RUN_OPTIONS', allVars.get('DBT_RUN_OPTIONS'), 'Additional options to dbt run, such as --models for model selection. Details here: https://docs.getdbt.com/docs/model-selection-syntax')
+                stringParam('DBT_RUN_EXCLUDE', allVars.get('DBT_RUN_EXCLUDE'), 'Additional options to dbt run, such as --exclude. Details here: https://docs.getdbt.com/docs/model-selection-syntax')
+                stringParam('DBT_TEST_OPTIONS', allVars.get('DBT_TEST_OPTIONS'), 'Additional options to dbt test, such as --models for model selection. Details here: https://docs.getdbt.com/docs/model-selection-syntax')
+                stringParam('DBT_TEST_EXCLUDE', allVars.get('DBT_TEST_EXCLUDE'), 'Additional options to dbt test, such as "--exclude <model>". Details here: https://docs.getdbt.com/docs/model-selection-syntax')
+                stringParam('DB_NAME', allVars.get('DB_NAME'), 'Database name used to create output schema of dbt run/tests')
+                stringParam('NOTIFY', allVars.get('NOTIFY'), 'Space separated list of emails to send notifications to.')
+                stringParam('ANALYTICS_TOOLS_URL', allVars.get('ANALYTICS_TOOLS_URL'), 'URL for the analytics tools repo.')
+                stringParam('ANALYTICS_TOOLS_BRANCH', allVars.get('ANALYTICS_TOOLS_BRANCH'), 'Branch of analytics tools repo to use.')
+                stringParam('JENKINS_JOB_DSL_URL', allVars.get('JENKINS_JOB_DSL_URL'), 'URL for the jenkins-job-dsl repo.')
+                stringParam('JENKINS_JOB_DSL_BRANCH', allVars.get('JENKINS_JOB_DSL_BRANCH'), 'Branch of jenkins-job-dsl repo to use.')
+
+            }
+            environmentVariables {
+                env('KEY_PATH', allVars.get('KEY_PATH'))
+                env('PASSPHRASE_PATH', allVars.get('PASSPHRASE_PATH'))
+                env('USER', allVars.get('USER'))
+                env('ACCOUNT', allVars.get('ACCOUNT'))
+            }                      
+            multiscm secure_scm(allVars) << {
+                git {
+                    remote {
+                        url('$WAREHOUSE_TRANSFORMS_URL')
+                        branch('$WAREHOUSE_TRANSFORMS_BRANCH')
+                        credentials('1') 
+                    }
+                    extensions {
+                        relativeTargetDirectory('warehouse-transforms')
+                        pruneBranches()
+                        cleanAfterCheckout()
+                    }
+                }
+                git {
+                    remote {
+                        url('$ANALYTICS_TOOLS_URL')
+                        branch('$ANALYTICS_TOOLS_BRANCH')
+                        credentials('1')
+                    }
+                    extensions {
+                        relativeTargetDirectory('analytics-tools')
+                        pruneBranches()
+                        cleanAfterCheckout()
+                    }
+                }  
+                git {
+                    remote {
+                        url('$JENKINS_JOB_DSL_URL')
+                        branch('$JENKINS_JOB_DSL_BRANCH')
+                        credentials('1')
+                    }
+                    extensions {
+                        relativeTargetDirectory('jenkins-job-dsl')
+                        pruneBranches()
+                        cleanAfterCheckout()
+                    }
+                }                              
+            }
+            triggers common_triggers(allVars)
+            publishers common_publishers(allVars)
+            concurrentBuild(true)
+            throttleConcurrentBuilds {
+                maxTotal(5)
+            }            
+            wrappers {
+                colorizeOutput('xterm')
+            }
+            wrappers common_wrappers(allVars)
+            steps {
+                virtualenv {
+                    pythonName('PYTHON_3.7')
+                    nature("shell")
+                    systemSitePackages(false)
+                    command(
+                        dslFactory.readFileFromWorkspace("dataeng/resources/warehouse-transforms-ci-manual.sh")
+                    )
+                }
+            }
+        }
+    }
+}

--- a/dataeng/jobs/createJobsNew.groovy
+++ b/dataeng/jobs/createJobsNew.groovy
@@ -12,6 +12,7 @@ import static analytics.SnowflakeSchemaBuilder.job as SnowflakeSchemaBuilderJob
 import static analytics.WarehouseTransforms.job as WarehouseTransformsJob
 import static analytics.WarehouseTransformsCI.job as WarehouseTransformsCIJob
 import static analytics.WarehouseTransformsCIMasterMerges.job as WarehouseTransformsCIMasterMergesJob
+import static analytics.WarehouseTransformsCIManual.job as WarehouseTransformsCIManualJob
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.DEFAULT_VIEW
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.error.YAMLException
@@ -48,6 +49,7 @@ def taskMap = [
     WAREHOUSE_TRANSFORMS_JOB: WarehouseTransformsJob,
     WAREHOUSE_TRANSFORMS_CI_JOB: WarehouseTransformsCIJob,
     WAREHOUSE_TRANSFORMS_CI_MASTER_MERGES_JOB: WarehouseTransformsCIMasterMergesJob,
+    WAREHOUSE_TRANSFORMS_CI_MANUAL_JOB: WarehouseTransformsCIManualJob,
 ]
 
 for (task in taskMap) {

--- a/dataeng/resources/warehouse-transforms-ci-manual.sh
+++ b/dataeng/resources/warehouse-transforms-ci-manual.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -ex
+
+# Specifying GITHUB_PR_ID and WAREHOUSE_TRANSFORMS_BRANCH is a must
+if [[ "$GITHUB_PR_ID" == "" || "$WAREHOUSE_TRANSFORMS_BRANCH" == "" ]]
+then
+    echo "Please provide GITHUB_PR_ID and WAREHOUSE_TRANSFORMS_BRANCH"
+    exit 1
+fi    
+
+# Setup to run python script to create snowflake schema
+cd $WORKSPACE/analytics-tools/snowflake
+make requirements
+
+# Download Prod build manifest.json file from S3 and creating directory to place manifest file.
+cd $WORKSPACE/ && mkdir -p manifest
+
+pip install awscli
+
+aws s3 cp s3://edx-dbt-docs/manifest.json ${WORKSPACE}/manifest
+
+# Find the project name to append with CI_SCHEMA_NAME
+if echo $DBT_PROJECT_PATH | egrep "reporting" -q; then PROJECT_NAME="reporting"; fi
+if echo $DBT_PROJECT_PATH | egrep "automated/applications" -q; then PROJECT_NAME="automated/applications"; fi
+if echo $DBT_PROJECT_PATH | egrep "automated/raw_to_source" -q; then PROJECT_NAME="automated/raw_to_source"; fi
+if echo $DBT_PROJECT_PATH | egrep "automated/telemetry" -q; then PROJECT_NAME="automated/telemetry"; fi
+
+
+# Setup to run dbt commands
+cd $WORKSPACE/warehouse-transforms
+
+# To install right version of dbt
+pip install -r requirements.txt
+
+cd $WORKSPACE/analytics-tools/snowflake
+export CI_SCHEMA_NAME=PR_${GITHUB_PR_ID}_${PROJECT_NAME}
+# Schema is dynamically created against each run.
+# profiles.yml contains the name of Schema which is used to create output models when dbt runs.
+python create_ci_schema.py --key_path $KEY_PATH --passphrase_path $PASSPHRASE_PATH --automation_user $USER --account $ACCOUNT --db_name $DB_NAME --schema_name $CI_SCHEMA_NAME --no_drop_old
+
+cd $WORKSPACE/warehouse-transforms/projects/$DBT_PROJECT_PATH
+
+dbt clean --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ --profile $DBT_PROFILE --target $DBT_TARGET
+dbt deps --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ --profile $DBT_PROFILE --target $DBT_TARGET
+dbt seed --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ --profile $DBT_PROFILE --target $DBT_TARGET
+
+if [[ "$RUN_TESTS_ONLY" != "true" ]]
+then
+    dbt run $DBT_RUN_OPTIONS $DBT_RUN_EXCLUDE --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ --profile $DBT_PROFILE --target $DBT_TARGET
+fi
+
+dbt test $DBT_TEST_OPTIONS $DBT_TEST_EXCLUDE --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ --profile $DBT_PROFILE --target $DBT_TARGET


### PR DESCRIPTION
If some tests fails on your Warehouse Transform CI job and re-running the whole job is time consuming, this job provides short way of running CI only on failed tests

Warehouse Transform Manual CI job will be used to run only specific models that failed, specify GITHUB_PR_ID, WAREHOUSE_TRANSFORMS_BRANCH, marks that project as true and specify DBT_TEST_OPTIONS_<PROJECT-NAME>

Document: https://openedx.atlassian.net/wiki/spaces/DE/pages/2464776611/CI+Warehouse+Transform+Manual+Job
Ticket: https://openedx.atlassian.net/browse/DENG-788