### PR TITLE
Add organization param to cleanup job

### DIFF
--- a/testeng/jobs/cleanupPythonCode.groovy
+++ b/testeng/jobs/cleanupPythonCode.groovy
@@ -5,7 +5,7 @@ githubTeamReviewers = ['arbi-bom']
 job('cleanup-python-code') {
 
     parameters {
-        stringParam('org', ['edx', 'openedx'], 'Organization in which the repo(s) is/are located')
+        choiceParam('org', ['edx', 'openedx'], 'Organization in which the repo(s) is/are located')
         stringParam('repoNames', null, 'Comma or space separated list of names of (public) target repositories in $org org')
         choiceParam('pythonVersion', ['3.8', '3.5', '2.7'], 'Version of python to use')
         stringParam('packages', '', 'Comma or space separated list of packages to install (optional)')

--- a/testeng/jobs/cleanupPythonCode.groovy
+++ b/testeng/jobs/cleanupPythonCode.groovy
@@ -1,5 +1,3 @@
-org = 'edx'
-
 githubUserReviewers = ['mraarif']
 
 githubTeamReviewers = ['arbi-bom']
@@ -7,6 +5,7 @@ githubTeamReviewers = ['arbi-bom']
 job('cleanup-python-code') {
 
     parameters {
+        stringParam('org', ['edx', 'openedx'], 'Organization in which the repo(s) is/are located')
         stringParam('repoNames', null, 'Comma or space separated list of names of (public) target repositories in $org org')
         choiceParam('pythonVersion', ['3.8', '3.5', '2.7'], 'Version of python to use')
         stringParam('packages', '', 'Comma or space separated list of packages to install (optional)')
@@ -21,7 +20,7 @@ job('cleanup-python-code') {
         // Use a textarea for multiline input
         textParam('scripts', '', 'Bash script to run')
     }
-
+    org = '${org}'
     repoNames = '${repoNames}'
     pythonVersion = '${pythonVersion}'
     packagesToInstall = '${packages}'


### PR DESCRIPTION
Jira Issue: [BOM-3126](https://openedx.atlassian.net/browse/BOM-3126)

## Description
Cleanup Job currently had hard coded `edx` organization so there was no way to run cleanup job in repos under `openedx`.
This PR adds a dropdown to select organization.
These changes were tested by manually seeding the cleanup job and then testing the job on one repo each in both the organizations