### PR TITLE
chore: dbt v0.21.1 upgrade source freshness

### DIFF
--- a/dataeng/resources/dbtsource-freshness.sh
+++ b/dataeng/resources/dbtsource-freshness.sh
@@ -12,6 +12,8 @@ cd $WORKSPACE/warehouse-transforms/projects/reporting
 dbt clean --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ --profile $DBT_PROFILE --target $DBT_TARGET
 dbt deps --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ --profile $DBT_PROFILE --target $DBT_TARGET
 
-# Use the --select flag to snapshot freshness for specific sources, [--select [source_1, ...]]
-dbt source snapshot-freshness --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ --profile $DBT_PROFILE --target $DBT_TARGET
+# For dbt v0.21.0 or above, dbt source snapshot-freshness has been renamed to dbt source freshness.
+# Its node selection logic is now consistent with other tasks. In order to check freshness for a specific source,
+# use --select flag and you must prefix it with source:   e.g. dbt source freshness --select source:snowplow
+dbt source freshness --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ --profile $DBT_PROFILE --target $DBT_TARGET
 


### PR DESCRIPTION
`dbt source snapshot-freshness` has been renamed to `dbt source freshness` from version dbt v0.21.0 and above