### PR TITLE
Update job creation scripts to show correct YAML parsing errors

### DIFF
--- a/dataeng/jobs/createJobs.groovy
+++ b/dataeng/jobs/createJobs.groovy
@@ -75,7 +75,7 @@ for (task in taskMap) {
         extraVars = yaml.load(extraVarsContents)
     }
     catch (Exception e) {
-        out.println("File $extraVarsFileName does not exist.")
+        out.println("Unable to parse the extra variables file ${extraVarsFileName}: ${e.message}")
     }
 
     task.value(this, commonConfigMap + extraVars)

--- a/dataeng/jobs/createJobsNew.groovy
+++ b/dataeng/jobs/createJobsNew.groovy
@@ -72,7 +72,7 @@ for (task in taskMap) {
         extraVars = yaml.load(extraVarsContents)
     }
     catch (Exception e) {
-        out.println("File $extraVarsFileName does not exist.")
+        out.println("Unable to parse the extra variables file ${extraVarsFileName}: ${e.message}")
     }
 
     task.value(this, commonConfigMap + extraVars)


### PR DESCRIPTION
This updates the job creation scripts to display the correct error messages whenever an extra vars file fails to parse.