### PR TITLE
chore: Use private key across all dbt jobs including CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run_gradle_check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Gradle Check
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Gradle Check
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-java@v2
+    - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '11'

--- a/dataeng/resources/dbt-docs.sh
+++ b/dataeng/resources/dbt-docs.sh
@@ -18,9 +18,9 @@ cd $WORKSPACE/warehouse-transforms/projects/reporting
 source $WORKSPACE/secrets-manager.sh
 # Fetch the secrets from AWS
 set +x
-get_secret_value analytics-secure/warehouse-transforms/profiles DBT_PASSWORD
+get_secret_value analytics-secure/warehouse-transforms/profiles PRIVATE_KEY
 set -x
-export DBT_PASSWORD
+export PRIVATE_KEY
 
 dbt clean --profiles-dir $WORKSPACE/warehouse-transforms/profiles/ --profile $DBT_PROFILE --target $DBT_TARGET
 dbt deps --profiles-dir $WORKSPACE/warehouse-transforms/profiles/ --profile $DBT_PROFILE --target $DBT_TARGET

--- a/dataeng/resources/model-transfers.sh
+++ b/dataeng/resources/model-transfers.sh
@@ -31,9 +31,9 @@ ARGS="{mart: ${MART_NAME} }"
 source $WORKSPACE/secrets-manager.sh
 # Fetch the secrets from AWS
 set +x
-get_secret_value analytics-secure/warehouse-transforms/profiles DBT_PASSWORD
+get_secret_value analytics-secure/warehouse-transforms/profiles PRIVATE_KEY
 set -x
-export DBT_PASSWORD
+export PRIVATE_KEY
 
 dbt deps --profiles-dir $WORKSPACE/warehouse-transforms/profiles --profile $DBT_PROFILE --target $DBT_TARGET
 

--- a/dataeng/resources/warehouse-transforms-ci-dbt.sh
+++ b/dataeng/resources/warehouse-transforms-ci-dbt.sh
@@ -11,7 +11,7 @@ source $WORKSPACE/secrets-manager.sh
 set +x
 get_secret_value analytics-secure/warehouse-transforms/profiles DBT_TRANSFORMER_CI_PRIVATE_KEY
 set -x
-export DBT_PASSWORD=$DBT_TRANSFORMER_CI_PRIVATE_KEY
+export PRIVATE_KEY=$DBT_TRANSFORMER_CI_PRIVATE_KEY
 
 dbt clean --profiles-dir $WORKSPACE/warehouse-transforms/profiles/ --profile $DBT_PROFILE --target $DBT_TARGET
 dbt deps --profiles-dir $WORKSPACE/warehouse-transforms/profiles/ --profile $DBT_PROFILE --target $DBT_TARGET

--- a/dataeng/resources/warehouse-transforms-ci-dbt.sh
+++ b/dataeng/resources/warehouse-transforms-ci-dbt.sh
@@ -9,9 +9,9 @@ cd $WORKSPACE/warehouse-transforms/projects/$DBT_PROJECT_PATH
 source $WORKSPACE/secrets-manager.sh
 # Fetch the secrets from AWS
 set +x
-get_secret_value analytics-secure/warehouse-transforms/profiles DBT_PASSWORD
+get_secret_value analytics-secure/warehouse-transforms/profiles DBT_TRANSFORMER_CI_PRIVATE_KEY
 set -x
-export DBT_PASSWORD
+export DBT_PASSWORD=$DBT_TRANSFORMER_CI_PRIVATE_KEY
 
 dbt clean --profiles-dir $WORKSPACE/warehouse-transforms/profiles/ --profile $DBT_PROFILE --target $DBT_TARGET
 dbt deps --profiles-dir $WORKSPACE/warehouse-transforms/profiles/ --profile $DBT_PROFILE --target $DBT_TARGET

--- a/dataeng/resources/warehouse-transforms-ci-manual.sh
+++ b/dataeng/resources/warehouse-transforms-ci-manual.sh
@@ -50,7 +50,7 @@ source $WORKSPACE/secrets-manager.sh
 set +x
 get_secret_value analytics-secure/warehouse-transforms/profiles DBT_TRANSFORMER_CI_PRIVATE_KEY
 set -x
-export DBT_PASSWORD=$DBT_TRANSFORMER_CI_PRIVATE_KEY
+export PRIVATE_KEY=$DBT_TRANSFORMER_CI_PRIVATE_KEY
 
 dbt clean --profiles-dir $WORKSPACE/warehouse-transforms/profiles/ --profile $DBT_PROFILE --target $DBT_TARGET
 dbt deps --profiles-dir $WORKSPACE/warehouse-transforms/profiles/ --profile $DBT_PROFILE --target $DBT_TARGET

--- a/dataeng/resources/warehouse-transforms-ci-manual.sh
+++ b/dataeng/resources/warehouse-transforms-ci-manual.sh
@@ -48,9 +48,9 @@ cd $WORKSPACE/warehouse-transforms/projects/$DBT_PROJECT_PATH
 source $WORKSPACE/secrets-manager.sh
 # Fetch the secrets from AWS
 set +x
-get_secret_value analytics-secure/warehouse-transforms/profiles DBT_PASSWORD
+get_secret_value analytics-secure/warehouse-transforms/profiles DBT_TRANSFORMER_CI_PRIVATE_KEY
 set -x
-export DBT_PASSWORD
+export DBT_PASSWORD=$DBT_TRANSFORMER_CI_PRIVATE_KEY
 
 dbt clean --profiles-dir $WORKSPACE/warehouse-transforms/profiles/ --profile $DBT_PROFILE --target $DBT_TARGET
 dbt deps --profiles-dir $WORKSPACE/warehouse-transforms/profiles/ --profile $DBT_PROFILE --target $DBT_TARGET


### PR DESCRIPTION
use private key auth for dbt CI jobs and model transfer and dbt-docs job