### PR TITLE
Feat: Add App-Permissions for other IDAs

### DIFF
--- a/devops/jobs/AppPermissionsRunner.groovy
+++ b/devops/jobs/AppPermissionsRunner.groovy
@@ -17,139 +17,140 @@ class AppPermissionsRunner {
     public static def job = { dslFactory, extraVars ->
         assert extraVars.containsKey('DEPLOYMENTS') : "Please define DEPLOYMENTS. It should be a list of strings."
         assert !(extraVars.get('DEPLOYMENTS') instanceof String) : "Make sure DEPLOYMENTS is a list and not a string"
-        List jobTypes = ['groups-lms', 'groups-cms', 'active-users', 'inactive-users']
         extraVars.get('DEPLOYMENTS').each { deployment, configuration ->
-            configuration.environments.each { environment ->
-                jobTypes.each { jobType ->
-                    dslFactory.job(extraVars.get("FOLDER_NAME","App-Permissions") + "/app-permissions-runner-${environment}-${deployment}-${jobType}") {
+            configuration.environments.each { environments ->
+                environments.each { environment, jobtypes ->
+                    jobtypes.each { jobType ->
+                        dslFactory.job(extraVars.get("FOLDER_NAME","App-Permissions") + "/app-permissions-runner-${environment}-${deployment}-${jobType}") {
 
-                        wrappers common_wrappers
-                        logRotator common_logrotator
+                            wrappers common_wrappers
+                            logRotator common_logrotator
 
-                        wrappers {
-                            credentialsBinding {
-                                string('GIT_TOKEN',"edx_git_bot_token")
-                                file('AWS_CONFIG_FILE','tools-edx-jenkins-aws-credentials')
-                                string('ROLE_ARN', "find-active-instances-${deployment}-role-arn")
+                            wrappers {
+                                credentialsBinding {
+                                    string('GIT_TOKEN',"edx_git_bot_token")
+                                    file('AWS_CONFIG_FILE','tools-edx-jenkins-aws-credentials')
+                                    string('ROLE_ARN', "find-active-instances-${deployment}-role-arn")
+                                }
+                                assert extraVars.containsKey('DEPLOYMENT_KEY_NAME') : "Make sure you define the deployment key name"
+
+                                sshAgent(extraVars.get('DEPLOYMENT_KEY_NAME'))
                             }
-                            assert extraVars.containsKey('DEPLOYMENT_KEY_NAME') : "Make sure you define the deployment key name"
 
-                            sshAgent(extraVars.get('DEPLOYMENT_KEY_NAME'))
-                        }
-
-                        def access_control = extraVars.get('ACCESS_CONTROL', [])
-                        access_control.each { acl ->
-                            common_read_permissions.each { perm ->
-                                authorization {
-                                    permission(perm,acl)
+                            def access_control = extraVars.get('ACCESS_CONTROL', [])
+                            access_control.each { acl ->
+                                common_read_permissions.each { perm ->
+                                    authorization {
+                                        permission(perm,acl)
+                                    }
                                 }
                             }
-                        }
 
-                        throttleConcurrentBuilds {
-                            maxPerNode(0)
-                            maxTotal(0)
-                        }
+                            throttleConcurrentBuilds {
+                                maxPerNode(0)
+                                maxTotal(0)
+                            }
 
-                        assert extraVars.containsKey('APP_PERMISSIONS_REPO') : 'Make sure you define the app permissions repository'
+                            assert extraVars.containsKey('APP_PERMISSIONS_REPO') : 'Make sure you define the app permissions repository'
 
-                        def gitCredentialId = extraVars.get('SECURE_GIT_CREDENTIALS','')
+                            def gitCredentialId = extraVars.get('SECURE_GIT_CREDENTIALS','')
 
-                        parameters{
-                            stringParam('CONFIGURATION_REPO', extraVars.get('CONFIGURATION_REPO', 'https://github.com/edx/configuration.git'),
-                                    'Git repo containing edX configuration.')
-                            stringParam('CONFIGURATION_BRANCH', extraVars.get('CONFIGURATION_BRANCH', 'master'),
-                                    'e.g. tagname or origin/branchname')
-                            stringParam('APP_PERMISSIONS_REPO', extraVars.get('APP_PERMISSIONS_REPO'),
-                                    'Git repo containing edx app permissions')
-                            stringParam('APP_PERMISSIONS_BRANCH', extraVars.get('APP_PERMISSIONS_BRANCH', 'master'),
-                                    'e.g. tagname or origin/branchname')
-                            stringParam('TUBULAR_REPO', extraVars.get('TUBULAR_REPO'),
-                                    'Git repo containing tubular')
-                            stringParam('TUBULAR_BRANCH', extraVars.get('TUBULAR_BRANCH', 'master'),
-                                    'e.g. tagname or origin/branchname')
-                        }
+                            parameters{
+                                stringParam('CONFIGURATION_REPO', extraVars.get('CONFIGURATION_REPO', 'https://github.com/edx/configuration.git'),
+                                        'Git repo containing edX configuration.')
+                                stringParam('CONFIGURATION_BRANCH', extraVars.get('CONFIGURATION_BRANCH', 'master'),
+                                        'e.g. tagname or origin/branchname')
+                                stringParam('APP_PERMISSIONS_REPO', extraVars.get('APP_PERMISSIONS_REPO'),
+                                        'Git repo containing edx app permissions')
+                                stringParam('APP_PERMISSIONS_BRANCH', extraVars.get('APP_PERMISSIONS_BRANCH', 'master'),
+                                        'e.g. tagname or origin/branchname')
+                                stringParam('TUBULAR_REPO', extraVars.get('TUBULAR_REPO'),
+                                        'Git repo containing tubular')
+                                stringParam('TUBULAR_BRANCH', extraVars.get('TUBULAR_BRANCH', 'master'),
+                                        'e.g. tagname or origin/branchname')
+                            }
 
-                        multiscm{
+                            multiscm{
+                                git {
+                                    remote {
+                                        url('$CONFIGURATION_REPO')
+                                        branch('$CONFIGURATION_BRANCH')
+                                    }
+                                    extensions {
+                                        cleanAfterCheckout()
+                                        pruneBranches()
+                                        relativeTargetDirectory('configuration')
+                                    }
+                                }
+                                git {
+                                    remote {
+                                        url('$APP_PERMISSIONS_REPO')
+                                        branch('$APP_PERMISSIONS_BRANCH')
+                                            if (gitCredentialId) {
+                                                credentials(gitCredentialId)
+                                            }
+                                    }
+                                    extensions {
+                                        cleanAfterCheckout()
+                                        pruneBranches()
+                                        relativeTargetDirectory('app-permissions')
+                                    }
+                                }
                             git {
-                                remote {
-                                    url('$CONFIGURATION_REPO')
-                                    branch('$CONFIGURATION_BRANCH')
-                                }
-                                extensions {
-                                    cleanAfterCheckout()
-                                    pruneBranches()
-                                    relativeTargetDirectory('configuration')
+                                    remote {
+                                        url('$TUBULAR_REPO')
+                                        branch('$TUBULAR_BRANCH')
+                                    }
+                                    extensions {
+                                        cleanAfterCheckout()
+                                        pruneBranches()
+                                        relativeTargetDirectory('tubular')
+                                    }
                                 }
                             }
-                            git {
-                                remote {
-                                    url('$APP_PERMISSIONS_REPO')
-                                    branch('$APP_PERMISSIONS_BRANCH')
-                                        if (gitCredentialId) {
-                                            credentials(gitCredentialId)
+
+                            environmentVariables {
+                                env('ENVIRONMENT', environment)
+                                env('DEPLOYMENT', deployment)
+                                env('JOB_TYPE', jobType)
+                                env('USER', extraVars.get('USER', 'ubuntu'))
+                            }
+
+
+                            steps {
+                            shell(dslFactory.readFileFromWorkspace('devops/resources/run-app-permissions.sh'))
+                            conditionalSteps {
+                                condition {
+                                    status('SUCCESS','SUCCESS')
+                                }
+                                steps {
+                                    shell(dslFactory.readFileFromWorkspace('devops/resources/app-permission-runner-success.sh'))
+                                }
+                                }
+                            }
+
+                            publishers {
+                                downstreamParameterized {
+                                    trigger('app-permissions-failure') {
+                                        condition('FAILED')
+                                        parameters {
+                                            predefinedProp('ENVIRONMENT', environment)
+                                            predefinedProp('DEPLOYMENT', deployment)
+                                            predefinedProp('JOB_TYPE', jobType)
+                                            predefinedProp('GIT_PREVIOUS_COMMIT_1', '${GIT_PREVIOUS_COMMIT_1}')
+                                            predefinedProp('GIT_COMMIT_1', '${GIT_COMMIT_1}')
+                                            predefinedProp('UPSTREAM_BUILD_URL', '${BUILD_URL}')
                                         }
+                                    }
                                 }
-                                extensions {
-                                    cleanAfterCheckout()
-                                    pruneBranches()
-                                    relativeTargetDirectory('app-permissions')
+                                if (extraVars.get('NOTIFY_ON_FAILURE')){
+                                    publishers {
+                                    mailer(extraVars.get('NOTIFY_ON_FAILURE'), false, false)
+                                    }
                                 }
-                            }
-                           git {
-                                remote {
-                                    url('$TUBULAR_REPO')
-                                    branch('$TUBULAR_BRANCH')
-                                }
-                                extensions {
-                                    cleanAfterCheckout()
-                                    pruneBranches()
-                                    relativeTargetDirectory('tubular')
-                                }
+
                             }
                         }
-
-                        environmentVariables {
-                            env('ENVIRONMENT', environment)
-                            env('DEPLOYMENT', deployment)
-                            env('JOB_TYPE', jobType)
-                            env('USER', extraVars.get('USER', 'ubuntu'))
-                        }
-
-
-                        steps {
-                           shell(dslFactory.readFileFromWorkspace('devops/resources/run-app-permissions.sh'))
-                           conditionalSteps {
-                               condition {
-                                   status('SUCCESS','SUCCESS')
-                               }
-                               steps {
-                                   shell(dslFactory.readFileFromWorkspace('devops/resources/app-permission-runner-success.sh'))
-                               }
-                            }
-                        }
-
-                        publishers {
-                            downstreamParameterized {
-                                 trigger('app-permissions-failure') {
-                                     condition('FAILED')
-                                     parameters {
-                                         predefinedProp('ENVIRONMENT', environment)
-                                         predefinedProp('DEPLOYMENT', deployment)
-                                         predefinedProp('JOB_TYPE', jobType)
-                                         predefinedProp('GIT_PREVIOUS_COMMIT_1', '${GIT_PREVIOUS_COMMIT_1}')
-                                         predefinedProp('GIT_COMMIT_1', '${GIT_COMMIT_1}')
-                                         predefinedProp('UPSTREAM_BUILD_URL', '${BUILD_URL}')
-                                     }
-                                }
-                            }
-                            if (extraVars.get('NOTIFY_ON_FAILURE')){
-                                publishers {
-                                   mailer(extraVars.get('NOTIFY_ON_FAILURE'), false, false)
-                                }
-                            }
-
-                       }
                     }
                 }
             }

--- a/devops/resources/run-app-permissions.sh
+++ b/devops/resources/run-app-permissions.sh
@@ -17,22 +17,53 @@ env
 assume-role ${ROLE_ARN}
 cd $WORKSPACE/configuration/playbooks
 
+# Function to set ASG and path variables
+function setASGAndPath () {
+	service_name="$1"
+	if [[ "${service_name}" == "lms" ]] || [[ "${service_name}" == "cms" ]] || [[ "${service_name}" == "edxapp" ]]; then
+		INVENTORY=$(./active_instances_in_asg.py --asg ${ENVIRONMENT}-${DEPLOYMENT}-worker)
+		SERVICE_ENV_PATH="/edx/app/edxapp/edxapp_env"
+		SERVICE_PYTHON_PATH="/edx/app/edxapp/venvs/edxapp/bin/python"
+		SERVICE_MANAGE_PATH="/edx/bin/manage.edxapp"
+	else
+		INVENTORY=$(./active_instances_in_asg.py --asg ${ENVIRONMENT}-${DEPLOYMENT}-${service_name})
+		SERVICE_ENV_PATH="/edx/app/${service_name}/${service_name}_env"
+		SERVICE_PYTHON_PATH="/edx/app/${service_name}/venvs/${service_name}/bin/python"
+		SERVICE_MANAGE_PATH="/edx/bin/manage.${service_name}"
+	fi
+}
+
 if [[ "$JOB_TYPE" =~ ^groups-(.+)$ ]]; then
 	service="${BASH_REMATCH[1]}"
 	configfile=${WORKSPACE}/app-permissions/groups/${service}.yml
-elif [[ "$JOB_TYPE" = 'active-users' ]] || [[ "$JOB_TYPE" = 'inactive-users' ]]; then
-	configfile=${WORKSPACE}/app-permissions/users/${ENVIRONMENT}-${DEPLOYMENT}.yml
+	setASGAndPath ${service}
+	if [[ "${service}" == "lms" ]] || [[ "${service}" == "cms" ]]; then
+		ANSIBLE_TAG="manage-$JOB_TYPE"
+	else
+		ANSIBLE_TAG="manage-groups-ida"
+	fi
+elif [[ "$JOB_TYPE" =~ ^(.+)-users-(.+)$ ]]; then
+	job_type_prefix="${BASH_REMATCH[1]}"
+	service="${BASH_REMATCH[2]}"
+	configfile=${WORKSPACE}/app-permissions/users/${service}/${ENVIRONMENT}-${DEPLOYMENT}.yml
+	setASGAndPath ${service}
+	if [[ "${service}" == "edxapp" ]]; then
+		ANSIBLE_TAG="manage-$JOB_TYPE"
+	else
+		ANSIBLE_TAG="manage-${job_type_prefix}-users-ida"
+	fi
 else
 	echo "Bad job type: ${JOB_TYPE}."
-	echo "Expected active-users, inactive-users, or groups-<service>."
+	echo "Expected active-users-edxapp, inactive-users-edxapp, inactive-users-<service> or groups-<service>."
 	exit 1
 fi
 
-INVENTORY=$(./active_instances_in_asg.py --asg ${ENVIRONMENT}-${DEPLOYMENT}-worker)
 if [[ -n ${INVENTORY} ]]; then
     ansible-playbook -i ${INVENTORY} manage_edxapp_users_and_groups.yml \
+										 -e "env_path=${SERVICE_ENV_PATH}" -e "python_path=${SERVICE_PYTHON_PATH}" \
+										 -e "manage_path=${SERVICE_MANAGE_PATH}" -e "service=${service}" \
                      -e@${configfile} -e "group_environment=${ENVIRONMENT}-${DEPLOYMENT}" \
-                     --user ${USER} --tags manage-${JOB_TYPE}
+                     --user ${USER} --tags ${ANSIBLE_TAG}
 else
     echo "Skipping ${ENVIRONMENT} ${DEPLOYMENT}, no worker cluster available, get it next time"
 fi


### PR DESCRIPTION
This PR adds services other than `edxapp` into App-Permissions. See [ADR](https://edx.readthedocs.io/projects/edx-django-utils/en/latest/decisions/0005-user-and-group-management-commands.html) for more context.