### PR TITLE
build: Add usamasadiq as user_reviewer in cleanup job

### DIFF
--- a/testeng/jobs/cleanupPythonCode.groovy
+++ b/testeng/jobs/cleanupPythonCode.groovy
@@ -1,4 +1,4 @@
-githubUserReviewers = []
+githubUserReviewers = ['usamasadiq']
 
 githubTeamReviewers = ['arbi-bom']
 


### PR DESCRIPTION
Keeping the UserReviewers list empty causes the cleanup job to fail. 
Adding user `usamasadiq` as reviewer as a temporary fix. This'll be changed to tag the person  triggering the job later on. 