### PR TITLE
fix: fix the vault login race condition

### DIFF
--- a/dataeng/resources/prefect-flows-deployment.sh
+++ b/dataeng/resources/prefect-flows-deployment.sh
@@ -20,11 +20,13 @@ aws ecr get-login-password --region us-east-1 | docker login --username AWS --pa
 # The following statement will help us to determine if repository already exists otherwise it will create a new repository with the name of flow
 aws ecr describe-repositories --repository-names $FLOW_NAME --region us-east-1 || aws ecr create-repository --repository-name $FLOW_NAME --region us-east-1
 
-# Preparing to Autheticate with Prefect Cloud by getting token from Vault
-vault write -field=token auth/approle/login \
-  role_id=${ANALYTICS_VAULT_ROLE_ID} \
-  secret_id=${ANALYTICS_VAULT_SECRET_ID} \
-| vault login -no-print token=-
+# Retrieve a vault token corresponding to the jenkins AppRole.  The token is then stored in the VAULT_TOKEN variable
+# which is implicitly used by subsequent vault commands within this script.
+# Instructions followed: https://learn.hashicorp.com/tutorials/vault/approle#step-4-login-with-roleid-secretid
+VAULT_TOKEN=$(vault write -field=token auth/approle/login \
+    role_id=${ANALYTICS_VAULT_ROLE_ID} \
+    secret_id=${ANALYTICS_VAULT_SECRET_ID}
+)
 
 PREFECT_CLOUD_AGENT_TOKEN=$(
   vault kv get \

--- a/dataeng/resources/remote-config.sh
+++ b/dataeng/resources/remote-config.sh
@@ -91,10 +91,14 @@ unassume_role
 #         usernamePassword('ANALYTICS_VAULT_ROLE_ID', 'ANALYTICS_VAULT_SECRET_ID', 'analytics-vault');
 #     }
 # }
-vault write -field=token auth/approle/login \
+#
+# Retrieve a vault token corresponding to the jenkins AppRole.  The token is then stored in the VAULT_TOKEN variable
+# which is implicitly used by subsequent vault commands within this script.
+# Instructions followed: https://learn.hashicorp.com/tutorials/vault/approle#step-4-login-with-roleid-secretid
+VAULT_TOKEN=$(vault write -field=token auth/approle/login \
     role_id=${ANALYTICS_VAULT_ROLE_ID} \
-    secret_id=${ANALYTICS_VAULT_SECRET_ID} \
-| vault login -no-print token=-
+    secret_id=${ANALYTICS_VAULT_SECRET_ID}
+)
 
 # For each deployment, fetch the appropriate decryption keys from Vault and decrypt lms and studio configs.
 for DEPLOYMENT in edx edge; do


### PR DESCRIPTION
We used to take the retrieved vault token, then pass it into `vault login` which persists the token in a shared path under the home directory.  That creates a race condition in which multiple jenkins builds could clobber each other's "/home/jenkins/.vault-token.tmp" files.  Furthermore, jenkins jobs could also end up using each-other's temporary vault tokens if the timing lines up.

This new approach keeps each vault login session isolated within each build environment by not relying on a file to persist the token, but rather an environment variable.