### PR TITLE
fix: Change ImportCountryWorkflow to use the correct task 

### DIFF
--- a/dataeng/resources/user-location-by-course.sh
+++ b/dataeng/resources/user-location-by-course.sh
@@ -9,7 +9,7 @@ fi
 env
 
 ${WORKSPACE}/analytics-configuration/automation/run-automated-task.sh \
-  ImportCountryWorkflow --local-scheduler \
+  InsertToMysqlLastCountryPerCourseTask --local-scheduler \
   --interval-end $END_DATE \
   --n-reduce-tasks $NUM_REDUCE_TASKS \
   --overwrite \


### PR DESCRIPTION
The old one was deleted in Vertica deprecation. Should now be InsertToMysqlLastCountryPerCourseTask