### PR TITLE
fix: schema builder hub token

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeSchemaBuilder.groovy
+++ b/dataeng/jobs/analytics/SnowflakeSchemaBuilder.groovy
@@ -38,7 +38,7 @@ class SnowflakeSchemaBuilder {
             wrappers {
                 timestamps()
                 credentialsBinding {
-                    usernamePassword('GITHUB_USER', 'GITHUB_TOKEN', 'GITHUB_USER_PASS_COMBO');
+                    string('GITHUB_TOKEN', 'GHPRB_BOT_TOKEN');
                 }
             }
             publishers common_publishers(allVars)

--- a/dataeng/resources/snowflake-schema-builder.sh
+++ b/dataeng/resources/snowflake-schema-builder.sh
@@ -37,5 +37,5 @@ else
   git commit --message "chore: Schema Builder automated dbt update at $now"
 
   # Create a PR on Github from the new branch
-  HUB_PROTOCOL=ssh HUB_USER=edx-analytics-automation /snap/bin/hub pull-request --push --no-edit -r edx/edx-data-engineering
+  HUB_PROTOCOL=ssh /snap/bin/hub pull-request --push --no-edit -r edx/edx-data-engineering
 fi


### PR DESCRIPTION
Exporting github token as an environment variable that will be used by Hub to created pull request