### PR TITLE
fix: fix setting end date in user retirement archiver script

### DIFF
--- a/devops/resources/user-retirement-archiver.sh
+++ b/devops/resources/user-retirement-archiver.sh
@@ -19,9 +19,9 @@ assume-role ${ROLE_ARN}
 cd $WORKSPACE/tubular
 pip install -r requirements.txt
 
-# In case this is being run without an explicit END_DATE, default to running with "now"
-if [[ "$END_DATE" == "" ]]; then
-    END_DATE=$(date +%Y-%m-%d)
+# In case this is being run without an explicit END_DATE, default to running with "now" - COOL_OFF_DAYS
+if [[ ! -v END_DATE ]]; then
+    END_DATE=$(date --iso --date "$(date --iso) - $COOL_OFF_DAYS days")
 fi
 
 # Call the script to read the retirement statuses from the LMS, send them to S3, and delete them from the LMS.


### PR DESCRIPTION
Tested locally: 
```
jenkins-job-dsl (estute/deng-983-date) % END_DATE=2021-09-22
jenkins-job-dsl (estute/deng-983-date) % COOL_OFF_DAYS=10
jenkins-job-dsl (estute/deng-983-date) % END_DATE=$(date --date "$(date "+%B %d, %Y") -$COOL_OFF_DAYS days" +%y-%m-%d)
jenkins-job-dsl (estute/deng-983-date) % echo $END_DATE
21-09-12
```