### PR TITLE
feat: add profile and learner-dashboard to sandbox

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -237,6 +237,12 @@ class CreateSandbox {
                 stringParam("prospectus_version","master","")
                 stringParam("prospectus_contentful_environment","master","")
 
+                booleanParam("profile",false,"Enable Profile MFE")
+                stringParam("profle_version","master","The repository version of the frontend-app-profile mfe")
+
+                booleanParam("learner_dashboard",false,"Enable Learner Dashboard MFE")
+                stringParam("learner_dashboard_version","master","The repository version of the learner dashboard mfe")
+
                 booleanParam("authn",true,"Enable Authn MFE")
                 stringParam("authn_version","master","The repository version of the frontend-app-authn")
 


### PR DESCRIPTION
As part of the frontend plugin POC, we need profile and learner-dashboard in the sandbox.