### PR TITLE
chore: Increase timeout threshold on sandbox creation

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -37,7 +37,7 @@ class CreateSandbox {
                 buildName('#${BUILD_NUMBER} ${ENV,var="BUILD_USER_ID"} ${ENV,var="dns_name"}')
 
                 timeout {
-                    absolute(120)
+                    absolute(210)
                     failBuild()
                 }
             }


### PR DESCRIPTION
Sandboxes created for prospectus may be taking more than 2h and sometimes they fail because they time out at 2h. 

This PR increases the threshold to 3.5h to give the sandbox more time to build successfully.