### PR TITLE
Add docker ci failure notification

### DIFF
--- a/devops/jobs/ImageBuilder.groovy
+++ b/devops/jobs/ImageBuilder.groovy
@@ -131,6 +131,25 @@ class ImageBuilder {
                     shell(dslFactory.readFileFromWorkspace('devops/resources/build-push-app.sh'))
 
                 }
+                publishers {
+
+                extendedEmail {
+                    recipientList(extraVars.get('NOTIFY_ON_FAILURE'))
+                    replyToList(extraVars.get('NOTIFY_ON_FAILURE'))
+                    contentType('text/plain')
+                    defaultSubject('Docker CI Image builder job failed. Check Logs for details')
+                    defaultContent('''\
+                        Docker CI Image builder job failed. Check the logs below for more details.
+                        $BUILD_URL
+                        $BUILD_LOG
+                        
+                        '''.stripIndent())
+
+                        triggers {
+                            failure {}
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## DESC
This PR adds email notifications for docker CI image builder job failures. It uses `NOTIFY_ON_FAILURE` extra var which has been added in this [PR](https://github.com/edx/edx-internal/pull/7528/files) and will be merged before this PR.

**Ticket**: https://github.com/edx/edx-arch-experiments/issues/94