### PR TITLE
chore: Clear docker build cache.

### DIFF
--- a/dataeng/resources/prefect-flows-deployment.sh
+++ b/dataeng/resources/prefect-flows-deployment.sh
@@ -14,6 +14,10 @@ FLOW_NAME=$(echo $JOB_NAME | cut -c 26-)
 cd $WORKSPACE/prefect-flows
 pip install -r requirements.txt
 
+# Clear docker build cache so that it picks new changes and don't use cached images
+# https://docs.docker.com/engine/reference/commandline/buildx_prune/
+docker builder prune -af
+
 # Get ECR authetication
 aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ECR_LOGIN
 


### PR DESCRIPTION
After doing a bit of digging find out that we can clear docker cache using **docker build prune** or using **docker image prune**
Right now I am going with **docker build prune** because it easier to implement because in case of **docker image prune** we might have to use additional **--filter** parameter to find out images that are cached. 
After running command **docker image ls -a** on our Jenkins-new server found out that images that have **REPOSITORY** & **TAG** <none> are the cached images.

REPOSITORY   TAG       IMAGE ID       CREATED        SIZE
none                 none    30a6144e1f17   6 days ago     1.6GB
none                 none    a7899d08c95d   6 days ago     1.6GB

I grepped the image id's and matched it with console output on Jenkins server and found out that those images that were getting cached have **REPOSITORY** & **TAG** <none>
https://jenkins-new.analytics.edx.org/job/prefect-flows-deployment-load_cybersource_reports_to_snowflake/6/console

$ docker image ls -a | grep 9d21736b3068
None       None    9d21736b3068   2 weeks ago    912MB
$ docker image ls -a | grep 1086e8ebbcc6
None       None    1086e8ebbcc6   2 weeks ago    930MB
$ docker image ls -a | grep 4cf16f7717bc
None       None    4cf16f7717bc   2 weeks ago    1.17GB
$ docker image ls -a | grep c62b5068aae2
None       None    c62b5068aae2   7 days ago     1.6GB
$ docker image ls -a | grep 25530e01ebc7
None       None    25530e01ebc7   7 days ago     1.6GB
$ docker image ls -a | grep a7899d08c95d
None       None    a7899d08c95d   6 days ago     1.6GB
$ docker image ls -a | grep 30a6144e1f17
None       None    30a6144e1f17   6 days ago     1.6GB

From documents and resources its seems that docker builder will clear cache 
1- https://docs.docker.com/engine/reference/commandline/buildx_prune/
2- https://forums.docker.com/t/clear-docker-cache/110176

**docker build --no-cache** requires a docker file, but in our case we are using prefect provided docker base image so this might not work for us.




