### PR TITLE
fix: remove stale branches during python tests and quality checking

### DIFF
--- a/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
+++ b/platform/jobs/pipelines/edxPlatformPipelinePr.groovy
@@ -302,6 +302,8 @@ jobConfigs.each { jobConfig ->
                     git {
                         extensions {
                             cleanBeforeCheckout()
+                            pruneBranches()
+                            pruneStaleBranch()
                             cloneOptions {
                                 honorRefspec(true)
                                 noTags(true)


### PR DESCRIPTION
We already do this for accessibility and javascript test
runs.

Based on https://github.com/edx/jenkins-job-dsl/pull/1308