### PR TITLE
chore: update user retirement to use python3.11

### DIFF
--- a/dataeng/resources/user-retirement-collector.sh
+++ b/dataeng/resources/user-retirement-collector.sh
@@ -12,7 +12,7 @@ env
 # setting on the jenkins worker, it would be safest to keep the builds from
 # clobbering each other's virtualenvs.
 VENV="venv-${BUILD_NUMBER}"
-virtualenv --python=python3.8 --clear "${VENV}"
+virtualenv --python=python3.11 --clear "${VENV}"
 source "${VENV}/bin/activate"
 
 # Make sure that when we try to write unicode to the console, it

--- a/dataeng/resources/user-retirement-driver.sh
+++ b/dataeng/resources/user-retirement-driver.sh
@@ -12,7 +12,7 @@ env
 # setting on the jenkins worker, it would be safest to keep the builds from
 # clobbering each other's virtualenvs.
 VENV="venv-${BUILD_NUMBER}"
-virtualenv --python=python3.8 --clear "${VENV}"
+virtualenv --python=python3.11 --clear "${VENV}"
 source "${VENV}/bin/activate"
 
 # Make sure that when we try to write unicode to the console, it


### PR DESCRIPTION
Switch from python3.8 to python3.11 for user retirement jobs.