### PR TITLE
feat: Add a FULL_REFRESH_INCREMENTALS toggle to warehouse-transforms jobs

### DIFF
--- a/dataeng/jobs/analytics/WarehouseTransforms.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransforms.groovy
@@ -27,6 +27,7 @@ class WarehouseTransforms{
                     stringParam('TEST_SOURCES_FIRST', env_config.get('TEST_SOURCES_FIRST', 'true'), 'Set to \'true\' to perform source testing first (if SKIP_TESTS is false). All other values test sources post-run.')
                     stringParam('PUSH_ARTIFACTS_TO_SNOWFLAKE', env_config.get('PUSH_ARTIFACTS_TO_SNOWFLAKE', 'false'), 'Set to \'true\' to push the run results file to Snowflake for telemetry. Avoid this on frequently-running jobs.')
                     stringParam('NOTIFY', env_config.get('NOTIFY', allVars.get('NOTIFY','$PAGER_NOTIFY')), 'Space separated list of emails to send notifications to.')
+                    booleanParam('FULL_REFRESH_INCREMENTALS', false, '[DANGEROUS] Supply the --full-refresh flag to the `dbt run` command. Use when you need to re-compute an incremental table from scratch.  Applies to ALL incrementals in this run.')
                 }
                 multiscm secure_scm(allVars) << {
                     git {

--- a/dataeng/resources/warehouse-transforms.sh
+++ b/dataeng/resources/warehouse-transforms.sh
@@ -47,8 +47,14 @@ then
     postCommandChecks "source_test" $ret ;
 fi
 
+FULL_REFRESH_ARG=""
+if [ "$FULL_REFRESH_INCREMENTALS" = 'true' ]
+then
+    FULL_REFRESH_ARG="--full-refresh"
+fi
+
 # Compile/build all models with this tag.
-dbt run --models tag:$MODEL_TAG $exclude_param --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ ; ret=$?;
+dbt run $FULL_REFRESH_ARG --models tag:$MODEL_TAG $exclude_param --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ ; ret=$?;
 postCommandChecks "run" $ret ;
 
 


### PR DESCRIPTION
This enables us to easily fully-refresh incrementals, without having to
perform multiple operations locally.

DESUPPORT-959