### PR TITLE
chore: Remove day check from exporter.

### DIFF
--- a/dataeng/resources/setup-exporter.sh
+++ b/dataeng/resources/setup-exporter.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# Check that the DATE_MODIFIER is set to a Sunday, or if blank the current day is a Sunday
-DAYOFWEEK=$(date +%u ${DATE_MODIFIER})
-if [ $DAYOFWEEK != 7 ]; then
-   exit 1
-fi
-
 # Create destination directory
 mkdir -p /var/lib/jenkins/tmp/analytics-exporter/course-data
 


### PR DESCRIPTION
This should allow specifying any day of the week for CWSM dump instead of enforcing Sunday.