### PR TITLE
fix: Remove unused config for edx-certificates

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -156,9 +156,6 @@ class CreateSandbox {
                 stringParam("ecommerce_worker_version","master","")
                 booleanParam("ecommerce_worker_decrypt_and_copy_config_enabled",true,"Checking this option will decrypt and copy ecommerce_worker config file from configuration internal repo.")
 
-                booleanParam("certs",false,"")
-                stringParam("certs_version","master","")
-
                 booleanParam("analyticsapi",false,"")
                 stringParam("analytics_api_version","master","")
                 booleanParam("analytics_api_decrypt_and_copy_config_enabled",true,"Checking this option will decrypt and copy analytics_api config file from configuration internal repo.")

--- a/devops/jobs/CreateSandboxCI.groovy
+++ b/devops/jobs/CreateSandboxCI.groovy
@@ -97,7 +97,6 @@ class CreateSandboxCI {
                   booleanParam("forum",false)
                   booleanParam("xqueue",false)
                   booleanParam("ecommerce_worker",false)
-                  booleanParam("certs",false)
                   booleanParam("analyticsapi",false)
                   booleanParam("insights",false)
                   booleanParam("demo",false)


### PR DESCRIPTION
Remove configuration for the edx-certificates repository as the repo is no longer used.

MICROBA-1362 DEPR-160