### PR TITLE
build: Updated the upgradePythonRequirements job

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -319,17 +319,6 @@ List jobConfigs = [
     ],
     [
         org: 'edx',
-        repoName: 'edx-platform',
-        defaultBranch: "master",
-        pythonVersion: '3.8',
-        cronValue: cronOffHoursBusinessDailyLahore,
-        githubUserReviewers: [],
-        githubTeamReviewers: ['arbi-bom'],
-        emails: ['arbi-bom@edx.org'],
-        alwaysNotify: false
-    ],
-    [
-        org: 'edx',
         repoName: 'edx-proctoring',
         defaultBranch: 'master',
         pythonVersion: '3.8',
@@ -344,17 +333,6 @@ List jobConfigs = [
         repoName: 'edx-rbac',
         defaultBranch: 'master',
         pythonVersion: '3.8',
-        cronValue: cronOffHoursBusinessWeekdayLahore,
-        githubUserReviewers: [],
-        githubTeamReviewers: ['arbi-bom'],
-        emails: ['arbi-bom@edx.org'],
-        alwaysNotify: false
-    ],
-    [
-        org: 'edx',
-        repoName: 'edx-repo-health',
-        defaultBranch: 'master',
-        pythonVersion: '3.6',
         cronValue: cronOffHoursBusinessWeekdayLahore,
         githubUserReviewers: [],
         githubTeamReviewers: ['arbi-bom'],
@@ -444,7 +422,7 @@ List jobConfigs = [
         defaultBranch: 'master',
         pythonVersion: '3.8',
         cronValue: cronOffHoursBusinessWeekdayLahore,
-        githubUserReviewers: ['cpennington'],
+        githubUserReviewers: [],
         githubTeamReviewers: ['arbi-bom'],
         emails: ['arbi-bom@edx.org'],
         alwaysNotify: false
@@ -470,17 +448,6 @@ List jobConfigs = [
         githubTeamReviewers: [],  // Reviewer mention unnecessary due to Master's OpsGenie alert.
         emails: ['masters-requirements-update@edx.opsgenie.net'],
         alwaysNotify: true
-    ],
-    [
-        org: 'edx',
-        repoName: 'pytest-repo-health',
-        defaultBranch: 'master',
-        pythonVersion: '3.6',
-        cronValue: cronOffHoursBusinessWeekdayLahore,
-        githubUserReviewers: [],
-        githubTeamReviewers: ['arbi-bom'],
-        emails: ['arbi-bom@edx.org'],
-        alwaysNotify: false
     ],
     [
         org: 'edx',
@@ -554,7 +521,7 @@ List jobConfigs = [
         defaultBranch: 'master',
         pythonVersion: '3.8',
         cronValue: cronOffHoursBusinessWeekdayLahore,
-        githubUserReviewers: ['cpennington'],
+        githubUserReviewers: [],
         githubTeamReviewers: ['arbi-bom'],
         emails: ['arbi-bom@edx.org'],
         alwaysNotify: false


### PR DESCRIPTION
## Description

- Removed cpennington as reviewer from Xblock & opaque-keys jobs as he isn't in the organization any more which causes the PR tagging to fail in the [upgrade builds](https://build.testeng.edx.org/job/XBlock-upgrade-python-requirements/changes).
- Removed edx-repo-health & pytest-repo-health requirements jobs because they have been switched to Github Actions and the [Jenkins upgrade builds](https://build.testeng.edx.org/job/edx-repo-health-upgrade-python-requirements/changes) fail due to `Python3.6` interpreter error after Jenkins has been updated to `Python3.8`.
- Removed edx-platform Jenkins job.