### PR TITLE
feat: adding token helper and vault-config

### DIFF
--- a/dataeng/jobs/analytics/AnalyticsExporter.groovy
+++ b/dataeng/jobs/analytics/AnalyticsExporter.groovy
@@ -99,7 +99,7 @@ class AnalyticsExporter {
                 stringParam('ORG')
                 stringParam('PLATFORM_VENV')
                 stringParam('EXTRA_OPTIONS')
-            }
+                stringParam('JOB_DSL_BRANCH','master', 'Branch to use for the jenkins-job-dsl repository.')            }
             parameters secure_scm_parameters(allVars)
 
             environmentVariables {
@@ -124,7 +124,19 @@ class AnalyticsExporter {
 
             concurrentBuild()
 
-            multiscm secure_scm(allVars)
+            multiscm secure_scm(allVars) << {
+                git {
+                    remote {
+                        url('git@github.com:edx/jenkins-job-dsl.git')
+                        branch('$JOB_DSL_BRANCH')
+                        credentials('1')
+                    }
+                    extensions {
+                        pruneBranches()
+                        relativeTargetDirectory('jenkins-job-dsl')
+                    }
+                }
+            }
 
             wrappers {
                 timestamps()
@@ -177,7 +189,8 @@ class AnalyticsExporter {
                 stringParam('ORG_CONFIG', 'data-czar-keys/config.yaml', 'Path to the data-czar organization config file.')
                 stringParam('DATA_CZAR_KEYS_BRANCH', 'master', 'Branch to use for the data-czar-keys repository.')
                 stringParam('PRIORITY_ORGS', allVars.get('PRIORITY_ORGS'), 'Space separated list of organizations to process first.')
-                stringParam('JOB_DSL_BRANCH', 'origin/master', 'Branch from the jenkins job dsl repository to get vault token helper.')
+                
+
             }
             parameters secure_scm_parameters(allVars)
             environmentVariables {
@@ -219,7 +232,7 @@ class AnalyticsExporter {
                         relativeTargetDirectory('data-czar-keys')
                     }
                 }
-
+                
             }
 
             triggers{

--- a/dataeng/jobs/analytics/AnalyticsExporter.groovy
+++ b/dataeng/jobs/analytics/AnalyticsExporter.groovy
@@ -99,7 +99,8 @@ class AnalyticsExporter {
                 stringParam('ORG')
                 stringParam('PLATFORM_VENV')
                 stringParam('EXTRA_OPTIONS')
-                stringParam('JOB_DSL_BRANCH','master', 'Branch to use for the jenkins-job-dsl repository.')            }
+                stringParam('JOB_DSL_BRANCH','master', 'Branch to use for the jenkins-job-dsl repository.')            
+            }
             parameters secure_scm_parameters(allVars)
 
             environmentVariables {
@@ -129,7 +130,6 @@ class AnalyticsExporter {
                     remote {
                         url('git@github.com:edx/jenkins-job-dsl.git')
                         branch('$JOB_DSL_BRANCH')
-                        credentials('1')
                     }
                     extensions {
                         pruneBranches()
@@ -189,8 +189,6 @@ class AnalyticsExporter {
                 stringParam('ORG_CONFIG', 'data-czar-keys/config.yaml', 'Path to the data-czar organization config file.')
                 stringParam('DATA_CZAR_KEYS_BRANCH', 'master', 'Branch to use for the data-czar-keys repository.')
                 stringParam('PRIORITY_ORGS', allVars.get('PRIORITY_ORGS'), 'Space separated list of organizations to process first.')
-                
-
             }
             parameters secure_scm_parameters(allVars)
             environmentVariables {

--- a/dataeng/jobs/analytics/AnalyticsExporter.groovy
+++ b/dataeng/jobs/analytics/AnalyticsExporter.groovy
@@ -17,7 +17,6 @@ class AnalyticsExporter {
                 stringParam('NOTIFY', '', 'Space separated list of emails to notify in case of failure.')
                 stringParam('DATE_MODIFIER', '', 'Used to set the date of the CWSM dump.  Leave blank to use today\'s date.  Set to "-d 202x-0x-0x" if that is when the CWSM dump took place.  (Leave off quotes.)')
                 stringParam('TASKS', '', 'Space separated list of tasks to process. Leave this blank to use the task list specified in the config file.  Specify here only if you are running tests of a specific task.')
-                stringParam('JOB_DSL_BRANCH', 'origin/master', 'Branch from the jenkins job dsl repository to get vault token helper.')
             }
             parameters secure_scm_parameters(allVars)
 
@@ -55,17 +54,7 @@ class AnalyticsExporter {
                         relativeTargetDirectory('analytics-exporter')
                     }
                 }
-                git {
-                    remote {
-                        url('git@github.com:edx/jenkins-job-dsl.git')
-                        branch('$JOB_DSL_BRANCH')
-                        credentials('1')
-                    }
-                    extensions {
-                        pruneBranches()
-                        relativeTargetDirectory('jenkins-job-dsl')
-                    }
-                }
+
             }
 
             wrappers {
@@ -78,13 +67,6 @@ class AnalyticsExporter {
             steps {
                 // This will create python 3.8 venv inside shell script instead of using shiningpanda
                 shell(dslFactory.readFileFromWorkspace('dataeng/resources/setup-platform-venv-py3.sh'))
-                virtualenv {
-                    pythonName('PYTHON_3.7')
-                    nature("shell")
-                    command(
-                        dslFactory.readFileFromWorkspace("dataeng/resources/vault-config.sh")
-                    )
-                }
                 virtualenv {
                     pythonName('PYTHON_3.7')
                     nature("shell")

--- a/dataeng/jobs/analytics/AnalyticsExporter.groovy
+++ b/dataeng/jobs/analytics/AnalyticsExporter.groovy
@@ -17,6 +17,7 @@ class AnalyticsExporter {
                 stringParam('NOTIFY', '', 'Space separated list of emails to notify in case of failure.')
                 stringParam('DATE_MODIFIER', '', 'Used to set the date of the CWSM dump.  Leave blank to use today\'s date.  Set to "-d 202x-0x-0x" if that is when the CWSM dump took place.  (Leave off quotes.)')
                 stringParam('TASKS', '', 'Space separated list of tasks to process. Leave this blank to use the task list specified in the config file.  Specify here only if you are running tests of a specific task.')
+                stringParam('JOB_DSL_BRANCH', 'origin/master', 'Branch from the jenkins job dsl repository to get vault token helper.')
             }
             parameters secure_scm_parameters(allVars)
 
@@ -54,6 +55,17 @@ class AnalyticsExporter {
                         relativeTargetDirectory('analytics-exporter')
                     }
                 }
+                git {
+                    remote {
+                        url('git@github.com:edx/jenkins-job-dsl.git')
+                        branch('$JOB_DSL_BRANCH')
+                        credentials('1')
+                    }
+                    extensions {
+                        pruneBranches()
+                        relativeTargetDirectory('jenkins-job-dsl')
+                    }
+                }
             }
 
             wrappers {
@@ -66,6 +78,13 @@ class AnalyticsExporter {
             steps {
                 // This will create python 3.8 venv inside shell script instead of using shiningpanda
                 shell(dslFactory.readFileFromWorkspace('dataeng/resources/setup-platform-venv-py3.sh'))
+                virtualenv {
+                    pythonName('PYTHON_3.7')
+                    nature("shell")
+                    command(
+                        dslFactory.readFileFromWorkspace("dataeng/resources/vault-config.sh")
+                    )
+                }
                 virtualenv {
                     pythonName('PYTHON_3.7')
                     nature("shell")
@@ -138,6 +157,13 @@ class AnalyticsExporter {
                     pythonName('PYTHON_3.7')
                     nature("shell")
                     command(
+                        dslFactory.readFileFromWorkspace("dataeng/resources/vault-config.sh")
+                    )
+                }
+                virtualenv {
+                    pythonName('PYTHON_3.7')
+                    nature("shell")
+                    command(
                         dslFactory.readFileFromWorkspace("dataeng/resources/remote-config.sh")
                     )
                 }
@@ -169,6 +195,7 @@ class AnalyticsExporter {
                 stringParam('ORG_CONFIG', 'data-czar-keys/config.yaml', 'Path to the data-czar organization config file.')
                 stringParam('DATA_CZAR_KEYS_BRANCH', 'master', 'Branch to use for the data-czar-keys repository.')
                 stringParam('PRIORITY_ORGS', allVars.get('PRIORITY_ORGS'), 'Space separated list of organizations to process first.')
+                stringParam('JOB_DSL_BRANCH', 'origin/master', 'Branch from the jenkins job dsl repository to get vault token helper.')
             }
             parameters secure_scm_parameters(allVars)
             environmentVariables {
@@ -210,6 +237,7 @@ class AnalyticsExporter {
                         relativeTargetDirectory('data-czar-keys')
                     }
                 }
+
             }
 
             triggers{

--- a/dataeng/resources/remote-config.sh
+++ b/dataeng/resources/remote-config.sh
@@ -91,10 +91,17 @@ unassume_role
 #         usernamePassword('ANALYTICS_VAULT_ROLE_ID', 'ANALYTICS_VAULT_SECRET_ID', 'analytics-vault');
 #     }
 # }
+# set path for config file which store token in each job workspace
+export VAULT_CONFIG_PATH= ${WORKSPACE}/vault-config/vault_config
+
+# write credentials to vault server to get the token
 vault write -field=token auth/approle/login \
     role_id=${ANALYTICS_VAULT_ROLE_ID} \
     secret_id=${ANALYTICS_VAULT_SECRET_ID} \
 | vault login -no-print token=-
+
+# set vault token 
+export VAULT_TOKEN="$(cat ${WORKSPACE}/vault-config/vault-token)"
 
 # For each deployment, fetch the appropriate decryption keys from Vault and decrypt lms and studio configs.
 for DEPLOYMENT in edx edge; do
@@ -122,3 +129,6 @@ for DEPLOYMENT in edx edge; do
     # for some reason.
     rm ${DECRYPTION_KEY_PATH}
 done
+
+# remove the persisted token vault configs
+rm -rf ${WORKSPACE}/vault-config

--- a/dataeng/resources/remote-config.sh
+++ b/dataeng/resources/remote-config.sh
@@ -92,7 +92,7 @@ unassume_role
 #     }
 # }
 # set path for config file which store token in each job workspace
-export VAULT_CONFIG_PATH= ${WORKSPACE}/vault-config/vault_config
+export VAULT_CONFIG_PATH=${WORKSPACE}/vault-config/vault_config
 
 # write credentials to vault server to get the token
 vault write -field=token auth/approle/login \

--- a/dataeng/resources/remote-config.sh
+++ b/dataeng/resources/remote-config.sh
@@ -100,7 +100,18 @@ vault write -field=token auth/approle/login \
     secret_id=${ANALYTICS_VAULT_SECRET_ID} \
 | vault login -no-print token=-
 
-# set vault token 
+
+# set vault token
+
+# Creating separate token for each job in its workspace
+# By default token is generated in home directory of server
+# When token location is changed using VAULT_CONFIG_PATH vault cli
+# should find the new location of token using the vault config file
+# This is the expected behaviour for vault cli. But vault cli was
+# not working as expected and is not able to locate the new token location
+# Have to explicitly store token in token environment variable so that
+# vault cli can use the newly generated token for each job
+
 export VAULT_TOKEN="$(cat ${WORKSPACE}/vault-config/vault-token)"
 
 # For each deployment, fetch the appropriate decryption keys from Vault and decrypt lms and studio configs.

--- a/dataeng/resources/token-helper.py
+++ b/dataeng/resources/token-helper.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     # get jobs worspace path
     workspace = os.environ['WORKSPACE']
     # path to store token   
-    PATH=workspace+"/vault-token"
+    PATH=workspace+"/vault-config/vault-token"
     
     args = sys.argv[1:][0]
     

--- a/dataeng/resources/token-helper.py
+++ b/dataeng/resources/token-helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 A vault token helper to change the default location for vault token.
@@ -6,6 +6,11 @@ By default vault writes token to home direcotry of the server. This
 creates a race condition when multiple jobs try to access the token
 in parallel. In order to avoid it generating a separate token for 
 each job in its workspace.
+
+Documentation Reference:
+https://www.vaultproject.io/docs/commands/token-helper
+https://www.hashicorp.com/blog/building-a-vault-token-helper
+
 """
 
 import sys

--- a/dataeng/resources/token-helper.py
+++ b/dataeng/resources/token-helper.py
@@ -57,5 +57,3 @@ if __name__ == "__main__":
     else:
         print("Unknown method {}".format(args))
         exit(1)
-
-

--- a/dataeng/resources/token-helper.py
+++ b/dataeng/resources/token-helper.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python
+
+"""
+A vault token helper to change the default location for vault token.
+By default vault writes token to home direcotry of the server. This
+creates a race condition when multiple jobs try to access the token
+in parallel. In order to avoid it generating a separate token for 
+each job in its workspace.
+"""
+
+import sys
+import os.path
+
+
+def get(PATH):
+    
+    if os.path.exists(PATH):
+      token = open(PATH,"r")
+      token = token.read().strip()
+      
+    
+def store(PATH):
+    
+    with open(PATH,"wb+") as f:
+        for token in sys.stdin:
+            f.write(token.strip())
+            
+    
+def erase(PATH):
+
+    if os.path.exists(PATH):
+        os.remove(PATH)
+
+if __name__ == "__main__":
+
+    # get jobs worspace path
+    workspace = os.environ['WORKSPACE']
+    # path to store token   
+    PATH=workspace+"/vault-token"
+    
+    args = sys.argv[1:][0]
+    
+    if args == "get":
+        get(PATH)
+
+    elif args == "erase":
+        erase(PATH)
+
+    elif args == "store":
+        store(PATH)
+        
+    else:
+        print("Unknown method {}".format(args))
+        exit(1)
+
+

--- a/dataeng/resources/vault-config.sh
+++ b/dataeng/resources/vault-config.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+
+# make a directory to store vault token helper and config file
+mkdir ${WORKSPACE}/vault-config
+# get token helper from repo
+cp ${WORKSPACE}/jenkins-job-dsl/dataeng/resources/token-helper.py ${WORKSPACE}/vault-config/token-helper.py
+# remove the repo after getting token helper
+rm -rf ${WORKSPACE}/jenkins-job-dsl
+# create path for helper
+path_to_helper = ${WORKSPACE}"/vault-config/token-helper.py"
+# set up config for config file
+token_config = "$(echo token_helper = \"$path_to_helper\" )"
+# create the config file
+echo $token_config >> ${WORKSPACE}/vault-config/vault_config

--- a/dataeng/resources/vault-config.sh
+++ b/dataeng/resources/vault-config.sh
@@ -7,7 +7,8 @@
 # multiple jobs access the token in parallel, which was causing login failure for several chlid jobs
 # Now creating separate token for each job in its workspace so that each job can use its own token
 
-
+# making sure there is no vault config for new job 
+rm -rf ${WORKSPACE}/vault-config
 # make a directory to store vault token helper and config file
 mkdir ${WORKSPACE}/vault-config
 # create path for helper

--- a/dataeng/resources/vault-config.sh
+++ b/dataeng/resources/vault-config.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
 
+# This script will create a vault_config file.
+# This config file is used to change the defualt location where vault token is stored.
+# By default vault token is stored in home directory of server, this config file will change this behaviour 
+# When token was stored at home directory of the server that was creating race condition when
+# multiple jobs access the token in parallel, which was causing login failure for several chlid jobs
+# Now creating separate token for each job in its workspace so that each job can use its own token
+
 
 # make a directory to store vault token helper and config file
 mkdir ${WORKSPACE}/vault-config
-# get token helper from repo
-cp ${WORKSPACE}/jenkins-job-dsl/dataeng/resources/token-helper.py ${WORKSPACE}/vault-config/token-helper.py
-# remove the repo after getting token helper
-rm -rf ${WORKSPACE}/jenkins-job-dsl
 # create path for helper
-path_to_helper = ${WORKSPACE}"/vault-config/token-helper.py"
+path_to_helper = ${WORKSPACE}"/jenkins-job-dsl/dataeng/resources/token-helper.py"
 # set up config for config file
 token_config = "$(echo token_helper = \"$path_to_helper\" )"
 # create the config file


### PR DESCRIPTION
The Following changes have been made to avoid race condition in analytics exporter job.
1 - A token helper with name token-helper.py has been added to resources folder in Jenkins job dsl repo, this token helper allow us to create a separate token for each worker job.
2 - A vault-config.sh file has been added this file will help to setup configuration for vault cli to use the token helper (token-helper.py)
3 - Since token-helper.py is added to resources folder of Jenkins-job-dsl repo. Need to clone this repo to get the token helper, need to provide exact path  for token helper to enable vault cli to locate it