### PR TITLE
chore: Disable Docker CI for old releases

### DIFF
--- a/devops/jobs/AppWatcher.groovy
+++ b/devops/jobs/AppWatcher.groovy
@@ -112,8 +112,9 @@ class AppWatcher {
                         }
                     }
 
-// 2022-09-28 jdmulloy: Temporarily disable docker automatic builds due to server overload
-//                    triggers { githubPush() }
+                    if (! extraVars.get("DISABLE_GH_PUSH", false)){
+                        triggers { githubPush() }
+                    }
 
                     steps {
                         // trigger image-builder job, passing commit checked out of the application code repository 

--- a/devops/jobs/ConfigurationWatcher.groovy
+++ b/devops/jobs/ConfigurationWatcher.groovy
@@ -108,8 +108,9 @@ class ConfigurationWatcher {
                 }
             }
 
-// 2022-09-28 jdmulloy: Temporarily disable docker automatic builds due to server overload
-//            triggers { githubPush() }
+            if (! extraVars.get("DISABLE_GH_PUSH", false)){
+                triggers { githubPush() }
+            }
 
             // run the trigger-builds shell script in a virtual environment called venv
             steps {

--- a/devops/jobs/ImageBuilder.groovy
+++ b/devops/jobs/ImageBuilder.groovy
@@ -120,10 +120,11 @@ class ImageBuilder {
                     }
                 }
 
-// 2022-09-28 jdmulloy: Temporarily disable docker automatic builds due to server overload
-//                triggers {
-//                    cron("H H * * H")
-//                }
+                if (extraVars.containsKey('CRON')) {
+                    triggers {
+                        cron(extraVars.get('CRON'))
+                    }
+                }
 
                 steps {
                     // run the build-push-app shell script in a virtual environment called venv


### PR DESCRIPTION
Running docker builds for these very old openedx releases is overloading our tools jenkins server.