### PR TITLE
chore: load only required seeds using SEED_SELECTOR

### DIFF
--- a/dataeng/jobs/analytics/WarehouseTransforms.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransforms.groovy
@@ -23,6 +23,7 @@ class WarehouseTransforms{
                     stringParam('DBT_PROFILE', env_config.get('DBT_PROFILE', allVars.get('DBT_PROFILE')), 'dbt profile from analytics-secure to work on.')
                     stringParam('DBT_TARGET', env_config.get('DBT_TARGET', allVars.get('DBT_TARGET')), 'dbt target from analytics-secure to work on.')
                     stringParam('DBT_COMMAND', env_config.get('DBT_COMMAND', allVars.get('DBT_COMMAND', 'run')), 'dbt command to be executed.  Default is \'run\'.')
+                    stringParam('SEED_SELECTOR', env_config.get('SEED_SELECTOR', allVars.get('SEED_SELECTOR', '*')), 'Model selector that will be used when running the seed step.  Defaults to "*".')
                     stringParam('SKIP_TESTS', env_config.get('SKIP_TESTS', 'false'), 'Set to \'true\' to skip all tests. All other values will allow tests to run given the other configuration values.')
                     stringParam('SKIP_SEED', env_config.get('SKIP_SEED', 'false'), 'Set to \'true\' to skip the dbt seed step. All other values will cause the seed step to be run.')
                     stringParam('TEST_SOURCES_FIRST', env_config.get('TEST_SOURCES_FIRST', 'true'), 'Set to \'true\' to perform source testing first (if SKIP_TESTS is false). All other values test sources post-run.')

--- a/dataeng/resources/warehouse-transforms.sh
+++ b/dataeng/resources/warehouse-transforms.sh
@@ -49,7 +49,7 @@ set +e
 
 if [ "$SKIP_SEED" != 'true' ]
 then
-  dbt seed --full-refresh --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ ; ret=$?;
+  dbt seed --full-refresh --models "$SEED_SELECTOR" --profile $DBT_PROFILE --target $DBT_TARGET --profiles-dir $WORKSPACE/analytics-secure/warehouse-transforms/ ; ret=$?;
   postCommandChecks "seed" $ret ;
 fi
 


### PR DESCRIPTION
In the past, all seeds were loaded on every run of a DBT workflow.
But since all runs use a MODEL_SELECTOR to run a subset of models,
only a subset of seeds are actually needed.  Excluding these helps
streamline the Amplitude-extraction workflow, which writes to
different ("amplitude_"-prefixed) schema names, and some seeds get
loaded into a schema that doesn't exist.

In support of DENG-1070.