### PR TITLE
chore: update schema builder python venv to 3.8 version

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeSchemaBuilder.groovy
+++ b/dataeng/jobs/analytics/SnowflakeSchemaBuilder.groovy
@@ -44,14 +44,8 @@ class SnowflakeSchemaBuilder {
             publishers common_publishers(allVars)
             steps {
 
-                virtualenv {
-                    pythonName('PYTHON_3.7')
-                    nature("shell")
-                    systemSitePackages(false)
-                    command(
-                        dslFactory.readFileFromWorkspace("dataeng/resources/snowflake-schema-builder.sh")
-                    )
-                }
+                // This will create python 3.8 venv inside shell script instead of using shiningpanda
+                shell(readFileFromWorkspace('dataeng/resources/snowflake-schema-builder.sh'))
             }
         }
     }

--- a/dataeng/resources/snowflake-schema-builder.sh
+++ b/dataeng/resources/snowflake-schema-builder.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -ex
 
+# Creating python 3.8 virtual environment to run schema builder
+PYTHON38_VENV="py38_venv"
+virtualenv --python=python3.8 --clear "${PYTHON38_VENV}"
+source "${PYTHON38_VENV}/bin/activate"
+
 # Setup
 cd $WORKSPACE/warehouse-transforms
 pip install --upgrade dbt-schema-builder


### PR DESCRIPTION
As part of dbt version upgrade, we are updating python version from 3.7 to 3.8 in schema builder repository. This PR is updating python virtual environment version to 3.8 to run schema builder script in jenkins.