### PR TITLE
feat: full refresh checkbox also uses larger warehouse

### DIFF
--- a/dataeng/jobs/analytics/WarehouseTransforms.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransforms.groovy
@@ -27,7 +27,7 @@ class WarehouseTransforms{
                     stringParam('TEST_SOURCES_FIRST', env_config.get('TEST_SOURCES_FIRST', 'true'), 'Set to \'true\' to perform source testing first (if SKIP_TESTS is false). All other values test sources post-run.')
                     stringParam('PUSH_ARTIFACTS_TO_SNOWFLAKE', env_config.get('PUSH_ARTIFACTS_TO_SNOWFLAKE', 'false'), 'Set to \'true\' to push the run results file to Snowflake for telemetry. Avoid this on frequently-running jobs.')
                     stringParam('NOTIFY', env_config.get('NOTIFY', allVars.get('NOTIFY','$PAGER_NOTIFY')), 'Space separated list of emails to send notifications to.')
-                    booleanParam('FULL_REFRESH_INCREMENTALS', false, '[DANGEROUS] Supply the --full-refresh flag to the `dbt run` command. Use when you need to re-compute an incremental table from scratch.  Applies to ALL incrementals in this run.')
+                    booleanParam('FULL_REFRESH_INCREMENTALS', false, '[DANGEROUS] Supply the --full-refresh flag to the `dbt run` command, and use a larger warehouse. Use when you need to re-compute an incremental table from scratch.  Applies to ALL incrementals in this run.')
                 }
                 multiscm secure_scm(allVars) << {
                     git {


### PR DESCRIPTION
Typically, full refreshes should use a large warehouse, so this commit
will codify that.

DESUPPORT-959