### PR TITLE
PSRE-974 | Bugfix in devops/resources/create-data-czar.sh

### DIFF
--- a/devops/resources/create-data-czar.sh
+++ b/devops/resources/create-data-czar.sh
@@ -8,7 +8,7 @@ create_virtualenv --python=python3.8 --clear
 . "$venvpath/bin/activate"
 set -u
 
-cd $WORKSPACE/configuration
+cd "$WORKSPACE/configuration"
 pip install -r requirements.txt
 . util/jenkins/assume-role.sh
 


### PR DESCRIPTION
`cd` command failed due to space in name of jenkins folder which is "Data Czar"