### PR TITLE
fix: set bash env for analytics exporter jobs

### DIFF
--- a/dataeng/resources/org-exporter-worker.sh
+++ b/dataeng/resources/org-exporter-worker.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
 TODAY=$(date +%d)
 
 env | sort

--- a/dataeng/resources/run-course-exporter.sh
+++ b/dataeng/resources/run-course-exporter.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
 # Create destination directory
 WORKING_DIRECTORY=/var/lib/jenkins/tmp/analytics-course-exporter
 mkdir -p ${WORKING_DIRECTORY}/course-data

--- a/dataeng/resources/setup-exporter-email-optin.sh
+++ b/dataeng/resources/setup-exporter-email-optin.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
 # Create destination directory
 mkdir -p /var/lib/jenkins/tmp/analytics-exporter/course-data
 

--- a/dataeng/resources/setup-exporter.sh
+++ b/dataeng/resources/setup-exporter.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
 # Check that the DATE_MODIFIER is set to a Sunday, or if blank the current day is a Sunday
 DAYOFWEEK=$(date +%u ${DATE_MODIFIER})
 if [ $DAYOFWEEK != 7 ]; then

--- a/dataeng/resources/setup-platform-venv-legacy.sh
+++ b/dataeng/resources/setup-platform-venv-legacy.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
 # Some recent changes in edx-platform breaks the exporter.
 # We are currently using edx-platform's aed/analytics-exporter-settings-hotfix(Nov 2017) which follows an old
 # requirements installation strategy. This file would go away in favor of 'setup-platform-env' once we figure out the


### PR DESCRIPTION
The exporter recently failed to do a pip install but kept running. This led to all of the worker jobs have incorrectly set up environments and eventually sending all partner orgs with empty data packages.