### PR TITLE
fix: temporarily disable usages of build-name-setter (continued)

### DIFF
--- a/platform/jobs/RetirementJobEdxTriggers.groovy
+++ b/platform/jobs/RetirementJobEdxTriggers.groovy
@@ -106,7 +106,9 @@ jobConfigs.each { jobConfig ->
         logRotator JENKINS_PUBLIC_LOG_ROTATOR(30)
 
         wrappers {
-            buildName('#${BUILD_NUMBER}')
+            // DENG-1063/PSRE-1204: Temporarily avoid using the build-name-setter
+            // plugin while it's currently broken due to plugin incompatibilities.
+            //buildName('#${BUILD_NUMBER}')
             timestamps()
             colorizeOutput('xterm')
         }


### PR DESCRIPTION
This is a continuation of a previous commit.  I forgot one more change.

DENG-1063/PSRE-1204