### PR TITLE
build: set payment-mfe default to false in sandbox config

### DIFF
--- a/devops/jobs/CreateSandbox.groovy
+++ b/devops/jobs/CreateSandbox.groovy
@@ -232,7 +232,7 @@ class CreateSandbox {
                 booleanParam("authn",true,"Enable Authn MFE")
                 stringParam("authn_version","master","The repository version of the frontend-app-authn")
 
-                booleanParam("payment",true,"Enable Payment MFE")
+                booleanParam("payment",false,"Enable Payment MFE")
                 stringParam("payment_version","master","The repository version of the frontend-app-payment")
 
                 booleanParam("learning",true,"Enable Learning MFE")


### PR DESCRIPTION
## Description
- payment-mfe is currently failing in sandbox so setting it as false to enable sandbox build success on master.