### PR TITLE
fix: change ssl-expiration-check job to look at monitoring scripts repo

### DIFF
--- a/devops/jobs/SSLExpirationCheck.groovy
+++ b/devops/jobs/SSLExpirationCheck.groovy
@@ -52,9 +52,9 @@ class SSLExpirationCheck{
                             'Git repo containing edX configuration.')
                     stringParam('CONFIGURATION_BRANCH', extraVars.get('CONFIGURATION_BRANCH', 'master'),
                             'e.g. tagname or origin/branchname')
-                    stringParam('SYSADMIN_REPO', extraVars.get('SYSADMIN_REPO'),
-                            'Git repo containing sysadmin configuration which contains the ssl expiration check script.')
-                    stringParam('SYSADMIN_BRANCH', extraVars.get('SYSADMIN_BRANCH', 'master'),
+                    stringParam('MONITORING_SCRIPTS_REPO', extraVars.get('MONITORING_SCRIPTS_REPO', 'https://github.com/edx/monitoring-scripts'),
+                            'Git repo containing edX monitoring scripts, which contains the ssl expiration check script.')
+                    stringParam('MONITORING_SCRIPTS_BRANCH', extraVars.get('MONITORING_SCRIPTS_BRANCH', 'master'),
                             'e.g. tagname or origin/branchname')
                     stringParam('TO_ADDRESS', extraVars.get('TO_ADDRESS', ""))
                     stringParam('FROM_ADDRESS', extraVars.get('FROM_ADDRESS', ""))
@@ -74,8 +74,8 @@ class SSLExpirationCheck{
                     }
                     git {
                         remote {
-                            url('$SYSADMIN_REPO')
-                            branch('$SYSADMIN_BRANCH')
+                            url('$MONITORING_SCRIPTS_REPO')
+                            branch('$MONITORING_SCRIPTS_BRANCH')
                             if (gitCredentialId) {
                                 credentials(gitCredentialId)
                             }
@@ -83,7 +83,7 @@ class SSLExpirationCheck{
                         extensions {
                             cleanAfterCheckout()
                             pruneBranches()
-                            relativeTargetDirectory('sysadmin')
+                            relativeTargetDirectory('monitoring-scripts')
                         }
                     }
                 }

--- a/devops/resources/ssl-expiration-check.sh
+++ b/devops/resources/ssl-expiration-check.sh
@@ -20,9 +20,9 @@ pip install -r requirements.txt
 
 assume-role ${ROLE_ARN}
 
-cd $WORKSPACE/sysadmin
+cd $WORKSPACE/monitoring-scripts
 pip install -r requirements/base.txt
-cd jenkins
+cd ssl_expiration_check
 
 if [[ -n "${FROM_ADDRESS}" && "${TO_ADDRESS}" ]]; then
 	python ssl-expiration-check.py --region $REGION -d $DAYS  -r $TO_ADDRESS -f $FROM_ADDRESS


### PR DESCRIPTION
Updates SSL expiration check jenkins job to look at the monitoring scripts repo instead of the sysadmin repo. Part of PSRE-1440: https://openedx.atlassian.net/browse/PSRE-1440