### PR TITLE
fix: increase sleep in emr-cost-reporter setup

### DIFF
--- a/dataeng/resources/emr-cost-reporter.sh
+++ b/dataeng/resources/emr-cost-reporter.sh
@@ -2,7 +2,7 @@
 set -ex
 
 rm -rf /tmp/ecc-venv
-sleep 10
+sleep 100
 mkdir /tmp/ecc-venv
 virtualenv /tmp/ecc-venv
 . /tmp/ecc-venv/bin/activate


### PR DESCRIPTION
I hate this solution, but I don't have the time to dig into it. The original issue is spelled out here: https://github.com/edx/jenkins-job-dsl/pull/1392. If this doesn't fix it, then I will circle back around to do something like creating a unique string in the virtualenv name.