### PR TITLE
chore: removed the trigger for build-packer-ami

### DIFF
--- a/testeng/jobs/buildPackerAMIjob.groovy
+++ b/testeng/jobs/buildPackerAMIjob.groovy
@@ -50,10 +50,6 @@ job('build-packer-ami') {
         }
     }
 
-    triggers {
-        cron('@weekly')
-    }
-
     wrappers {
         timeout {
             absolute(180)


### PR DESCRIPTION
removed the trigger for `build-packer-ami` job to stop building `jenkins_worker` AMI since we've stopped using that AMI for `edx-platform` unit tests.
This will keep the job alive for `jenkins_worker` AMI for `android`, `codejail`, and retirement jobs.