### PR TITLE
feat: load lms groups, cms groups, and users from separate files

### DIFF
--- a/devops/jobs/AppPermissionsRunner.groovy
+++ b/devops/jobs/AppPermissionsRunner.groovy
@@ -17,7 +17,7 @@ class AppPermissionsRunner {
     public static def job = { dslFactory, extraVars ->
         assert extraVars.containsKey('DEPLOYMENTS') : "Please define DEPLOYMENTS. It should be a list of strings."
         assert !(extraVars.get('DEPLOYMENTS') instanceof String) : "Make sure DEPLOYMENTS is a list and not a string"
-        List jobTypes = ['groups', 'active-users', 'inactive-users']
+        List jobTypes = ['groups-lms', 'groups-cms', 'active-users', 'inactive-users']
         extraVars.get('DEPLOYMENTS').each { deployment, configuration ->
             configuration.environments.each { environment ->
                 jobTypes.each { jobType ->


### PR DESCRIPTION
Along with the restructuring of edx/app-permissions and
the additions to manage_edxapp_users_and_groups.yml in
edx/configuration, this commit cuts us over to the new
app-permissions system in which LMS and CMS groups are
managed separately and per-service, whereas users are
still managed per-environment.

https://openedx.atlassian.net/browse/TNL-8274

Prerequisites:
* https://github.com/edx/configuration/pull/6410
* https://github.com/edx/app-permissions/pull/1442