### PR TITLE
chore: refactor dbt to use MODEL_SELECTOR instead of MODEL_TAG.

### DIFF
--- a/dataeng/jobs/analytics/WarehouseTransforms.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransforms.groovy
@@ -18,10 +18,11 @@ class WarehouseTransforms{
                 parameters {
                     stringParam('WAREHOUSE_TRANSFORMS_URL', allVars.get('WAREHOUSE_TRANSFORMS_URL'), 'URL for the Warehouse Transforms Repo.')
                     stringParam('WAREHOUSE_TRANSFORMS_BRANCH', allVars.get('WAREHOUSE_TRANSFORMS_BRANCH'), 'Branch of Warehouse Transforms to use.')
-                    stringParam('MODEL_TAG', env_config.get('MODEL_TAG', allVars.get('MODEL_TAG')), 'Tagged model that will be run.')
+                    stringParam('MODEL_SELECTOR', env_config.get('MODEL_SELECTOR', allVars.get('MODEL_SELECTOR')), 'Model selector that will be run.  Often a tag selector.')
                     stringParam('DBT_PROJECT', env_config.get('DBT_PROJECT', allVars.get('DBT_PROJECT')), 'dbt project in warehouse-transforms to work on.')
                     stringParam('DBT_PROFILE', env_config.get('DBT_PROFILE', allVars.get('DBT_PROFILE')), 'dbt profile from analytics-secure to work on.')
                     stringParam('DBT_TARGET', env_config.get('DBT_TARGET', allVars.get('DBT_TARGET')), 'dbt target from analytics-secure to work on.')
+                    stringParam('DBT_COMMAND', env_config.get('DBT_COMMAND', allVars.get('DBT_COMMAND', 'run')), 'dbt command to be executed.  Default is \'run\'.')
                     stringParam('SKIP_TESTS', env_config.get('SKIP_TESTS', 'false'), 'Set to \'true\' to skip all tests. All other values will allow tests to run given the other configuration values.')
                     stringParam('SKIP_SEED', env_config.get('SKIP_SEED', 'false'), 'Set to \'true\' to skip the dbt seed step. All other values will cause the seed step to be run.')
                     stringParam('TEST_SOURCES_FIRST', env_config.get('TEST_SOURCES_FIRST', 'true'), 'Set to \'true\' to perform source testing first (if SKIP_TESTS is false). All other values test sources post-run.')

--- a/dataeng/resources/warehouse-transforms.sh
+++ b/dataeng/resources/warehouse-transforms.sh
@@ -62,7 +62,7 @@ then
 fi
 
 # Compile/build all models with this tag.
-dbt run $FULL_REFRESH_ARG --models tag:$MODEL_TAG $exclude_param --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ ; ret=$?;
+dbt $DBT_COMMAND $FULL_REFRESH_ARG --models $MODEL_SELECTOR $exclude_param --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ ; ret=$?;
 postCommandChecks "run" $ret ;
 
 
@@ -78,6 +78,6 @@ then
     fi
 
     # Run all tests which haven't been excluded.
-    dbt test --models tag:$MODEL_TAG $exclude_param --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ ; ret=$?;
+    dbt test --models $MODEL_SELECTOR $exclude_param --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ ; ret=$?;
     postCommandChecks "test" $ret ;
 fi


### PR DESCRIPTION
for DENG-1070, we need more general selector than just a tag name, so move the "tag:" prefix into the definition of MODEL_SELECTOR values.

for DENG-1062, we also need to be able to run 'dbt snapshot' instead of 'dbt run'.  So define DBT_COMMAND to allow this to be overridden.
