### PR TITLE
Katebygrace/snowflake expire jobs secretsmanager

### DIFF
--- a/dataeng/jobs/analytics/SnowflakeExpirePasswords.groovy
+++ b/dataeng/jobs/analytics/SnowflakeExpirePasswords.groovy
@@ -41,8 +41,6 @@ class SnowflakeExpirePasswords {
                     }
                 }
                 environmentVariables {
-                    env('KEY_PATH', allVars.get('KEY_PATH'))
-                    env('PASSPHRASE_PATH', allVars.get('PASSPHRASE_PATH'))
                     env('USER', allVars.get('USER'))
                     env('ACCOUNT', allVars.get('ACCOUNT'))
                 }

--- a/dataeng/resources/snowflake-expire-individual-password.sh
+++ b/dataeng/resources/snowflake-expire-individual-password.sh
@@ -10,9 +10,17 @@ source "${PYTHON_VENV}/bin/activate"
 cd $WORKSPACE/analytics-tools/snowflake
 make requirements
 
+
+python3 secrets-manager.py -w -n analytics-secure/snowflake/rsa_key_snowflake_task_automation_user.p8 -v rsa_key_snowflake_task_automation_user
+python3 secrets-manager.py -w -n analytics-secure/snowflake/rsa_key_passphrase_snowflake_task_automation_user -v rsa_key_passphrase_snowflake_task_automation_user
+
 python expire_user_passwords.py \
-    --key_path $KEY_PATH \
-    --passphrase_path $PASSPHRASE_PATH \
-    --automation_user $USER \
-    --account $ACCOUNT \
-    --user_to_expire $USER_TO_EXPIRE
+    --automation_user 'SNOWFLAKE_TASK_AUTOMATION_USER' \
+    --account 'edx.us-east-1' \
+    --user_to_expire $USER_TO_EXPIRE \
+    --key_file "$(cat "rsa_key_snowflake_task_automation_user")" \
+    --pass_file  "$(cat "rsa_key_passphrase_snowflake_task_automation_user")"
+
+
+rm rsa_key_snowflake_task_automation_user
+rm rsa_key_passphrase_snowflake_task_automation_user

--- a/dataeng/resources/snowflake-expire-passwords.sh
+++ b/dataeng/resources/snowflake-expire-passwords.sh
@@ -10,8 +10,15 @@ source "${PYTHON_VENV}/bin/activate"
 cd $WORKSPACE/analytics-tools/snowflake
 make requirements
 
+
+python3 secrets-manager.py -w -n analytics-secure/snowflake/rsa_key_snowflake_task_automation_user.p8 -v rsa_key_snowflake_task_automation_user
+python3 secrets-manager.py -w -n analytics-secure/snowflake/rsa_key_passphrase_snowflake_task_automation_user -v rsa_key_passphrase_snowflake_task_automation_user
+
 python expire_user_passwords.py \
-    --key_path $KEY_PATH \
-    --passphrase_path $PASSPHRASE_PATH \
-    --automation_user $USER \
-    --account $ACCOUNT
+    --automation_user 'SNOWFLAKE_TASK_AUTOMATION_USER' \
+    --account 'edx.us-east-1' \
+    --key_file "$(cat "rsa_key_snowflake_task_automation_user")" \
+    --pass_file  "$(cat "rsa_key_passphrase_snowflake_task_automation_user")"
+
+rm rsa_key_snowflake_task_automation_user
+rm rsa_key_passphrase_snowflake_task_automation_user


### PR DESCRIPTION
Remove calls to other secrets manager scripts in jenkins

Remove calls to secrets manager scripts in shell script
Check and remove the key_path and passphrase_path
Run python script x2
Change calls to python script to include key_file and passphrase_file (note slashes)
rm files

Review vars in analytics secure if there are any others that need to be set

---

---
job-configs/SNOWFLAKE_EXPIRE_PASSWORDS_JOB_EXTRA_VARS.yaml

# The following two variables are paths to the clone of analytics-secure in a Jenkins workspace, relative to where the expire_user_passwords script is being invoked.
KEY_PATH: '$WORKSPACE/analytics-secure/snowflake/rsa_key_snowflake_task_automation_user.p8'
PASSPHRASE_PATH: '$WORKSPACE/analytics-secure/snowflake/rsa_key_passphrase_snowflake_task_automation_user'
USER: 'SNOWFLAKE_TASK_AUTOMATION_USER'
ACCOUNT: 'edx.us-east-1'
# job executes on the 3rd of every 3rd month.
JOB_FREQUENCY: "H H 3 */3 *"
SECURE_BRANCH: 'origin/master'