### PR TITLE
temp: disable the user-retirement jobs due to high load during an AWS…

### DIFF
--- a/platform/jobs/RetirementJobEdxTriggers.groovy
+++ b/platform/jobs/RetirementJobEdxTriggers.groovy
@@ -16,7 +16,7 @@ List jobConfigs = [
         environmentDeployment: 'prod-edx',
         extraMembersCanBuild: [],
         cron: 'H * * * *',  // Hourly at an arbitrary, but consistent minute.
-        disabled: false
+        disabled: true  // temporarily disable this job due to AWS outage (12/7/21)
     ],
     [
         downstreamJobName: 'user-retirement-collector',
@@ -24,7 +24,7 @@ List jobConfigs = [
         environmentDeployment: 'prod-edge',
         extraMembersCanBuild: [],
         cron: 'H * * * *',  // Hourly at an arbitrary, but consistent minute.
-        disabled: false
+        disabled: true  // temporarily disable this job due to AWS outage (12/7/21)
     ],
     [
         downstreamJobName: 'retirement-partner-reporter',


### PR DESCRIPTION
… outage

There was a wide-scale AWS outage today. This has impacted the EC2 service, which has in turn made it impossible for the user-retirement workflow to spin up the batches of workers it needs to process a backlog of users. I have manually disabled this job and will re-enable it when we can reliably process these users. This PR serves just to codify a manual change I have made.