### PR TITLE
fix: provision sandboxes with frontend-app-learning by default

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -221,7 +221,7 @@ class CreateSandbox {
                 booleanParam("payment",false,"Enable Payment MFE")
                 stringParam("payment_version","master","The repository version of the frontend-app-payment")
 
-                booleanParam("learning",false,"Enable Learning MFE")
+                booleanParam("learning",true,"Enable Learning MFE")
                 stringParam("learning_version","master","The branch of the frontend-app-learning repository")
 
                 choiceParam("server_type",


### PR DESCRIPTION
## Description

frontend-app-learning hosts the default course home
and courseware experiences. So, sandboxes are "broken"
(that is, courseware won't load) unless users remember
to check the box to enable frontend-app-learning.

In this fix, we just provision with the MFE by default.
If a dev really doesn't want the MFE, they can uncheck it.

## Supporting Information

https://openedx.atlassian.net/browse/TNL-8535

## Testing Instructions

* Go to https://tools-edx-jenkins.edx.org/job/Sandboxes/job/CreateSandbox/build (VPN required)
* Ensure "Enable Learning MFE" is checked by default

![image](https://user-images.githubusercontent.com/3628148/128397526-9598f8c4-6a4d-4096-a435-76ba4f372216.png)
