### PR TITLE
fix: bind credentials correctly

### DIFF
--- a/dataeng/jobs/analytics/WarehouseTransforms.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransforms.groovy
@@ -68,11 +68,6 @@ class WarehouseTransforms{
                 wrappers {
                     credentialsBinding {
                         string('OPSGENIE_HEARTBEAT_CONFIG_KEY', 'opsgenie_heartbeat_config_key')
-                    }
-                }
-                wrappers {
-                    timestamps()
-                    credentialsBinding {
                         usernamePassword('ANALYTICS_VAULT_ROLE_ID', 'ANALYTICS_VAULT_SECRET_ID', 'analytics-vault');
                     }
                 }


### PR DESCRIPTION
Currently in **Bindings** of warehouse-transform jobs **OPSGENIE_HEARTBEAT_CONFIG_KEY** is missing. For example: https://jenkins-new.analytics.edx.org/view/dbt/job/warehouse-transforms-google_analytics_sessions/configure in the mentioned job **Bindings** only **ANALYTICS_VAULT_ROLE_ID** and **ANALYTICS_VAULT_SECRET_ID** are present but **OPSGENIE_HEARTBEAT_CONFIG_KEY** is missing. Due to this reason when https://github.com/edx/jenkins-job-dsl/blob/master/dataeng/resources/opsgenie-enable-heartbeat.sh gets executed the key is missing and due to missing key it doesn't add heartbeat to the job. 
Tested the change and now job is adding heart beat : https://jenkins-new.analytics.edx.org/view/dbt/job/warehouse-transforms-google_analytics_sessions/12936/console

**JIRA TICKET**: https://2u-internal.atlassian.net/browse/DENG-1318?atlOrigin=eyJpIjoiOTcxMTBiNTVjMjY3NDFhMmEyYTk2MTdjZjFkZTBjYTUiLCJwIjoiaiJ9