### PR TITLE
Katebygrace/demographics secretsmanager

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeDemographicsCleanup.groovy
+++ b/dataeng/jobs/analytics/SnowflakeDemographicsCleanup.groovy
@@ -20,8 +20,6 @@ class SnowflakeDemographicsCleanup {
                 stringParam('PYTHON_VENV_VERSION', 'python3.7', 'Python virtual environment version to used.')
             }
             environmentVariables {
-                env('KEY_PATH', allVars.get('KEY_PATH'))
-                env('PASSPHRASE_PATH', allVars.get('PASSPHRASE_PATH'))
                 env('USER', allVars.get('USER'))
                 env('ACCOUNT', allVars.get('ACCOUNT'))
             }

--- a/dataeng/resources/snowflake-demographics-cleanup.sh
+++ b/dataeng/resources/snowflake-demographics-cleanup.sh
@@ -10,8 +10,19 @@ source "${PYTHON_VENV}/bin/activate"
 cd $WORKSPACE/analytics-tools/snowflake
 make requirements
 
+
+python3 secrets-manager.py -w -n analytics-secure/snowflake/rsa_key_stitch_loader.p8 -v rsa_key_stitch_loader
+python3 secrets-manager.py -w -n analytics-secure/snowflake/rsa_key_passphrase_stitch_loader -v rsa_key_passphrase_stitch_loader
+
+unset KEY_PATH
+unset PASSPHRASE_PATH
+
 python demographics_cleanup.py \
-    --key_path $WORKSPACE/analytics-secure/$KEY_PATH \
-    --passphrase_path $WORKSPACE/analytics-secure/$PASSPHRASE_PATH \
-    --user $USER \
-    --account $ACCOUNT
+    --user 'STITCH_LOADER' \
+    --account 'edx.us-east-1' \
+    --key_file "$(cat "rsa_key_stitch_loader")" \
+    --passphrase_file "$(cat "rsa_key_passphrase_stitch_loader")"
+
+
+rm rsa_key_stitch_loader
+rm rsa_key_passphrase_stitch_loader


### PR DESCRIPTION

Remove calls to other secrets manager scripts in jenkins
Remove calls to secrets manager scripts in shell script
Check and remove the key_path and passphrase_path
Run python script x2
Change calls to python script to include key_file and passphrase_file (note slashes)
rm files
Review vars in analytics secure if there are any others that need to be set



---

---

job-configs/SNOWFLAKE_DEMOGRAPHICS_CLEANUP_JOB_EXTRA_VARS.yaml


KEY_PATH: "snowflake/rsa_key_stitch_loader.p8"
PASSPHRASE_PATH: 'snowflake/rsa_key_passphrase_stitch_loader'
USER: 'STITCH_LOADER'
ACCOUNT: 'edx.us-east-1'
USER_ROLES:
  edx*edx-aperture:
    - "hudson.model.Item.Build"
    - "hudson.model.Item.Cancel"
    - "hudson.model.Run.Delete"
    - "hudson.model.Item.Discover"
    - "hudson.model.Item.Read"
    - "hudson.model.Run.Update"
    - "hudson.model.Item.Workspace"