### PR TITLE
feat: Add ability to grant access to insights jobs

### DIFF
--- a/dataeng/jobs/analytics/AnswerDistribution.groovy
+++ b/dataeng/jobs/analytics/AnswerDistribution.groovy
@@ -1,4 +1,5 @@
 package analytics
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_authorization
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_multiscm
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_parameters
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_log_rotator
@@ -11,6 +12,7 @@ class AnswerDistribution {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("answer-distribution-$environment") {
+                authorization common_authorization(env_config)
                 logRotator common_log_rotator(allVars, env_config)
                 multiscm common_multiscm(allVars)
                 triggers common_triggers(allVars, env_config)

--- a/dataeng/jobs/analytics/Enrollment.groovy
+++ b/dataeng/jobs/analytics/Enrollment.groovy
@@ -1,4 +1,5 @@
 package analytics
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_authorization
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_multiscm
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_parameters
 import static org.edx.jenkins.dsl.AnalyticsConstants.from_date_interval_parameter
@@ -13,6 +14,7 @@ class Enrollment {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("enrollment-$environment") {
+                authorization common_authorization(env_config)
                 logRotator common_log_rotator(allVars)
                 multiscm common_multiscm(allVars)
                 triggers common_triggers(allVars, env_config)

--- a/dataeng/jobs/analytics/ModuleEngagement.groovy
+++ b/dataeng/jobs/analytics/ModuleEngagement.groovy
@@ -1,4 +1,5 @@
 package analytics
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_authorization
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_multiscm
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_parameters
 import static org.edx.jenkins.dsl.AnalyticsConstants.to_date_interval_parameter
@@ -11,6 +12,7 @@ class ModuleEngagement {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("module-engagement-$environment") {
+                authorization common_authorization(env_config)
                 logRotator common_log_rotator(allVars)
                 multiscm common_multiscm(allVars)
                 parameters common_parameters(allVars, env_config)

--- a/dataeng/jobs/analytics/UserActivity.groovy
+++ b/dataeng/jobs/analytics/UserActivity.groovy
@@ -1,4 +1,5 @@
 package analytics
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_authorization
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_multiscm
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_parameters
 import static org.edx.jenkins.dsl.AnalyticsConstants.to_date_interval_parameter
@@ -11,6 +12,7 @@ class UserActivity {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("user-activity-$environment") {
+                authorization common_authorization(env_config)
                 logRotator common_log_rotator(allVars, env_config)
                 parameters common_parameters(allVars, env_config)
                 parameters to_date_interval_parameter(allVars)

--- a/dataeng/jobs/analytics/UserLocationByCourse.groovy
+++ b/dataeng/jobs/analytics/UserLocationByCourse.groovy
@@ -1,4 +1,5 @@
 package analytics
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_authorization
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_multiscm
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_parameters
 import static org.edx.jenkins.dsl.AnalyticsConstants.to_date_interval_parameter
@@ -12,6 +13,7 @@ class UserLocationByCourse {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("user-location-by-course-$environment") {
+                authorization common_authorization(env_config)
                 logRotator common_log_rotator(allVars, env_config)
                 multiscm common_multiscm(allVars)
                 triggers common_triggers(allVars, env_config)

--- a/dataeng/jobs/analytics/VideoTimeline.groovy
+++ b/dataeng/jobs/analytics/VideoTimeline.groovy
@@ -1,4 +1,5 @@
 package analytics
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_authorization
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_multiscm
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_parameters
 import static org.edx.jenkins.dsl.AnalyticsConstants.from_date_interval_parameter
@@ -13,6 +14,7 @@ class VideoTimeline {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("video-timeline-$environment") {
+                authorization common_authorization(env_config)
                 logRotator common_log_rotator(allVars, env_config)
                 multiscm common_multiscm(allVars)
                 triggers common_triggers(allVars, env_config)


### PR DESCRIPTION
As a first step to configure access to these jobs from analytics-secure,
we must first make the jobs capable of receiving the configuration by
adding an authorization mechanism.

DESUPPORT-1003