### PR TITLE
fix: add a sleep to emr-cost-reporter to get around race condition in…

### DIFF
--- a/dataeng/resources/emr-cost-reporter.sh
+++ b/dataeng/resources/emr-cost-reporter.sh
@@ -2,6 +2,7 @@
 set -ex
 
 rm -rf /tmp/ecc-venv
+sleep 10
 mkdir /tmp/ecc-venv
 virtualenv /tmp/ecc-venv
 . /tmp/ecc-venv/bin/activate


### PR DESCRIPTION
… setup.

I don't understand why, but this job has been failing to create a directory immediately after removing it from the file system. It is my understanding that a program such as `rm` should not return an exit code (and therefore continue onto the next command) until it has completed, but here we are. Since we are not planning on investing in the EMR infrastructure, adding a sleep should get us up and running again.