### PR TITLE
feat: mark event-export-incremental build as unstable if a gpg key is…

### DIFF
--- a/dataeng/jobs/analytics/EventExportIncremental.groovy
+++ b/dataeng/jobs/analytics/EventExportIncremental.groovy
@@ -34,6 +34,8 @@ class EventExportIncremental {
                     postBuildTask {
                         task('org with Errors=', 'exit 1', true)
                     }
+                    // Mark the build as unstable if a GPG key is near expiry.
+                    textFinder("is near expiry", '', true, false, true)
                 }
                 publishers common_publishers(allVars)
                 steps {


### PR DESCRIPTION
… near expiry.
A separate opsgenie alert will be sent out if this job becomes unstable due to key expiration.