### PR TITLE
REV-2184: add frontend-app-learning for sandboxes

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -225,6 +225,9 @@ class CreateSandbox {
                 booleanParam("payment",false,"Enable Payment MFE")
                 stringParam("payment_version","master","The repository version of the frontend-app-payment")
 
+                booleanParam("learning",false,"Enable Learning MFE")
+                stringParam("learning_version","master","The branch of the frontend-app-learning repository")
+
                 choiceParam("server_type",
                             [
                             "full_edx_installation_from_scratch",


### PR DESCRIPTION
For REV-2184: adding frontend-app-learning for sandboxes, following Step 2 from here:
https://openedx.atlassian.net/wiki/spaces/FEDX/pages/2124677169/How+To+Add+an+MFE+to+a+Sandbox