### PR TITLE
build: bind transifex auth token in python cleanup job

### DIFF
--- a/testeng/jobs/cleanupPythonCode.groovy
+++ b/testeng/jobs/cleanupPythonCode.groovy
@@ -66,6 +66,7 @@ job('cleanup-python-code') {
         credentialsBinding {
             string('GITHUB_TOKEN', 'GITHUB_REQUIREMENTS_BOT_TOKEN')
             string('GITHUB_USER_EMAIL', 'GITHUB_REQUIREMENTS_BOT_EMAIL')
+            string('TRANSIFEX_AUTH_TOKEN', 'TRANSIFEX_AUTH_TOKEN')
         }
         timestamps()
     }


### PR DESCRIPTION
## Description
- Binding the `TRANSIFEX_AUTH_TOKEN` needed to run the cleanup job for transifex commands api v3.