### PR TITLE
fix: update AppPermissionsWatcher with new job types

### DIFF
--- a/devops/jobs/AppPermissionsWatcher.groovy
+++ b/devops/jobs/AppPermissionsWatcher.groovy
@@ -81,7 +81,7 @@ class AppPermissionsWatcher{
 
             triggers merge_to_master_trigger(repo_branch)
 
-            List jobTypes = ['groups', 'active-users', 'inactive-users']
+            List jobTypes = ['groups-lms', 'groups-cms', 'active-users', 'inactive-users']
             steps{
                 extraVars.get('DEPLOYMENTS').each { deployment, configuration ->
                     configuration.environments.each { environment ->


### PR DESCRIPTION
In AppPermissionsRunner, the 'groups' job type was split into
'groups-lms' and 'groups-cms'. This commit fixes
AppPermissionsWatcher (which triggers the AppPermissionRunner
jobs) to use the new job types as well.

Part of https://openedx.atlassian.net/browse/TNL-8274

Fixes bug introduced in https://github.com/edx/jenkins-job-dsl/pull/1376