### PR TITLE
feat: let failure notif. recipients for diff. sandbox jobs diverge

### DIFF
--- a/devops/jobs/CreateSandboxCI.groovy
+++ b/devops/jobs/CreateSandboxCI.groovy
@@ -130,7 +130,7 @@ class CreateSandboxCI {
         }
 
         publishers {
-          mailer(extraVars.get('NOTIFY_ON_FAILURE',''), false, false)
+          mailer(extraVars.get(type.toUpperCase() + "_NOTIFY_ON_FAILURE",''), false, false)
         }
       }
     }


### PR DESCRIPTION
I would just rely on the already-built heartbeat-based alerts to meet
notification needs here, but I'd like to include someone who I'm not
sure I can onboard to opsgenie.

JIRA:EDUCATOR-5393