### PR TITLE
chore: update python venv version

### DIFF
--- a/dataeng/jobs/analytics/DBTDocs.groovy
+++ b/dataeng/jobs/analytics/DBTDocs.groovy
@@ -40,7 +40,7 @@ class DBTDocs{
             publishers common_publishers(allVars)
             steps {
                 virtualenv {
-                    pythonName('PYTHON_3.7')
+                    pythonName('PYTHON_3.8')
                     nature("shell")
                     systemSitePackages(false)
                     command(

--- a/dataeng/jobs/analytics/DBTRun.groovy
+++ b/dataeng/jobs/analytics/DBTRun.groovy
@@ -56,7 +56,7 @@ class DBTRun{
             publishers common_publishers(allVars)
             steps {
                 virtualenv {
-                    pythonName('PYTHON_3.7')
+                    pythonName('PYTHON_3.8')
                     nature("shell")
                     systemSitePackages(false)
                     command(
@@ -109,7 +109,7 @@ class DBTRun{
             publishers common_publishers(allVars)
             steps {
                 virtualenv {
-                    pythonName('PYTHON_3.7')
+                    pythonName('PYTHON_3.8')
                     nature("shell")
                     systemSitePackages(false)
                     command(

--- a/dataeng/jobs/analytics/DBTSourceFreshness.groovy
+++ b/dataeng/jobs/analytics/DBTSourceFreshness.groovy
@@ -45,7 +45,7 @@ class DBTSourceFreshness{
             publishers common_publishers(allVars)
             steps {
                 virtualenv {
-                    pythonName('PYTHON_3.7')
+                    pythonName('PYTHON_3.8')
                     nature("shell")
                     systemSitePackages(false)
                     command(

--- a/dataeng/jobs/analytics/SnowflakeSchemaBuilder.groovy
+++ b/dataeng/jobs/analytics/SnowflakeSchemaBuilder.groovy
@@ -45,7 +45,7 @@ class SnowflakeSchemaBuilder {
             steps {
 
                 virtualenv {
-                    pythonName('PYTHON_3.7')
+                    pythonName('PYTHON_3.8')
                     nature("shell")
                     systemSitePackages(false)
                     command(

--- a/dataeng/jobs/analytics/WarehouseTransforms.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransforms.groovy
@@ -67,7 +67,7 @@ class WarehouseTransforms{
                 steps {
                     shell(dslFactory.readFileFromWorkspace('dataeng/resources/opsgenie-enable-heartbeat.sh'))
                     virtualenv {
-                        pythonName('PYTHON_3.7')
+                        pythonName('PYTHON_3.8')
                         nature("shell")
                         systemSitePackages(false)
                         command(

--- a/dataeng/jobs/analytics/WarehouseTransformsCI.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransformsCI.groovy
@@ -109,7 +109,7 @@ class WarehouseTransformsCI{
             wrappers common_wrappers(allVars)
             steps {
                 virtualenv {
-                    pythonName('PYTHON_3.7')
+                    pythonName('PYTHON_3.8')
                     nature("shell")
                     systemSitePackages(false)
                     command(

--- a/dataeng/jobs/analytics/WarehouseTransformsCIManual.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransformsCIManual.groovy
@@ -90,7 +90,7 @@ class WarehouseTransformsCIManual{
             wrappers common_wrappers(allVars)
             steps {
                 virtualenv {
-                    pythonName('PYTHON_3.7')
+                    pythonName('PYTHON_3.8')
                     nature("shell")
                     systemSitePackages(false)
                     command(

--- a/dataeng/jobs/analytics/WarehouseTransformsCIMasterMerges.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransformsCIMasterMerges.groovy
@@ -136,7 +136,7 @@ class WarehouseTransformsCIMasterMerges{
             wrappers common_wrappers(allVars)
             steps {
                 virtualenv {
-                    pythonName('PYTHON_3.7')
+                    pythonName('PYTHON_3.8')
                     nature("shell")
                     systemSitePackages(false)
                     command(


### PR DESCRIPTION
As part of dbt version upgrade, I am updating python version from 3.7 to 3.8. Relevant jenkins jobs python venv should also be using python 3.8. This PR is updating python virtual environment version to 3.8 in schema builder and all of the warehouse transform related jobs.