### PR TITLE
fix: Install click for recent users script

### DIFF
--- a/devops/resources/run-app-permissions.sh
+++ b/devops/resources/run-app-permissions.sh
@@ -7,9 +7,10 @@ create_virtualenv --python=python3.8 --clear
 . "$venvpath/bin/activate"
 set -u
 
-cd configuration
+cd $WORKSPACE/configuration
 pip install -r pre-requirements.txt
 pip install -r requirements.txt
+pip install -r util/jenkins/requirements.txt
 
 env
 . util/jenkins/assume-role.sh


### PR DESCRIPTION
recent_users.py needs click to work and the default configuration repo requirements file doesn't include the click library. So we add a requirements file that has click