### PR TITLE
refactor: remove staff_graded-xblock from upgrade jobs

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -289,17 +289,6 @@ List jobConfigs = [
     ],
     [
         org: 'edx',
-        repoName: 'staff_graded-xblock',
-        defaultBranch: 'master',
-        pythonVersion: '3.8',
-        cronValue: cronOffHoursBusinessWeekdayTwiceMonthlyOdd,
-        githubUserReviewers: [],
-        githubTeamReviewers: [],
-        emails: ['teaching-and-learning@edx.opsgenie.net'],
-        alwaysNotify: true
-    ],
-    [
-        org: 'edx',
         repoName: 'super-csv',
         defaultBranch: 'master',
         pythonVersion: '3.8',


### PR DESCRIPTION
It is now handled by GitHub actions:
https://github.com/edx/staff_graded-xblock/blob/master/.github/workflows/upgrade-python-requirements.yml