### PR TITLE
Use job dsl disabled method in more scripts to allow disabling jobs via config

### DIFF
--- a/dataeng/jobs/analytics/AggregateDailyTrackingLogs.groovy
+++ b/dataeng/jobs/analytics/AggregateDailyTrackingLogs.groovy
@@ -12,6 +12,7 @@ class AggregateDailyTrackingLogs {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("aggregate-daily-tracking-logs-$environment") {
+                disabled(env_config.get('DISABLED', false))
                 logRotator common_log_rotator(allVars, env_config)
                 parameters to_date_interval_parameter(env_config)
                 parameters common_parameters(allVars, env_config)

--- a/dataeng/jobs/analytics/DatabaseExportCoursewareStudentmodule.groovy
+++ b/dataeng/jobs/analytics/DatabaseExportCoursewareStudentmodule.groovy
@@ -11,6 +11,7 @@ class DatabaseExportCoursewareStudentmodule {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("database-export-courseware-studentmodule-$environment") {
+                disabled(env_config.get('DISABLED', false))
                 logRotator common_log_rotator(allVars, env_config)
                 multiscm common_multiscm(allVars)
                 triggers common_triggers(allVars, env_config)

--- a/dataeng/jobs/analytics/EnrollmentValidationEvents.groovy
+++ b/dataeng/jobs/analytics/EnrollmentValidationEvents.groovy
@@ -12,6 +12,7 @@ class EnrollmentValidationEvents {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("enrollment-validation-events-$environment") {
+                disabled(env_config.get('DISABLED', false))
                 logRotator common_log_rotator(allVars)
                 parameters common_parameters(allVars, env_config)
                 parameters from_date_interval_parameter(allVars)

--- a/dataeng/jobs/analytics/Enterprise.groovy
+++ b/dataeng/jobs/analytics/Enterprise.groovy
@@ -11,6 +11,7 @@ class Enterprise {
     public static def job = { dslFactory, allVars ->
         allVars.get('JOBS').each { job, job_config ->
             dslFactory.job("enterprise-$job") {
+                disabled(job_config.get('DISABLED', false))
                 authorization common_authorization(allVars)
                 logRotator common_log_rotator(allVars)
                 parameters common_parameters(allVars, job_config)

--- a/dataeng/jobs/analytics/EventExportIncremental.groovy
+++ b/dataeng/jobs/analytics/EventExportIncremental.groovy
@@ -14,6 +14,7 @@ class EventExportIncremental {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("event-export-incremental-$environment") {
+                disabled(env_config.get('DISABLED', false))
                 logRotator common_log_rotator(allVars, env_config)
                 parameters common_parameters(allVars, env_config)
                 parameters from_date_interval_parameter(allVars)

--- a/dataeng/jobs/analytics/EventExportIncrementalLarge.groovy
+++ b/dataeng/jobs/analytics/EventExportIncrementalLarge.groovy
@@ -15,6 +15,7 @@ class EventExportIncrementalLarge {
     public static def job = { dslFactory, allVars ->
         allVars.get('ENVIRONMENTS').each { environment, env_config ->
             dslFactory.job("event-export-incremental-large-$environment") {
+                disabled(env_config.get('DISABLED', false))
                 authorization common_authorization(allVars)
                 logRotator common_log_rotator(allVars, env_config)
                 parameters common_parameters(allVars, env_config)

--- a/dataeng/jobs/analytics/ReadReplicaExportToS3.groovy
+++ b/dataeng/jobs/analytics/ReadReplicaExportToS3.groovy
@@ -12,6 +12,7 @@ class ReadReplicaExportToS3 {
     public static def job = { dslFactory, allVars ->
         allVars.get('READ_REPLICA_EXPORTS').each { db, db_config ->
             dslFactory.job("${db.toLowerCase()}-read-replica-export-to-s3") {
+                disabled(db_config.get('DISABLED', false))
                 logRotator common_log_rotator(allVars)
                 parameters common_parameters(allVars, db_config)
                 parameters {

--- a/dataeng/jobs/analytics/SnowflakeReplicaImportFromS3.groovy
+++ b/dataeng/jobs/analytics/SnowflakeReplicaImportFromS3.groovy
@@ -45,6 +45,7 @@ class SnowflakeReplicaImportFromS3 {
 
         jobConfigs.each { appName, jobConfig ->
             dslFactory.job("snowflake-${appName.toLowerCase()}-read-replica-import-from-s3") {
+                disabled(jobConfig.get('DISABLED', false))
                 logRotator common_log_rotator(allVars)
                 parameters common_parameters(allVars, jobConfig)
                 parameters {


### PR DESCRIPTION
The PR updates many job definition scripts with the `disabled` method to fetch a job disabling config from passed configurations.