### PR TITLE
feat: Turn off Who-Tests-What check until we're ready to work on it again

### DIFF
--- a/platform/jobs/pipelines/edxPlatformPipelineMasterWTWNightly.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelineMasterWTWNightly.groovy
@@ -33,9 +33,13 @@ jobConfigs.each { jobConfig ->
                 PYTHON_VERSION: "${jobConfig.pythonVersion}"
             )
 
-            triggers {
-                cron('@daily')
-            }
+            // Turn off job until we're ready to work on it again; at
+            // that time make sure that it's not a blocking check for
+            // deploys if this gets reenabled. (Needs to be excluded
+            // from check_pr_tests_status.py call.)
+            // triggers {
+            //     cron('@daily')
+            // }
 
             cpsScm {
                 scm {


### PR DESCRIPTION
This check has been running on a daily basis, but the deployment pipeline has been waiting for it to finish (in `check_pr_tests_status.py`) meaning that it sometimes blocks deployment in the mornings as the check is still in the "pending" state.

We should either delete this check or exclude it from the status checks, but for now I'm just disabling the daily run on master so that we can defer that decision.

(I would have used `disabled()` but I don't know if it apples to `pipelineJob`.)

**Note:** Who-Tests-What (WTW) is a project to collect coverage information from tests so that we know which parts of the codebase are covered by which tests. This may be owned by @nedbat.