### PR TITLE
fix: install dbt deps in model transfer jobs

### DIFF
--- a/dataeng/resources/model-transfers.sh
+++ b/dataeng/resources/model-transfers.sh
@@ -23,5 +23,7 @@ fi
 
 ARGS="{mart: ${MART_NAME} }"
 
+dbt deps --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ --profile $DBT_PROFILE --target $DBT_TARGET
+
 # Call DBT to perform all transfers for this mart.
 dbt run-operation perform_s3_transfers --args "${ARGS}" --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/


### PR DESCRIPTION
Recently, the transfer dbt models jobs have started failing with the following message:
```
17:04:19-0500 Compilation Error
17:04:19-0500   dbt found 2 package(s) specified in packages.yml, but only 1 package(s) installed in dbt_modules. Run "dbt deps" to install package dependencies.
```
It seems that the model transfer jobs were the only ones in which we were not explicitly installing dependencies.