### PR TITLE
chore: remove monte carlo env variables.

### DIFF
--- a/dataeng/jobs/analytics/WarehouseTransforms.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransforms.groovy
@@ -51,9 +51,6 @@ class WarehouseTransforms{
                     env('OPSGENIE_HEARTBEAT_NAME', env_config.get('OPSGENIE_HEARTBEAT_NAME'))
                     env('OPSGENIE_HEARTBEAT_DURATION_NUM', env_config.get('OPSGENIE_HEARTBEAT_DURATION_NUM'))
                     env('OPSGENIE_HEARTBEAT_DURATION_UNIT', env_config.get('OPSGENIE_HEARTBEAT_DURATION_UNIT'))
-                    env('MONTE_CARLO_KEYS_VAULT_KV_PATH', allVars.get('MONTE_CARLO_KEYS_VAULT_KV_PATH'))
-                    env('MONTE_CARLO_KEYS_VAULT_KV_VERSION', allVars.get('MONTE_CARLO_KEYS_VAULT_KV_VERSION'))
-                    env('MONTE_CARLO_DBT_MANIFEST_BATCH_SIZE', allVars.get('MONTE_CARLO_DBT_MANIFEST_BATCH_SIZE'))
                 }
                 wrappers common_wrappers(allVars)
                 wrappers {


### PR DESCRIPTION
We are not integrating our warehouse transform jobs with Monte Carlo due to the number of API request limit in Monte Carlo API, so we don't need to keep env variables used for integration