### PR TITLE
fix: update vem req job python version

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -313,7 +313,7 @@ List jobConfigs = [
         org: 'edx',
         repoName: 'video-encode-manager',
         defaultBranch: 'master',
-        pythonVersion: '3.6',
+        pythonVersion: '3.8',
         cronValue: cronOffHoursBusinessWeekday,
         githubUserReviewers: [],
         githubTeamReviewers: ['incident-management'],


### PR DESCRIPTION
### [PROD-2361](https://openedx.atlassian.net/browse/PROD-2361)

### Description
update VEM requirements job to use python 3.8. Py36 is failing with an interpreter not found error on Jenkins.