### PR TITLE
fix: Temporarily diable DockerCI jobs

### DIFF
--- a/devops/jobs/AppWatcher.groovy
+++ b/devops/jobs/AppWatcher.groovy
@@ -112,7 +112,8 @@ class AppWatcher {
                         }
                     }
 
-                    triggers { githubPush() }
+// 2022-09-28 jdmulloy: Temporarily disable docker automatic builds due to server overload
+//                    triggers { githubPush() }
 
                     steps {
                         // trigger image-builder job, passing commit checked out of the application code repository 

--- a/devops/jobs/ConfigurationWatcher.groovy
+++ b/devops/jobs/ConfigurationWatcher.groovy
@@ -107,8 +107,9 @@ class ConfigurationWatcher {
                     }
                 }
             }
-            
-            triggers { githubPush() }
+
+// 2022-09-28 jdmulloy: Temporarily disable docker automatic builds due to server overload
+//            triggers { githubPush() }
 
             // run the trigger-builds shell script in a virtual environment called venv
             steps {

--- a/devops/jobs/ImageBuilder.groovy
+++ b/devops/jobs/ImageBuilder.groovy
@@ -120,9 +120,10 @@ class ImageBuilder {
                     }
                 }
 
-                triggers {
-                    cron("H H * * H")
-                }
+// 2022-09-28 jdmulloy: Temporarily disable docker automatic builds due to server overload
+//                triggers {
+//                    cron("H H * * H")
+//                }
 
                 steps {
                     // run the build-push-app shell script in a virtual environment called venv


### PR DESCRIPTION
Temorarily disable automatic triggering of the DockerCI jobs for devstack due to server overload. Need to reduce load to attempt building a few images and debug issues. Builds have been timing out after 90 minutes due to slowness. These build previously completed in about 8 minutes.