### PR TITLE
chore: remove unused fluentd var

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -298,8 +298,6 @@ class CreateSandbox {
                 booleanParam("run_oauth",true,"")
 
                 stringParam("nginx_users",'[{"name": "{{ COMMON_HTPASSWD_USER }}","password": "{{ COMMON_HTPASSWD_PASS }}","state":"present"}]',"")
-
-                booleanParam("fluentd_logging", false, "This enables a fluentd container which can be used for handling logs from other docker containers")
             }
 
 


### PR DESCRIPTION
## [MST-1729](https://2u-internal.atlassian.net/browse/MST-1729)

After https://github.com/openedx/configuration/pull/6860 was merged, the `fluentd_logging` var is no longer needed, as all code gated by it is now gated by `edxapp_workers_docker_container_enabled`