### PR TITLE
fix: remove pull of edx-secure from mongo_mms job

### DIFF
--- a/devops/jobs/MongoAgentsUpdate.groovy
+++ b/devops/jobs/MongoAgentsUpdate.groovy
@@ -15,10 +15,6 @@ class MongoAgentsUpdate {
                     'Git repo containing internal overrides')
                 stringParam('CONFIGURATION_INTERNAL_BRANCH', extraVars.get('CONFIGURATION_INTERNAL_BRANCH', 'master'),
                     'e.g. tagname or origin/branchname')
-                stringParam('CONFIGURATION_SECURE_REPO', extraVars.get('CONFIGURATION_SECURE_REPO',"git@github.com:edx-ops/edx-secure.git"),
-                    'Secure Git repo .')
-                stringParam('CONFIGURATION_SECURE_BRANCH', extraVars.get('CONFIGURATION_SECURE_BRANCH', 'master'),
-                    'e.g. tagname or origin/branchname')
             }
 
             wrappers common_wrappers
@@ -56,20 +52,6 @@ class MongoAgentsUpdate {
                         cleanAfterCheckout()
                         pruneBranches()
                         relativeTargetDirectory('configuration-internal')
-                    }
-                }
-                git {
-                    remote {
-                        url('$CONFIGURATION_SECURE_REPO')
-                        branch('$CONFIGURATION_SECURE_BRANCH')
-                            if (gitCredentialId) {
-                                credentials(gitCredentialId)
-                            }
-                    }
-                    extensions {
-                        cleanAfterCheckout()
-                        pruneBranches()
-                        relativeTargetDirectory('configuration-secure')
                     }
                 }
             }

--- a/devops/resources/mongo-agents-update.sh
+++ b/devops/resources/mongo-agents-update.sh
@@ -19,4 +19,4 @@ assume-role ${ROLE_ARN}
 set -x
 cd playbooks
 
-ansible-playbook -i ./ec2.py --limit tag_Name_edx-admin-mms mongo_mms.yml -e@../../configuration-internal/ansible/vars/edx.yml -e@../../configuration-secure/ansible/vars/edx.yml -u ubuntu
+ansible-playbook -i ./ec2.py --limit tag_Name_edx-admin-mms mongo_mms.yml -e@../../configuration-internal/ansible/vars/edx.yml ubuntu


### PR DESCRIPTION
I built my confidence that this would work by comparing and contrasting the values spookily (spook month doesn't have to end with the right attitude) [here](https://2u-internal.atlassian.net/wiki/spaces/~704249711/pages/639762433/Check+Diff+All+Ansible+Variables+After+Applying+Variables+from+Different+Lists+of+Places) (internal-to-2U link, sorry)

I think we also need to add secret-pulling permissions to the role this job uses, the policy for which is [here](https://github.com/edx/terraform/blob/da2e662605e502f38dd5d822dc50a8cc1bcd9cc6/plans/shared/templates/mongo-agents-update-policy.json.tpl) before this will work