### PR TITLE
fix: change emr-cost-reporter virtualenv setup

### DIFF
--- a/dataeng/resources/emr-cost-reporter.sh
+++ b/dataeng/resources/emr-cost-reporter.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -ex
 
-rm -rf /tmp/ecc-venv
-sleep 100
-mkdir /tmp/ecc-venv
-virtualenv /tmp/ecc-venv
-. /tmp/ecc-venv/bin/activate
+VENV_DIR="emr-cost-reporter-venvs"
+mkdir -p $VENV_DIR
+
+rm -rf $VENV_DIR/*
+VENV="$VENV_DIR/venv_$BUILD_ID"
+virtualenv $VENV
+. $VENV/bin/activate
 
 cd emr-cost-calculator
 pip install -r requirements.txt


### PR DESCRIPTION
for some reason, the setup script for the emr-cost-reporter has been
failing to create a directory. I'm not sure why, so I am attempting to
change where it is built (WORKSPACE on the mount instead of /tmp on the
root volume) and by giving each virtualenv a unique name by appending
the build id.