### PR TITLE
Fix: Update AppPermissionsWatcher for other IDAs

### DIFF
--- a/devops/jobs/AppPermissionsWatcher.groovy
+++ b/devops/jobs/AppPermissionsWatcher.groovy
@@ -81,13 +81,14 @@ class AppPermissionsWatcher{
 
             triggers merge_to_master_trigger(repo_branch)
 
-            List jobTypes = ['groups-lms', 'groups-cms', 'active-users', 'inactive-users']
             steps{
                 extraVars.get('DEPLOYMENTS').each { deployment, configuration ->
-                    configuration.environments.each { environment ->
-                        jobTypes.each { jobType ->
-                            downstreamParameterized {
-                                trigger("app-permissions-runner-${environment}-${deployment}-${jobType}")
+                    configuration.environments.each { environments ->
+                        environments.each { environment, jobtypes ->
+                            jobtypes.each { jobType ->
+                                downstreamParameterized {
+                                    trigger("app-permissions-runner-${environment}-${deployment}-${jobType}")
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This PR adds services other than edxapp into AppPermissionsWatcher. See [ADR](https://edx.readthedocs.io/projects/edx-django-utils/en/latest/decisions/0005-user-and-group-management-commands.html) for more context.