### PR TITLE
Specify python2 in virtualenv for emr-cost-reporter and deploy-cluster

### DIFF
--- a/dataeng/resources/deploy-cluster.sh
+++ b/dataeng/resources/deploy-cluster.sh
@@ -3,7 +3,7 @@ mkdir -p $VENV_ROOT
 rm -rf $WORKSPACE/logs
 if [ ! -d "$VENV_ROOT/analytics-configuration" ]
 then
-    virtualenv $VENV_ROOT/analytics-configuration
+    virtualenv --python=python2 $VENV_ROOT/analytics-configuration
 fi
 . $VENV_ROOT/analytics-configuration/bin/activate
 make -C analytics-configuration provision.emr

--- a/dataeng/resources/emr-cost-reporter.sh
+++ b/dataeng/resources/emr-cost-reporter.sh
@@ -6,7 +6,7 @@ mkdir -p $VENV_DIR
 
 rm -rf $VENV_DIR/*
 VENV="$VENV_DIR/venv_$BUILD_ID"
-virtualenv $VENV
+virtualenv --python=python2 $VENV
 . $VENV/bin/activate
 
 cd emr-cost-calculator


### PR DESCRIPTION
`emr-cost-reporter` and `deploy-cluster` were invoking `virtualenv` without specifying a python version. On the new Jenkins instance, a simple call to `virtualenv` without specifying a python version with the `--python` option creates a python3 virtual environment. However, these jobs need a python2 virtual environment. This changes fixes that.