### PR TITLE
Katebygrace/public grants cleaner

### DIFF
--- a/dataeng/resources/snowflake-public-grants-cleaner.sh
+++ b/dataeng/resources/snowflake-public-grants-cleaner.sh
@@ -10,13 +10,18 @@ source "${PYTHON_VENV}/bin/activate"
 cd $WORKSPACE/analytics-tools/snowflake
 make requirements
 
-source secrets-manager.sh analytics-secure/job-configs/SNOWFLAKE_PUBLIC_GRANTS_CLEANER_JOB_EXTRA_VARS KEY_PATH
-source secrets-manager.sh analytics-secure/job-configs/SNOWFLAKE_PUBLIC_GRANTS_CLEANER_JOB_EXTRA_VARS PASSPHRASE_PATH
-source secrets-manager.sh analytics-secure/job-configs/SNOWFLAKE_PUBLIC_GRANTS_CLEANER_JOB_EXTRA_VARS USER
-source secrets-manager.sh analytics-secure/job-configs/SNOWFLAKE_PUBLIC_GRANTS_CLEANER_JOB_EXTRA_VARS ACCOUNT
+python3 secrets-manager.py -w -n analytics-secure/snowflake/rsa_key_stitch_loader.p8 -v rsa_key_stitch_loader
+python3 secrets-manager.py -w -n analytics-secure/snowflake/rsa_key_passphrase_stitch_loader -v rsa_key_passphrase_stitch_loader
+
+unset KEY_PATH
+unset PASSPHRASE_PATH
 
 python snowflake_public_grants_cleaner.py \
-    --key_path $WORKSPACE/analytics-secure/$KEY_PATH \
-    --passphrase_path $WORKSPACE/analytics-secure/$PASSPHRASE_PATH \
-    --user $USER \
-    --account $ACCOUNT
+    --user "STITCH_LOADER" \
+    --account "edx.us-east-1" \ 
+    --key_file "$(cat "rsa_key_stitch_loader")" \
+    --passphrase_file "$(cat "rsa_key_passphrase_stitch_loader")"
+
+
+rm rsa_key_stitch_loader
+rm rsa_key_passphrase_stitch_loader


### PR DESCRIPTION
Remove calls to other secrets manager scripts in jenkins

Remove calls to secrets manager scripts in shell script
Check and remove the key_path and passphrase_path
Run python script x2
Change calls to python script to include key_file and passphrase_file (note slashes)
rm files

Review vars in analytics secure if there are any others that need to be set

---

KEY_PATH: "snowflake/rsa_key_stitch_loader.p8"
PASSPHRASE_PATH: 'snowflake/rsa_key_passphrase_stitch_loader'
USER: 'STITCH_LOADER'
ACCOUNT: 'edx.us-east-1'
JOB_FREQUENCY: "*/15 * * * *"

