### PR TITLE
build: remove duplicate requirements jobs

### DIFF
--- a/testeng/jobs/upgradePythonRequirements.groovy
+++ b/testeng/jobs/upgradePythonRequirements.groovy
@@ -56,16 +56,6 @@ List jobConfigs = [
     ],
     [
         org: 'edx',
-        repoName: 'platform-plugin-coaching',
-        defaultBranch: 'master',
-        pythonVersion: '3.8',
-        cronValue: cronOffHoursBusinessWeekday,
-        githubUserReviewers: [],
-        githubTeamReviewers: ['edx-aperture'],
-        emails: ['aperture@edx.opsgenie.net'],
-    ],
-    [
-        org: 'edx',
         repoName: 'configuration',
         defaultBranch: 'master',
         pythonVersion: '3.8',
@@ -85,26 +75,6 @@ List jobConfigs = [
         githubTeamReviewers: [],
         emails: ['engage-squad-eng@edx.org'],
         alwaysNotify: false
-    ],
-    [
-        org: 'edx',
-        repoName: 'credentials',
-        defaultBranch: 'master',
-        pythonVersion: '3.8',
-        cronValue: cronOffHoursBusinessWeekday,
-        githubUserReviewers: [],
-        githubTeamReviewers: ['edx-aperture'],
-        emails: ['aperture@edx.opsgenie.net'],
-    ],
-    [
-        org: 'edx',
-        repoName: 'credentials-themes',
-        defaultBranch: 'master',
-        pythonVersion: '3.8',
-        cronValue: cronOffHoursBusinessWeekday,
-        githubUserReviewers: [],
-        githubTeamReviewers: ['edx-aperture'],
-        emails: ['aperture@edx.opsgenie.net'],
     ],
     [
         org: 'edx',


### PR DESCRIPTION
Credentials, credentials-themes, and platform-plugin-coaching all have requirements PR done via Github Actions now.