### PR TITLE
Merges to Master WT CI

### DIFF
--- a/dataeng/jobs/analytics/WarehouseTransformsMasterCI.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransformsMasterCI.groovy
@@ -1,0 +1,143 @@
+package analytics
+import static org.edx.jenkins.dsl.AnalyticsConstants.secure_scm
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_log_rotator
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_wrappers
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_publishers
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_triggers
+import static org.edx.jenkins.dsl.AnalyticsConstants.secure_scm_parameters
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_authorization
+
+
+class WarehouseTransformsMasterCI{
+    public static def job = { dslFactory, allVars ->
+        dslFactory.job("warehouse-transforms-master-ci"){
+            authorization common_authorization(allVars)
+            logRotator common_log_rotator(allVars)
+            parameters secure_scm_parameters(allVars)
+            parameters {
+                stringParam('WAREHOUSE_TRANSFORMS_URL', allVars.get('WAREHOUSE_TRANSFORMS_URL'), 'URL for the warehouse-transforms repository.')
+                stringParam('WAREHOUSE_TRANSFORMS_BRANCH', allVars.get('WAREHOUSE_TRANSFORMS_BRANCH'), 'Branch of warehouse-transforms repository to use.')
+                stringParam('DBT_TARGET', allVars.get('DBT_TARGET'), 'DBT target from profiles.yml in analytics-secure.')
+                stringParam('DBT_PROFILE', allVars.get('DBT_PROFILE'), 'DBT profile from profiles.yml in analytics-secure.')
+                stringParam('DBT_RUN_OPTIONS', allVars.get('DBT_RUN_OPTIONS'), 'Additional options to dbt run, such as --models for model selection. Details here: https://docs.getdbt.com/docs/model-selection-syntax')
+                stringParam('DBT_RUN_EXCLUDE', allVars.get('DBT_RUN_EXCLUDE'), 'Additional options to dbt run, such as --exclude. Details here: https://docs.getdbt.com/docs/model-selection-syntax')
+                stringParam('DBT_TEST_OPTIONS', allVars.get('DBT_TEST_OPTIONS'), 'Additional options to dbt test, such as --models for model selection. Details here: https://docs.getdbt.com/docs/model-selection-syntax')
+                stringParam('DBT_TEST_EXCLUDE', allVars.get('DBT_TEST_EXCLUDE'), 'Additional options to dbt test, such as --exclude. Details here: https://docs.getdbt.com/docs/model-selection-syntax')
+                stringParam('ANALYTICS_TOOLS_URL', allVars.get('ANALYTICS_TOOLS_URL'), 'URL for the analytics tools repo.')
+                stringParam('ANALYTICS_TOOLS_BRANCH', allVars.get('ANALYTICS_TOOLS_BRANCH'), 'Branch of analytics tools repo to use.')
+                stringParam('JENKINS_JOB_DSL_URL', allVars.get('JENKINS_JOB_DSL_URL'), 'URL for the jenkins-job-dsl repo.')
+                stringParam('JENKINS_JOB_DSL_BRANCH', allVars.get('JENKINS_JOB_DSL_BRANCH'), 'Branch of jenkins-job-dsl repo to use.')
+                stringParam('DB_NAME', allVars.get('DB_NAME'), 'Database name used to create output schema of dbt run/tests')
+                stringParam('NOTIFY', allVars.get('NOTIFY','$PAGER_NOTIFY'), 'Space separated list of emails to send notifications to.')
+            }                    
+            scm {
+                git {
+                    remote {
+                        url('$WAREHOUSE_TRANSFORMS_URL')
+                        branch('$WAREHOUSE_TRANSFORMS_BRANCH')
+                        credentials('1') 
+                    }
+                    extensions {
+                        relativeTargetDirectory('warehouse-transforms')
+                        pruneBranches()
+                        cleanAfterCheckout()
+                    }
+                } 
+
+            }
+            triggers {
+                scm('H/10 * * * *')
+            }            
+
+            wrappers {
+                colorizeOutput('xterm')
+            }
+            wrappers common_wrappers(allVars)
+        }
+
+
+        dslFactory.job("warehouse-transforms-worker-ci"){
+            authorization common_authorization(allVars)
+            logRotator common_log_rotator(allVars)
+            parameters secure_scm_parameters(allVars)
+            parameters {
+                stringParam('WAREHOUSE_TRANSFORMS_URL', allVars.get('WAREHOUSE_TRANSFORMS_URL'), 'URL for the warehouse-transforms repository.')
+                stringParam('WAREHOUSE_TRANSFORMS_BRANCH', allVars.get('WAREHOUSE_TRANSFORMS_BRANCH'), 'Branch of warehouse-transforms repository to use.')                
+                stringParam('DBT_TARGET', allVars.get('DBT_TARGET'), 'DBT target from profiles.yml in analytics-secure.')
+                stringParam('DBT_PROFILE', allVars.get('DBT_PROFILE'), 'DBT profile from profiles.yml in analytics-secure.')
+                stringParam('DBT_RUN_OPTIONS', allVars.get('DBT_RUN_OPTIONS'), 'Additional options to dbt run, such as --models for model selection. Details here: https://docs.getdbt.com/docs/model-selection-syntax')
+                stringParam('DBT_RUN_EXCLUDE', allVars.get('DBT_RUN_EXCLUDE'), 'Additional options to dbt run, such as --exclude. Details here: https://docs.getdbt.com/docs/model-selection-syntax')
+                stringParam('DBT_TEST_OPTIONS', allVars.get('DBT_TEST_OPTIONS'), 'Additional options to dbt test, such as --models for model selection. Details here: https://docs.getdbt.com/docs/model-selection-syntax')
+                stringParam('DBT_TEST_EXCLUDE', allVars.get('DBT_TEST_EXCLUDE'), 'Additional options to dbt test, such as --exclude. Details here: https://docs.getdbt.com/docs/model-selection-syntax')
+                stringParam('ANALYTICS_TOOLS_URL', allVars.get('ANALYTICS_TOOLS_URL'), 'URL for the analytics tools repo.')
+                stringParam('ANALYTICS_TOOLS_BRANCH', allVars.get('ANALYTICS_TOOLS_BRANCH'), 'Branch of analytics tools repo to use.')
+                stringParam('JENKINS_JOB_DSL_URL', allVars.get('JENKINS_JOB_DSL_URL'), 'URL for the jenkins-job-dsl repo.')
+                stringParam('JENKINS_JOB_DSL_BRANCH', allVars.get('JENKINS_JOB_DSL_BRANCH'), 'Branch of jenkins-job-dsl repo to use.')
+                stringParam('DB_NAME', allVars.get('DB_NAME'), 'Database name used to create output schema of dbt run/tests')
+                stringParam('NOTIFY', allVars.get('NOTIFY','$PAGER_NOTIFY'), 'Space separated list of emails to send notifications to.')
+            }
+            environmentVariables {
+                env('KEY_PATH', allVars.get('KEY_PATH'))
+                env('PASSPHRASE_PATH', allVars.get('PASSPHRASE_PATH'))
+                env('USER', allVars.get('USER'))
+                env('ACCOUNT', allVars.get('ACCOUNT'))
+            }                    
+            multiscm secure_scm(allVars) << {
+                git {
+                    remote {
+                        url('$WAREHOUSE_TRANSFORMS_URL')
+                        branch('$WAREHOUSE_TRANSFORMS_BRANCH')
+                        credentials('1') 
+                    }
+                    extensions {
+                        relativeTargetDirectory('warehouse-transforms')
+                        pruneBranches()
+                        cleanAfterCheckout()
+                    }
+                }
+                git {
+                    remote {
+                        url('$ANALYTICS_TOOLS_URL')
+                        branch('$ANALYTICS_TOOLS_BRANCH')
+                        credentials('1')
+                    }
+                    extensions {
+                        relativeTargetDirectory('analytics-tools')
+                        pruneBranches()
+                        cleanAfterCheckout()
+                    }
+                }  
+                git {
+                    remote {
+                        url('$JENKINS_JOB_DSL_URL')
+                        branch('$JENKINS_JOB_DSL_BRANCH')
+                        credentials('1')
+                    }
+                    extensions {
+                        relativeTargetDirectory('jenkins-job-dsl')
+                        pruneBranches()
+                        cleanAfterCheckout()
+                    }
+                }                              
+            }
+            triggers {
+                upstream('warehouse-transforms-master-ci', 'SUCCESS')
+            }            
+            publishers common_publishers(allVars)
+            wrappers {
+                colorizeOutput('xterm')
+            }
+            wrappers common_wrappers(allVars)
+            steps {
+                virtualenv {
+                    pythonName('PYTHON_3.7')
+                    nature("shell")
+                    systemSitePackages(false)
+                    command(
+                        dslFactory.readFileFromWorkspace("dataeng/resources/warehouse-transforms-master-ci.sh")
+                    )
+                }
+            }
+        }
+    }
+}

