### PR TITLE
chore: prune docker dangling images

### DIFF
--- a/dataeng/resources/prefect-flows-deployment.sh
+++ b/dataeng/resources/prefect-flows-deployment.sh
@@ -14,6 +14,9 @@ FLOW_NAME=$(echo $JOB_NAME | cut -c 26-)
 cd $WORKSPACE/prefect-flows
 pip install -r requirements.txt
 
+# prune unused images
+docker image prune --filter dangling=true -f
+
 # Get ECR authetication
 aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ECR_LOGIN
 


### PR DESCRIPTION
Dangling image just means that you've created the new build of the image, but it wasn't given a new name. So the old images you have becomes the "dangling image". Those old image are the ones that are untagged and displays "<none>" on its name when you run docker images.

This will be a good read : https://www.digitalocean.com/community/tutorials/how-to-remove-docker-images-containers-and-volumes