### PR TITLE
feat: Allow enabling datadog in sandboxes again

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -296,6 +296,8 @@ class CreateSandbox {
 
                 booleanParam("enable_newrelic",false,"Enable NewRelic application monitoring (this costs money, please ask devops before enabling). Server level New Relic monitoring is always enabled.  Select 'reconfigure' as well, if you want to deploy this.")
 
+                booleanParam("enable_datadog",false,"Enable DataDog monitoring (this costs money, please ask devops before enabling). Select 'reconfigure' as well, if you want to deploy this.")
+
                 booleanParam("enable_client_profiling",false,"Enable the SESSION_SAVE_EVERY_REQUEST django setting for client profiling.")
 
                 booleanParam("run_oauth",true,"")


### PR DESCRIPTION
For reference, this was removed in commit
8c08807776fb65efbaeece3e2de05519db50dd5e. I'm not reverting the changes to DATADOG_KEY because I'm not entirely sure if those are needed.