--- a/dataeng/jobs/createJobsNew.groovy
+++ b/dataeng/jobs/createJobsNew.groovy
@@ -11,6 +11,7 @@ import static analytics.UpdateUsers.job as UpdateUsersJob
 import static analytics.SnowflakeSchemaBuilder.job as SnowflakeSchemaBuilderJob
 import static analytics.WarehouseTransforms.job as WarehouseTransformsJob
 import static analytics.WarehouseTransformsCI.job as WarehouseTransformsCIJob
+import static analytics.WarehouseTransformsMasterCI.job as WarehouseTransformsMasterCIJob
 import static org.edx.jenkins.dsl.JenkinsPublicConstants.DEFAULT_VIEW
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.error.YAMLException
@@ -46,6 +47,7 @@ def taskMap = [
     SNOWFLAKE_SCHEMA_BUILDER_JOB: SnowflakeSchemaBuilderJob,
     WAREHOUSE_TRANSFORMS_JOB: WarehouseTransformsJob,
     WAREHOUSE_TRANSFORMS_CI_JOB: WarehouseTransformsCIJob,
+    WAREHOUSE_TRANSFORMS_MASTER_CI_JOB: WarehouseTransformsMasterCIJob,
 ]
 
 for (task in taskMap) {

--- a/dataeng/resources/warehouse-transforms-master-ci.sh
+++ b/dataeng/resources/warehouse-transforms-master-ci.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -ex
+
+# Setup to run python script to create snowflake schema
+cd $WORKSPACE/analytics-tools/snowflake
+make requirements
+
+# Setup to run dbt commands
+cd $WORKSPACE/warehouse-transforms
+
+COMMIT_ID=$(git rev-parse --short HEAD)
+# Only run CI on merge commits, otherwise exit
+HEAD_COMMIT=$(git rev-parse HEAD)
+LAST_MERGE_COMMIT=$(git log --merges origin/master --format='%H' --max-count=1)
+if [ $HEAD_COMMIT == $LAST_MERGE_COMMIT ]
+then
+    echo "This is one of merge commit, Run CI"
+else
+    echo "Exiting because not a merge commit"
+    exit 0
+fi 
+
+
+# Get second last merge commit id and compares it with the HEAD to find (git diff) files changed.
+PREV_MERGE_COMMIT_ID=$(git log --merges origin/master --format='%H' --max-count=2 | sed -n 2p)
+
+git diff $PREV_MERGE_COMMIT_ID --name-only
+
+# Finding the project names which has changed between since previous merge commit. Using git diff to compare.
+# It returns all the files name with full path. Searching through it using egrep to find which project(s) these changing files belong.
+if git diff $PREV_MERGE_COMMIT_ID --name-only | egrep "projects/reporting" -q; then isReporting="true"; else isReporting="false"; fi
+if git diff $PREV_MERGE_COMMIT_ID --name-only | egrep "projects/automated/applications" -q; then isApplications="true"; else isApplications="false"; fi
+if git diff $PREV_MERGE_COMMIT_ID --name-only | egrep "projects/automated/raw_to_source" -q; then isRawToSource="true"; else isRawToSource="false"; fi
+if git diff $PREV_MERGE_COMMIT_ID --name-only | egrep "projects/automated/telemetry" -q; then isTelemetry="true"; else isTelemetry="false"; fi
+
+
+# Setup to run dbt commands
+cd $WORKSPACE/warehouse-transforms
+
+# To install right version of dbt
+pip install -r requirements.txt
+
+if [ "$isReporting" == "true" ]
+then
+
+    cd $WORKSPACE/analytics-tools/snowflake
+
+    # Schema_Name will be the Github Commit ID e.g. 1724 prefixed with 'merged' and sufixed with project name e.g. 1724_reporting
+    export CI_SCHEMA_NAME=merged_${COMMIT_ID}_reporting
+    # Schema is dynamically created against each run.
+    # profiles.yml contains the name of Schema which is used to create output models when dbt runs. 
+    python create_ci_schema.py --key_path $KEY_PATH --passphrase_path $PASSPHRASE_PATH --automation_user $USER --account $ACCOUNT --db_name $DB_NAME --schema_name $CI_SCHEMA_NAME 
+
+    DBT_PROJECT_PATH='reporting'
+    # Full dbt run on merges to master CI (Might decide to run Slim CI in future)
+    DBT_RUN_OPTIONS='' 
+    DBT_RUN_EXCLUDE='' ## Add excluded models here if any
+    # Full dbt test on merges to master CI (Might decide to run Slim CI in future)
+    DBT_TEST_OPTIONS=''
+    DBT_TEST_EXCLUDE='' 
+
+    source $WORKSPACE/jenkins-job-dsl/dataeng/resources/warehouse-transforms-ci-dbt.sh
+
+    cd $WORKSPACE/analytics-tools/snowflake
+    python remove_ci_schema.py --key_path $KEY_PATH --passphrase_path $PASSPHRASE_PATH --automation_user $USER --account $ACCOUNT --db_name $DB_NAME --schema_name $CI_SCHEMA_NAME 
+
+fi
+
+
+if [ "$isApplications" == "true" ]
+then
+
+    cd $WORKSPACE/analytics-tools/snowflake
+    export CI_SCHEMA_NAME=merged_${COMMIT_ID}_applications
+    python create_ci_schema.py --key_path $KEY_PATH --passphrase_path $PASSPHRASE_PATH --automation_user $USER --account $ACCOUNT --db_name $DB_NAME --schema_name $CI_SCHEMA_NAME
+
+    DBT_PROJECT_PATH='automated/applications'
+    DBT_RUN_OPTIONS=''
+    DBT_RUN_EXCLUDE=''
+    DBT_TEST_OPTIONS=''
+    DBT_TEST_EXCLUDE=''
+
+    source $WORKSPACE/jenkins-job-dsl/dataeng/resources/warehouse-transforms-ci-dbt.sh
+
+    cd $WORKSPACE/analytics-tools/snowflake
+    python remove_ci_schema.py --key_path $KEY_PATH --passphrase_path $PASSPHRASE_PATH --automation_user $USER --account $ACCOUNT --db_name $DB_NAME --schema_name $CI_SCHEMA_NAME
+
+
+fi
+
+if [ "$isRawToSource" == "true" ]
+then
+
+
+    cd $WORKSPACE/analytics-tools/snowflake
+    export CI_SCHEMA_NAME=merged_${COMMIT_ID}_raw_to_source
+    python create_ci_schema.py --key_path $KEY_PATH --passphrase_path $PASSPHRASE_PATH --automation_user $USER --account $ACCOUNT --db_name $DB_NAME --schema_name $CI_SCHEMA_NAME
+
+    DBT_PROJECT_PATH='automated/raw_to_source'
+    DBT_RUN_OPTIONS=''
+    DBT_RUN_EXCLUDE=''
+    DBT_TEST_OPTIONS=''
+    DBT_TEST_EXCLUDE=''
+
+    source $WORKSPACE/jenkins-job-dsl/dataeng/resources/warehouse-transforms-ci-dbt.sh
+
+    cd $WORKSPACE/analytics-tools/snowflake
+    python remove_ci_schema.py --key_path $KEY_PATH --passphrase_path $PASSPHRASE_PATH --automation_user $USER --account $ACCOUNT --db_name $DB_NAME --schema_name $CI_SCHEMA_NAME
+
+
+fi
+
+
+if [ "$isTelemetry" == "true" ]
+then
+    cd $WORKSPACE/analytics-tools/snowflake
+    export CI_SCHEMA_NAME=merged_${COMMIT_ID}_telemetry
+    python create_ci_schema.py --key_path $KEY_PATH --passphrase_path $PASSPHRASE_PATH --automation_user $USER --account $ACCOUNT --db_name $DB_NAME --schema_name $CI_SCHEMA_NAME
+
+    DBT_PROJECT_PATH='automated/telemetry'
+    DBT_RUN_OPTIONS=''
+    DBT_RUN_EXCLUDE=''
+    DBT_TEST_OPTIONS=''
+    DBT_TEST_EXCLUDE=''
+
+    source $WORKSPACE/jenkins-job-dsl/dataeng/resources/warehouse-transforms-ci-dbt.sh
+
+    cd $WORKSPACE/analytics-tools/snowflake
+    python remove_ci_schema.py --key_path $KEY_PATH --passphrase_path $PASSPHRASE_PATH --automation_user $USER --account $ACCOUNT --db_name $DB_NAME --schema_name $CI_SCHEMA_NAME
+
+
+fi


### PR DESCRIPTION
DENG-774
I have created two jobs
1- First job keeps polling after 10m interval warehouse-transform for any new merges to master.
2- Second job which is the actual worker job to run dbt CI, it is a down stream of first polling job
Why we need additional polling job? because the actual dbt CI job has multiple repositories to clone to get required files for snowflake python scripts, secrets and dsl so their master merges won't caught as changes we needed separate polling job