### PR TITLE
Revert "Hamza442/deng 1140"

### DIFF
--- a/dataeng/resources/prefect-flows-deployment.sh
+++ b/dataeng/resources/prefect-flows-deployment.sh
@@ -21,13 +21,10 @@ aws ecr get-login-password --region us-east-1 | docker login --username AWS --pa
 aws ecr describe-repositories --repository-names $FLOW_NAME --region us-east-1 || aws ecr create-repository --repository-name $FLOW_NAME --region us-east-1
 
 # Preparing to Autheticate with Prefect Cloud by getting token from Vault
-# Retrieve a vault token corresponding to the jenkins AppRole.  The token is then stored in the VAULT_TOKEN variable
-# which is implicitly used by subsequent vault commands within this script.
-# Instructions followed: https://learn.hashicorp.com/tutorials/vault/approle#step-4-login-with-roleid-secretid
-VAULT_TOKEN=$(vault write -field=token auth/approle/login \
-     role_id=${ANALYTICS_VAULT_ROLE_ID} \
-     secret_id=${ANALYTICS_VAULT_SECRET_ID}
- )
+vault write -field=token auth/approle/login \
+  role_id=${ANALYTICS_VAULT_ROLE_ID} \
+  secret_id=${ANALYTICS_VAULT_SECRET_ID} \
+| vault login -no-print token=-
 
 # Avoid printing console logs that contains secrets
 set +x

--- a/dataeng/resources/remote-config.sh
+++ b/dataeng/resources/remote-config.sh
@@ -91,13 +91,10 @@ unassume_role
 #         usernamePassword('ANALYTICS_VAULT_ROLE_ID', 'ANALYTICS_VAULT_SECRET_ID', 'analytics-vault');
 #     }
 # }
-# Retrieve a vault token corresponding to the jenkins AppRole.  The token is then stored in the VAULT_TOKEN variable
-# which is implicitly used by subsequent vault commands within this script.
-# Instructions followed: https://learn.hashicorp.com/tutorials/vault/approle#step-4-login-with-roleid-secretid
-VAULT_TOKEN=$(vault write -field=token auth/approle/login \
-     role_id=${ANALYTICS_VAULT_ROLE_ID} \
-     secret_id=${ANALYTICS_VAULT_SECRET_ID}
- )
+vault write -field=token auth/approle/login \
+    role_id=${ANALYTICS_VAULT_ROLE_ID} \
+    secret_id=${ANALYTICS_VAULT_SECRET_ID} \
+| vault login -no-print token=-
 
 # For each deployment, fetch the appropriate decryption keys from Vault and decrypt lms and studio configs.
 for DEPLOYMENT in edx edge; do


### PR DESCRIPTION
Reverts edx/jenkins-job-dsl#1536

Unfortunately, the fix for the vault race condition is causing jobs to fail. All of the exporter worker jobs are failing with the following message (which was what we saw the first time we tried to roll out this change):
```
04:26:37+00:00 Error making API request.
04:26:37+00:00 
04:26:37+00:00 URL: GET <redacted>
04:26:37+00:00 Code: 403. Errors:
04:26:37+00:00 
04:26:37+00:00 * permission denied
```
We didn't see this until just now, because the change in https://github.com/edx/jenkins-job-dsl/pull/1536 wasn't seeded on Jenkins until 4/1.