### PR TITLE
chore: reverting to tubular-based retirement

### DIFF
--- a/dataeng/jobs/analytics/RetirementJobs.groovy
+++ b/dataeng/jobs/analytics/RetirementJobs.groovy
@@ -67,7 +67,7 @@ class RetirementJobs{
             // retry cloning repositories
             checkoutRetryCount(5)
 
-            multiscm (allVars) << {
+            multiscm {
                 git {
                     remote {
                         url('https://github.com/edx/configuration.git')
@@ -171,7 +171,7 @@ class RetirementJobs{
             // retry cloning repositories
             checkoutRetryCount(5)
 
-            multiscm << {
+            multiscm {
                 git {
                     remote {
                         url('https://github.com/edx/configuration.git')
@@ -320,7 +320,7 @@ class RetirementJobs{
             // retry cloning repositories
             checkoutRetryCount(5)
 
-            multiscm << {
+            multiscm {
                 git {
                     remote {
                         url('https://github.com/edx/configuration.git')
@@ -439,7 +439,7 @@ class RetirementJobs{
             // retry cloning repositories
             checkoutRetryCount(5)
 
-            multiscm << {
+            multiscm {
                 git {
                     remote {
                         url('https://github.com/edx/configuration.git')
@@ -539,7 +539,7 @@ class RetirementJobs{
             // retry cloning repositories
             checkoutRetryCount(5)
 
-            multiscm << {
+            multiscm {
                 git {
                     remote {
                         url('https://github.com/edx/configuration.git')

--- a/dataeng/jobs/analytics/RetirementJobs.groovy
+++ b/dataeng/jobs/analytics/RetirementJobs.groovy
@@ -59,7 +59,7 @@ class RetirementJobs{
             wrappers common_wrappers(allVars)
             parameters secure_scm_parameters(allVars)
             parameters {
-                stringParam('PLATFORM_BRANCH', 'origin/2u/release', 'Branch from the edx-platform repository. For tags use tags/[tag-name].')
+                stringParam('TUBULAR_BRANCH', 'master', 'Repo branch for the tubular scripts.')
                 stringParam('ENVIRONMENT', '', 'edx environment which contains the user in question, in ENVIRONMENT-DEPLOYMENT format.')
                 stringParam('RETIREMENT_USERNAME', '', 'Current username of learner to retire.')
             }
@@ -67,7 +67,7 @@ class RetirementJobs{
             // retry cloning repositories
             checkoutRetryCount(5)
 
-            multiscm platform_scm(allVars) << {
+            multiscm (allVars) << {
                 git {
                     remote {
                         url('https://github.com/edx/configuration.git')
@@ -75,6 +75,20 @@ class RetirementJobs{
                     branch('master')
                     extensions {
                         relativeTargetDirectory('configuration')
+                        cloneOptions {
+                            shallow()
+                            timeout(10)
+                        }
+                        cleanBeforeCheckout()
+                    }
+                }
+                git {
+                    remote {
+                        url('https://github.com/edx/tubular.git')
+                    }
+                    branch('$TUBULAR_BRANCH')
+                    extensions {
+                        relativeTargetDirectory('tubular')
                         cloneOptions {
                             shallow()
                             timeout(10)
@@ -146,18 +160,18 @@ class RetirementJobs{
                 }
             }
             parameters {
+                stringParam('TUBULAR_BRANCH', 'master', 'Repo branch for the tubular scripts.')
                 stringParam('ENVIRONMENT', '', 'edx environment which contains the user in question, in ENVIRONMENT-DEPLOYMENT format.')
                 stringParam('COOL_OFF_DAYS', '14', 'Number of days a learner should be in the retirement queue before being actually retired.')
                 stringParam('USER_COUNT_ERROR_THRESHOLD', '251', 'If more users than this number are returned we will error out instead of retiring.')
                 stringParam('MAX_USER_BATCH_SIZE', '200', 'Allow us to get a specified number of users and then continues with that')
-                stringParam('PLATFORM_BRANCH', 'origin/2u/release', 'Branch from the edx-platform repository. For tags use tags/[tag-name].')
                 stringParam('RETIREMENT_JOBS_MAILING_LIST', allVars.get('RETIREMENT_JOBS_MAILING_LIST'), 'Space separated list of emails to send notifications to.')
             }
 
             // retry cloning repositories
             checkoutRetryCount(5)
 
-            multiscm platform_scm(allVars) << {
+            multiscm << {
                 git {
                     remote {
                         url('https://github.com/edx/configuration.git')
@@ -165,6 +179,20 @@ class RetirementJobs{
                     branch('master')
                     extensions {
                         relativeTargetDirectory('configuration')
+                        cloneOptions {
+                            shallow()
+                            timeout(10)
+                        }
+                        cleanBeforeCheckout()
+                    }
+                }
+              git {
+                    remote {
+                        url('https://github.com/edx/tubular.git')
+                    }
+                    branch('$TUBULAR_BRANCH')
+                    extensions {
+                        relativeTargetDirectory('tubular')
                         cloneOptions {
                             shallow()
                             timeout(10)
@@ -203,7 +231,7 @@ class RetirementJobs{
                             unstable('UNSTABLE')
                         }
                         parameters {
-                            predefinedProp('PLATFORM_BRANCH', '${PLATFORM_BRANCH}')
+                            predefinedProp('TUBULAR_BRANCH', '${TUBULAR_BRANCH}')
                             predefinedProp('ENVIRONMENT', '${ENVIRONMENT}')
                         }
                         parameterFactories {
@@ -284,15 +312,15 @@ class RetirementJobs{
             }
 
             parameters {
+                stringParam('TUBULAR_BRANCH', 'master', 'Repo branch for the tubular scripts.')
                 stringParam('ENVIRONMENT', '', 'edx environment which contains the user in question, in ENVIRONMENT-DEPLOYMENT format.')
                 stringParam('RETIREMENT_JOBS_MAILING_LIST', allVars.get('RETIREMENT_JOBS_MAILING_LIST'), 'Space separated list of emails to send notifications to.')
-                stringParam('PLATFORM_BRANCH', 'origin/2u/release', 'Branch from the edx-platform repository. For tags use tags/[tag-name].')
             }
 
             // retry cloning repositories
             checkoutRetryCount(5)
 
-            multiscm platform_scm(allVars) << {
+            multiscm << {
                 git {
                     remote {
                         url('https://github.com/edx/configuration.git')
@@ -300,6 +328,20 @@ class RetirementJobs{
                     branch('master')
                     extensions {
                         relativeTargetDirectory('configuration')
+                        cloneOptions {
+                            shallow()
+                            timeout(10)
+                        }
+                        cleanBeforeCheckout()
+                    }
+                }
+                git {
+                    remote {
+                        url('https://github.com/edx/tubular.git')
+                    }
+                    branch('$TUBULAR_BRANCH')
+                    extensions {
+                        relativeTargetDirectory('tubular')
                         cloneOptions {
                             shallow()
                             timeout(10)
@@ -388,16 +430,16 @@ class RetirementJobs{
             }
 
             parameters {
+                stringParam('TUBULAR_BRANCH', 'master', 'Repo branch for the tubular scripts.')
                 stringParam('ENVIRONMENT', '', 'edx environment which contains the user in question, in ENVIRONMENT-DEPLOYMENT format.')
                 stringParam('AGE_IN_DAYS', '60', 'Number of days to keep partner reports.')
                 stringParam('RETIREMENT_JOBS_MAILING_LIST', allVars.get('RETIREMENT_JOBS_MAILING_LIST'), 'Space separated list of emails to send notifications to.')
-                stringParam('PLATFORM_BRANCH', 'origin/2u/release', 'Branch from the edx-platform repository. For tags use tags/[tag-name].')
             }
 
             // retry cloning repositories
             checkoutRetryCount(5)
 
-            multiscm platform_scm(allVars) << {
+            multiscm << {
                 git {
                     remote {
                         url('https://github.com/edx/configuration.git')
@@ -405,6 +447,20 @@ class RetirementJobs{
                     branch('master')
                     extensions {
                         relativeTargetDirectory('configuration')
+                        cloneOptions {
+                            shallow()
+                            timeout(10)
+                        }
+                        cleanBeforeCheckout()
+                    }
+                }
+                git {
+                    remote {
+                        url('https://github.com/edx/tubular.git')
+                    }
+                    branch('$TUBULAR_BRANCH')
+                    extensions {
+                        relativeTargetDirectory('tubular')
                         cloneOptions {
                             shallow()
                             timeout(10)
@@ -470,6 +526,7 @@ class RetirementJobs{
             }
 
             parameters {
+                stringParam('TUBULAR_BRANCH', 'master', 'Repo branch for the tubular scripts.')
                 stringParam('ENVIRONMENT', '', 'edx environment which contains the user in question, in ENVIRONMENT-DEPLOYMENT format.')
                 stringParam('START_DATE', '', 'Find users that requested deletion starting with this day (YYYY-MM-DD).')
                 stringParam('END_DATE', '', 'Find users that requested deletion ending with this day (YYYY-MM-DD). To select one day make the start and end dates the same.')
@@ -477,13 +534,12 @@ class RetirementJobs{
                 stringParam('NEW_STATE_NAME', '', 'Set the found learners to this state (ex: PENDING)')
                 stringParam('RETIREMENT_JOBS_MAILING_LIST', allVars.get('RETIREMENT_JOBS_MAILING_LIST'), 'Space separated list of emails to send notifications to.')
                 booleanParam('REWIND_STATE', false, 'Rewinds users to previous state, useful for redriving a large numnber of ERRORED users')
-                stringParam('PLATFORM_BRANCH', 'origin/2u/release', 'Branch from the edx-platform repository. For tags use tags/[tag-name].')
             }
 
             // retry cloning repositories
             checkoutRetryCount(5)
 
-            multiscm platform_scm(allVars) << {
+            multiscm << {
                 git {
                     remote {
                         url('https://github.com/edx/configuration.git')
@@ -491,6 +547,20 @@ class RetirementJobs{
                     branch('master')
                     extensions {
                         relativeTargetDirectory('configuration')
+                        cloneOptions {
+                            shallow()
+                            timeout(10)
+                        }
+                        cleanBeforeCheckout()
+                    }
+                }
+                git {
+                    remote {
+                        url('https://github.com/edx/tubular.git')
+                    }
+                    branch('$TUBULAR_BRANCH')
+                    extensions {
+                        relativeTargetDirectory('tubular')
                         cloneOptions {
                             shallow()
                             timeout(10)

--- a/dataeng/resources/retirement-partner-report-cleanup.sh
+++ b/dataeng/resources/retirement-partner-report-cleanup.sh
@@ -33,12 +33,14 @@ echo "$GOOGLE_SERVICE_ACCOUNT_JSON" > "$TEMP_GOOGLE_SECRETS"
 
 set -x
 
-# Prepare retirement scripts
-cd $WORKSPACE/edx-platform
-pip install -r scripts/user_retirement/requirements/base.txt
+# prepare tubular
+cd $WORKSPACE/tubular
+# snapshot the current latest versions of pip and setuptools.
+pip install 'pip==21.0.1' 'setuptools==53.0.0'
+pip install -r requirements.txt
 
 # Call the script to cleanup the reports
-python scripts/user_retirement/delete_expired_partner_gdpr_reports.py \
+python scripts/delete_expired_partner_gdpr_reports.py \
     --config_file=$TEMP_CONFIG_YAML \
     --google_secrets_file=$TEMP_GOOGLE_SECRETS \
     --age_in_days=$AGE_IN_DAYS

--- a/dataeng/resources/retirement-partner-reporter.sh
+++ b/dataeng/resources/retirement-partner-reporter.sh
@@ -45,16 +45,18 @@ echo "$GOOGLE_SERVICE_ACCOUNT_JSON" > "$TEMP_GOOGLE_SECRETS"
 
 set -x
 
-# Prepare retirement scripts
-cd $WORKSPACE/edx-platform
-pip install -r scripts/user_retirement/requirements/base.txt
+# prepare tubular
+cd $WORKSPACE/tubular
+# snapshot the current latest versions of pip and setuptools.
+pip install 'pip==21.0.1' 'setuptools==53.0.0'
+pip install -r requirements.txt
 
 # Create the directory where we will store reports, one per partner
 rm -rf $PARTNER_REPORTS_DIR
 mkdir $PARTNER_REPORTS_DIR
 
 # Call the script to generate the reports and upload them to Google Drive
-python scripts/user_retirement/retirement_partner_report.py \
+python scripts/retirement_partner_report.py \
     --config_file=$TEMP_CONFIG_YAML \
     --google_secrets_file=$TEMP_GOOGLE_SECRETS \
     --output_dir=$PARTNER_REPORTS_DIR

--- a/dataeng/resources/user-retirement-bulk-status.sh
+++ b/dataeng/resources/user-retirement-bulk-status.sh
@@ -37,12 +37,14 @@ echo "$CONFIG_YAML" > "$TEMP_CONFIG_YAML"
 
 set -x
 
-# Prepare retirement scripts
-cd $WORKSPACE/edx-platform
-pip install -r scripts/user_retirement/requirements/base.txt
+# prepare tubular
+cd $WORKSPACE/tubular
+# snapshot the current latest versions of pip and setuptools.
+pip install 'pip==21.0.1' 'setuptools==53.0.0'
+pip install -r requirements.txt
 
 # Call the script to collect the list of learners that are to be retired.
-python scripts/user_retirement/retirement_bulk_status_update.py \
+python scripts/retirement_bulk_status_update.py \
     --config_file=$TEMP_CONFIG_YAML \
     --start_date=$START_DATE \
     --end_date=$END_DATE \

--- a/dataeng/resources/user-retirement-collector.sh
+++ b/dataeng/resources/user-retirement-collector.sh
@@ -37,9 +37,11 @@ echo "$CONFIG_YAML" > "$TEMP_CONFIG_YAML"
 
 set -x
 
-# Prepare retirement scripts
-cd $WORKSPACE/edx-platform
-pip install -r scripts/user_retirement/requirements/base.txt
+# prepare tubular
+cd $WORKSPACE/tubular
+# snapshot the current latest versions of pip and setuptools.
+pip install 'pip==21.0.1' 'setuptools==53.0.0'
+pip install -r requirements.txt
 
 # Create the directory where we will populate properties files, one per
 # downstream build.
@@ -47,7 +49,7 @@ rm -rf $LEARNERS_TO_RETIRE_PROPERTIES_DIR
 mkdir $LEARNERS_TO_RETIRE_PROPERTIES_DIR
 
 # Call the script to collect the list of learners that are to be retired.
-python scripts/user_retirement/get_learners_to_retire.py \
+python scripts/get_learners_to_retire.py \
     --config_file=$TEMP_CONFIG_YAML \
     --output_dir=$LEARNERS_TO_RETIRE_PROPERTIES_DIR \
     --cool_off_days=$COOL_OFF_DAYS \

--- a/dataeng/resources/user-retirement-collector.sh
+++ b/dataeng/resources/user-retirement-collector.sh
@@ -12,7 +12,7 @@ env
 # setting on the jenkins worker, it would be safest to keep the builds from
 # clobbering each other's virtualenvs.
 VENV="venv-${BUILD_NUMBER}"
-virtualenv --python=python3.11 --clear "${VENV}"
+virtualenv --python=python3.8 --clear "${VENV}"
 source "${VENV}/bin/activate"
 
 # Make sure that when we try to write unicode to the console, it

--- a/dataeng/resources/user-retirement-driver.sh
+++ b/dataeng/resources/user-retirement-driver.sh
@@ -37,13 +37,15 @@ echo "$CONFIG_YAML" > "$TEMP_CONFIG_YAML"
 
 set -x
 
-# Prepare retirement scripts
-cd $WORKSPACE/edx-platform
-pip install -r scripts/user_retirement/requirements/base.txt
+# prepare tubular
+cd $WORKSPACE/tubular
+# snapshot the current latest versions of pip and setuptools.
+pip install 'pip==21.0.1' 'setuptools==53.0.0'
+pip install -r requirements.txt
 
 # Call the script to retire one learner.  This assumes the following build
 # parameters / environment variable is set: RETIREMENT_USERNAME.
-python scripts/user_retirement/retire_one_learner.py \
+python scripts/retire_one_learner.py \
     --config_file=$TEMP_CONFIG_YAML
 
 # Remove the temporary file after processing

--- a/dataeng/resources/user-retirement-driver.sh
+++ b/dataeng/resources/user-retirement-driver.sh
@@ -12,7 +12,7 @@ env
 # setting on the jenkins worker, it would be safest to keep the builds from
 # clobbering each other's virtualenvs.
 VENV="venv-${BUILD_NUMBER}"
-virtualenv --python=python3.11 --clear "${VENV}"
+virtualenv --python=python3.8 --clear "${VENV}"
 source "${VENV}/bin/activate"
 
 # Make sure that when we try to write unicode to the console, it

--- a/src/main/groovy/org/edx/jenkins/dsl/AnalyticsConstants.groovy
+++ b/src/main/groovy/org/edx/jenkins/dsl/AnalyticsConstants.groovy
@@ -75,34 +75,6 @@ class AnalyticsConstants {
         }
     }
 
-    public static def platform_scm = { allVars ->
-        return {
-            git {
-                remote {
-                    url('git@github.com:openedx/edx-platform.git')
-                    branch('$PLATFORM_BRANCH')
-                }
-                extensions {
-                    pruneBranches()
-                    relativeTargetDirectory('edx-platform')
-                    cloneOptions {
-                        shallow() // Shallow clone to reduce time and disk space
-                        depth(1) // Only clone the latest commit
-                        noTags() // Save time and disk space
-                        timeout(10)
-                    }
-                    sparseCheckoutPaths { // Only checkout the directories we need
-                        sparseCheckoutPaths {
-                            sparseCheckoutPath {
-                                path('scripts/user_retirement')
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     public static def common_parameters = { allVars, env=[:] ->
         def parameters = {
             stringParam('CONFIG_BRANCH', '$ANALYTICS_CONFIGURATION_RELEASE', 'e.g. tagname or origin/branchname, or $ANALYTICS_CONFIGURATION_RELEASE')


### PR DESCRIPTION
this is an attempt to revert https://github.com/edx/jenkins-job-dsl/pull/1733, which is too old for an automatic reversion. This will allow us to switch back to using tubular for user retirement.