### PR TITLE
slack publisher to notify build failures

### DIFF
--- a/dataeng/jobs/analytics/WarehouseTransformsMasterCI.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransformsMasterCI.groovy
@@ -6,6 +6,7 @@ import static org.edx.jenkins.dsl.AnalyticsConstants.common_publishers
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_triggers
 import static org.edx.jenkins.dsl.AnalyticsConstants.secure_scm_parameters
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_authorization
+import static org.edx.jenkins.dsl.AnalyticsConstants.slack_publisher
 
 
 class WarehouseTransformsMasterCI{
@@ -75,6 +76,8 @@ class WarehouseTransformsMasterCI{
                 stringParam('JENKINS_JOB_DSL_BRANCH', allVars.get('JENKINS_JOB_DSL_BRANCH'), 'Branch of jenkins-job-dsl repo to use.')
                 stringParam('DB_NAME', allVars.get('DB_NAME'), 'Database name used to create output schema of dbt run/tests')
                 stringParam('NOTIFY', allVars.get('NOTIFY'), 'Space separated list of emails to send notifications to.')
+                stringParam('SLACK_NOTIFICATION_CHANNEL', allVars.get('SLACK_NOTIFICATION_CHANNEL'), 'Space separated list of slack channel name to send build failure notifications')
+                stringParam('FAILURE_MESSAGE', allVars.get('FAILURE_MESSAGE'), 'Custom message for to send along with buid failure notification')
             }
             environmentVariables {
                 env('KEY_PATH', allVars.get('KEY_PATH'))
@@ -126,6 +129,7 @@ class WarehouseTransformsMasterCI{
                 upstream('warehouse-transforms-master-ci', 'SUCCESS')
             }
             publishers common_publishers(allVars)
+            publishers slack_publisher(allVars)
             wrappers {
                 colorizeOutput('xterm')
             }

--- a/src/main/groovy/org/edx/jenkins/dsl/AnalyticsConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/AnalyticsConstants.groovy
@@ -216,5 +216,25 @@ This text may reference other parameters in the task as shell variables, e.g.  $
             }
         }
     }
+    public static def slack_publisher = {
+        return {
+            slackNotifier {
+                room('$SLACK_NOTIFICATION_CHANNEL')
+                botUser (true)
+                startNotification (false) // A build has started, we do not want such notifications
+                notifySuccess (false) // A build was successfull, , we do not want such notifications
+                notifyAborted (true)
+                notifyNotBuilt (false)
+                notifyUnstable (true)
+                notifyFailure(true)
+                notifyBackToNormal (true)
+                notifyRepeatedFailure (true) // Notify on repeating failures
+                matrixTriggerMode('ONLY_CONFIGURATIONS')
+                commitInfoChoice('AUTHORS_AND_TITLES')
+                customMessageFailure('$FAILURE_MESSAGE')
+            }
+
+        }
+    }
 }
 


### PR DESCRIPTION
We also want to notify data-support if Merges to Master CI job has failed, if this job fails it will likely break warehouse-transforms Prod jobs so this job works as canary test to identify the job failure ahead.