### PR TITLE
feat: add new cli params to user retirement archiver job and increase…

### DIFF
--- a/devops/jobs/UserRetirementArchiver.groovy
+++ b/devops/jobs/UserRetirementArchiver.groovy
@@ -77,8 +77,28 @@ class UserRetirementArchiver {
             parameters {
                 stringParam(
                     'COOL_OFF_DAYS',
-                    '67',
+                    '74',
                     'Number of days after retirement request when a user retirement status should be archived in S3.'
+                )
+                stringParam(
+                    'BATCH_SIZE',
+                    '1000',
+                    'Size of batches of learner retirments to process.'
+                )
+                stringParam(
+                    'START_DATE',
+                    '2018-01-01',
+                    'Start of window used to select user retirements for archival. Only user retirements added to the retirement queue after this date will be processed.'
+                )
+                stringParam(
+                    'END_DATE',
+                    '',
+                    'End of window used to select user retirments for archival. Only user retirments added to the retirement queue before this date will be processed. In the case that this date is more recent than the value specified in the `cool_off_days` parameter, an error will be thrown. If this parameter is not used, the script will default to using an end_date based upon the `cool_off_days` parameter.'
+                )
+                stringParam(
+                    'DRY_RUN',
+                    'False',
+                    'Run this script with the `dry_run` flag, which will not perform the archival or deletion of a user.'
                 )
             }
 

--- a/devops/resources/user-retirement-archiver.sh
+++ b/devops/resources/user-retirement-archiver.sh
@@ -19,7 +19,16 @@ assume-role ${ROLE_ARN}
 cd $WORKSPACE/tubular
 pip install -r requirements.txt
 
+# In case this is being run without an explicit END_DATE, default to running with "now"
+if [[ "$END_DATE" == "" ]]; then
+    END_DATE=$(date +%Y-%m-%d)
+fi
+
 # Call the script to read the retirement statuses from the LMS, send them to S3, and delete them from the LMS.
 python scripts/retirement_archive_and_cleanup.py \
     --config_file=$WORKSPACE/user-retirement-secure/${ENVIRONMENT_DEPLOYMENT}.yml \
-    --cool_off_days=$COOL_OFF_DAYS
+    --cool_off_days=$COOL_OFF_DAYS \
+    --batch_size=$BATCH_SIZE \
+    --start_date=$START_DATE \
+    --end_date=$END_DATE \
+    --dry_run=$DRY_RUN


### PR DESCRIPTION
… cool off period.

Currently, the `cool_off` period for the user-retirement pipeline is 14 days. It was previously 7. Looking at this job, 67 seems to indicate 2 months after the cool off has completed, although I could be wrong. I have modified it to reflect the cool off in https://github.com/edx/jenkins-job-dsl/commit/47b9a3d63670ee237faca055c56f05d909172752