### PR TITLE
fix: update edx-app-android path to openedx

### DIFF
--- a/mobileApp/jobs/edxAppAndroidPr.groovy
+++ b/mobileApp/jobs/edxAppAndroidPr.groovy
@@ -68,7 +68,7 @@ pipelineJob('edx-app-android-build') {
                 git {
                     remote {
                         credentials('jenkins-worker')
-                        github('edx/edx-app-android', 'https', 'github.com')
+                        github('openedx/edx-app-android', 'https', 'github.com')
                         refspec('+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*')
                     }
                     branch('\${sha1}')


### PR DESCRIPTION
**Description**

Update GitHub repo path to openedx for [edx-app-android](https://github.com/openedx/edx-app-android/) because after moving the repository to openedx [android-jenkins](https://build.testeng.edx.org/job/edx-app-android-build/) jobs are not running.