### PR TITLE
fix: [PSRE-1830] commerce-coordinator default branch name

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -208,7 +208,7 @@ class CreateSandbox {
                 stringParam("license_manager_version","master","The repository version of the license-manager microservice")
 
                 booleanParam("commerce_coordinator",false,"Enable Commerce Coordinator")
-                stringParam("commerce_coordinator_version","master","The repository version of the commerce-coordinator microservice")
+                stringParam("commerce_coordinator_version","main","The repository version of the commerce-coordinator microservice")
 
 
                 booleanParam("video_pipeline",false,


### PR DESCRIPTION
## Description

The default branch of the commerce-coordinator is main, not master.

This PR changes the default branch for the CreateSandbox Jenkins job so that enabling Commerce Coordinator will by default have the sandbox creation pull from main.

This PR continues work from https://github.com/edx/jenkins-job-dsl/pull/1594.

## Additional information

* Jira: [PSRE-1830](https://2u-internal.atlassian.net/browse/PSRE-1830) Add Commerce Coordinator To Sandbox Jenkins Job
* Related PR: https://github.com/edx/jenkins-job-dsl/pull/1594
* Related ticket: [REV-2841](https://2u-internal.atlassian.net/browse/REV-2841) Plan and request infrastructure to connect Commerce Coordinator and Titan
* Tools Jenkins CreateSandbox build: `/job/sandboxes/job/CreateSandbox/48752/` with error:
    ```
    13:37:15 TASK [git_clone : Checkout code over https] ************************************
    13:37:16 failed: [$SANDBOX_URL] (item=None) => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
    13:37:16 fatal: [$SANDBOX_URL]: FAILED! => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
    ```

## Testing instructions

* [ ] Successfully run test sandbox build manually changing branch parameter to main.