### PR TITLE
fix: env interpolation in run-app-permissions.sh

### DIFF
--- a/devops/resources/run-app-permissions.sh
+++ b/devops/resources/run-app-permissions.sh
@@ -31,7 +31,7 @@ fi
 INVENTORY=$(./active_instances_in_asg.py --asg ${ENVIRONMENT}-${DEPLOYMENT}-worker)
 if [[ -n ${INVENTORY} ]]; then
     ansible-playbook -i ${INVENTORY} manage_edxapp_users_and_groups.yml \
-                     -e@${configfile} -e 'group_environment=${ENVIRONMENT}-${DEPLOYMENT}' \
+                     -e@${configfile} -e "group_environment=${ENVIRONMENT}-${DEPLOYMENT}" \
                      --user ${USER} --tags manage-${JOB_TYPE}
 else
     echo "Skipping ${ENVIRONMENT} ${DEPLOYMENT}, no worker cluster available, get it next time"


### PR DESCRIPTION
With single quotes, '${ENVIRONMENT}-${DEPLOYMENT}'
is passed in as a literal string. Use double quotes
so that it is interpolated to, eg, 'prod-edx'.

Part of https://openedx.atlassian.net/browse/TNL-8274

Fixes another bug introduced in #1376