### PR TITLE
Revert back to using service accounts to clean up drive files

### DIFF
--- a/dataeng/resources/retirement-partner-report-cleanup.sh
+++ b/dataeng/resources/retirement-partner-report-cleanup.sh
@@ -17,16 +17,7 @@ pip install 'pip==21.0.1' 'setuptools==53.0.0'
 pip install -r requirements.txt
 
 # Call the script to cleanup the reports
-# This section is for long term use
-# python scripts/delete_expired_partner_gdpr_reports.py \
-#     --config_file=$WORKSPACE/user-retirement-secure/$ENVIRONMENT.yml \
-#     --google_secrets_file=$WORKSPACE/user-retirement-secure/google-service-accounts/service-account-$ENVIRONMENT.json \
-#     --age_in_days=$AGE_IN_DAYS
-# This line is for use until 2022-05-13. Please make sure to uncomment
-# the script invocation above to make sure we revert back to using service accounts.
-# Please see DENG-1215 for more information
 python scripts/delete_expired_partner_gdpr_reports.py \
     --config_file=$WORKSPACE/user-retirement-secure/$ENVIRONMENT.yml \
-    --google_secrets_file=$WORKSPACE/user-retirement-secure/google-service-accounts/no-reply-user-oauth2-token.json \
-    --age_in_days=$AGE_IN_DAYS \
-    --as_user_account
+    --google_secrets_file=$WORKSPACE/user-retirement-secure/google-service-accounts/service-account-$ENVIRONMENT.json \
+    --age_in_days=$AGE_IN_DAYS


### PR DESCRIPTION
There are no more drive files to delete using a user account after this morning's build. We can go back to using service accounts across all the retirement jobs.