### PR TITLE
fix: enable user-retirement jobs

### DIFF
--- a/platform/jobs/RetirementJobEdxTriggers.groovy
+++ b/platform/jobs/RetirementJobEdxTriggers.groovy
@@ -16,7 +16,7 @@ List jobConfigs = [
         environmentDeployment: 'prod-edx',
         extraMembersCanBuild: [],
         cron: 'H * * * *',  // Hourly at an arbitrary, but consistent minute.
-        disabled: true
+        disabled: false
     ],
     [
         downstreamJobName: 'user-retirement-collector',
@@ -24,7 +24,7 @@ List jobConfigs = [
         environmentDeployment: 'prod-edge',
         extraMembersCanBuild: [],
         cron: 'H * * * *',  // Hourly at an arbitrary, but consistent minute.
-        disabled: true
+        disabled: false
     ],
     [
         downstreamJobName: 'retirement-partner-reporter',


### PR DESCRIPTION
Segment has fixed an issue with their deletions API that
was causing timeouts for our user-retirement pipelines.