### PR TITLE
fix: move pipeline acceptance job to old de jenkins

### DIFF
--- a/dataeng/jobs/analytics/PipelineAcceptanceTestManual.groovy
+++ b/dataeng/jobs/analytics/PipelineAcceptanceTestManual.groovy
@@ -61,14 +61,7 @@ class PipelineAcceptanceTestManual {
             wrappers common_wrappers(allVars)
 
             steps {
-                virtualenv {
-                    pythonName('PYTHON_2.7')
-                    nature("shell")
-                    systemSitePackages(false)
-                    command(
-                        dslFactory.readFileFromWorkspace("dataeng/resources/pipeline-acceptance-test-manual.sh")
-                    )
-                }
+                shell(dslFactory.readFileFromWorkspace("dataeng/resources/pipeline-acceptance-test-manual.sh"))
             }
 
             publishers {

--- a/dataeng/jobs/createJobs.groovy
+++ b/dataeng/jobs/createJobs.groovy
@@ -10,6 +10,7 @@ import static analytics.EventExportIncremental.job as EventExportIncrementalJob
 import static analytics.EventExportIncrementalLarge.job as EventExportIncrementalLargeJob
 import static analytics.JenkinsBackup.job as JenkinsBackupJob
 import static analytics.ModuleEngagement.job as ModuleEngagementJob
+import static analytics.PipelineAcceptanceTestManual.job as PipelineAcceptanceTestManualJob
 import static analytics.ReadReplicaExportToS3.job as ReadReplicaExportToS3Job
 import static analytics.SnowflakeDemographicsCleanup.job as SnowflakeDemographicsCleanupJob
 import static analytics.SnowflakeMicrobachelorsITK.job as SnowflakeMicrobachelorsITKJob
@@ -54,6 +55,7 @@ def taskMap = [
     EVENT_EXPORT_INCREMENTAL_LARGE_JOB: EventExportIncrementalLargeJob,
     JENKINS_BACKUP_JOB: JenkinsBackupJob,
     MODULE_ENGAGEMENT_JOB: ModuleEngagementJob,
+    PIPELINE_ACCEPTANCE_TEST_MANUAL_JOB: PipelineAcceptanceTestManualJob,
     READ_REPLICA_EXPORT_TO_S3_JOB: ReadReplicaExportToS3Job,
     SNOWFLAKE_DEMOGRAPHICS_CLEANUP_JOB: SnowflakeDemographicsCleanupJob,
     SNOWFLAKE_MICROBACHELORS_ITK_JOB: SnowflakeMicrobachelorsITKJob,

--- a/dataeng/jobs/createJobsNew.groovy
+++ b/dataeng/jobs/createJobsNew.groovy
@@ -4,7 +4,6 @@ import static analytics.DBTSourceFreshness.job as DBTSourceFreshnessJob
 import static analytics.DeployCluster.job as DeployClusterJob
 import static analytics.EmrCostReporter.job as EmrCostReporterJob
 import static analytics.ModelTransfers.job as ModelTransfersJob
-import static analytics.PipelineAcceptanceTestManual.job as PipelineAcceptanceTestManualJob
 import static analytics.SnowflakeCollectMetrics.job as SnowflakeCollectMetricsJob
 import static analytics.SnowflakeExpirePasswords.job as SnowflakeExpirePasswordsJob
 import static analytics.SnowflakeSchemaBuilder.job as SnowflakeSchemaBuilderJob
@@ -42,7 +41,6 @@ def taskMap = [
     DEPLOY_CLUSTER_JOB: DeployClusterJob,
     EMR_COST_REPORTER_JOB: EmrCostReporterJob,
     MODEL_TRANSFERS_JOB: ModelTransfersJob,
-    PIPELINE_ACCEPTANCE_TEST_MANUAL_JOB: PipelineAcceptanceTestManualJob,
     SNOWFLAKE_COLLECT_METRICS_JOB: SnowflakeCollectMetricsJob,
     SNOWFLAKE_EXPIRE_PASSWORDS_JOB: SnowflakeExpirePasswordsJob,
     SNOWFLAKE_SCHEMA_BUILDER_JOB: SnowflakeSchemaBuilderJob,

--- a/dataeng/resources/pipeline-acceptance-test-manual.sh
+++ b/dataeng/resources/pipeline-acceptance-test-manual.sh
@@ -39,8 +39,8 @@ env | sort
 
 mkdir -p $VENV_ROOT
 
-[ -f $TASKS_BIN/activate ] || virtualenv -p python2.7 $VENV_ROOT/analytics-tasks
-virtualenv -p python2.7 $VENV_ROOT/analytics-exporter
+[ -f $TASKS_BIN/activate ] || virtualenv -p /usr/bin/python2.7 $VENV_ROOT/analytics-tasks
+virtualenv -p /usr/bin/python2.7 $VENV_ROOT/analytics-exporter
 # The virtualenv on this version of Jenkins shiningpanda is old, so manually update both pip and setuptools before loading exporter.
 $EXPORTER_BIN/$PIP_INSTALL -U 'pip==20.3.4'
 $EXPORTER_BIN/$PIP_INSTALL -U 'setuptools<45'


### PR DESCRIPTION
For some reason, when I tried to get this job working on the new jenkins, it was able to create a virtualenv using the `python2.7` alias, but it is running into the following issue on the older box: 
```
/var/lib/jenkins/workspace/edx-analytics-pipeline-acceptance-test-manual/build/venvs/analytics-exporter/bin/python2.7: Too many levels of symbolic links
```
I fixed this by referring to the python2.7 binary instead of an alias.