### PR TITLE
fix: Upgrade Python version used to upgrade staff_graded-xblock reqs

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -475,7 +475,7 @@ List jobConfigs = [
         org: 'edx',
         repoName: 'staff_graded-xblock',
         defaultBranch: 'master',
-        pythonVersion: '3.5',
+        pythonVersion: '3.8',
         cronValue: cronOffHoursBusinessWeekdayTwiceMonthlyOdd,
         githubUserReviewers: [],
         githubTeamReviewers: [],


### PR DESCRIPTION
To Python 3.8.

Will fix this alert: 
https://edx.app.opsgenie.com/alert/detail/5981efdd-0fdb-481f-b919-3395d4eea277-1620077235102/details

Python 3.5 support for this XBlock was dropped in this earlier PR:
https://github.com/edx/staff_graded-xblock/pull/47
