### PR TITLE
chore: disabling the warehouse-transforms Schema Builder PR merge deploy jobs

### DIFF
--- a/dataeng/jobs/analytics/DBTRun.groovy
+++ b/dataeng/jobs/analytics/DBTRun.groovy
@@ -68,6 +68,7 @@ class DBTRun{
                 "Automatically run dbt <strong>in production</strong>, overwriting data in the PROD database when Schema Builder generated PR are merged"
             )
             logRotator common_log_rotator(allVars)
+            disabled()
             environmentVariables {
                 env('WAREHOUSE_TRANSFORMS_URL', allVars.get('WAREHOUSE_TRANSFORMS_URL'))
                 env('WAREHOUSE_TRANSFORMS_BRANCH', allVars.get('WAREHOUSE_TRANSFORMS_BRANCH'))

--- a/dataeng/jobs/analytics/WarehouseTransformsCIManual.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransformsCIManual.groovy
@@ -13,6 +13,7 @@ class WarehouseTransformsCIManual{
         dslFactory.job("warehouse-transforms-ci-manual"){
             authorization common_authorization(allVars)
             logRotator common_log_rotator(allVars)
+            disabled()
             parameters {
                 stringParam('WAREHOUSE_TRANSFORMS_URL', allVars.get('WAREHOUSE_TRANSFORMS_URL'), 'URL for the warehouse-transforms repository.')
                 stringParam('WAREHOUSE_TRANSFORMS_BRANCH', '', 'Must specify branch of warehouse-transforms repository to use.')

--- a/dataeng/jobs/analytics/WarehouseTransformsCIMasterMerges.groovy
+++ b/dataeng/jobs/analytics/WarehouseTransformsCIMasterMerges.groovy
@@ -14,6 +14,7 @@ class WarehouseTransformsCIMasterMerges{
         dslFactory.job("warehouse-transforms-ci-poll-master"){
             authorization common_authorization(allVars)
             logRotator common_log_rotator(allVars)
+            disabled()
             parameters {
                 stringParam('WAREHOUSE_TRANSFORMS_URL', allVars.get('WAREHOUSE_TRANSFORMS_URL'), 'URL for the warehouse-transforms repository.')
                 stringParam('WAREHOUSE_TRANSFORMS_BRANCH', allVars.get('WAREHOUSE_TRANSFORMS_BRANCH'), 'Branch of warehouse-transforms repository to use.')
@@ -59,6 +60,7 @@ class WarehouseTransformsCIMasterMerges{
         dslFactory.job("warehouse-transforms-ci-master-merges"){
             authorization common_authorization(allVars)
             logRotator common_log_rotator(allVars)
+            disabled()
             parameters {
                 stringParam('WAREHOUSE_TRANSFORMS_URL', allVars.get('WAREHOUSE_TRANSFORMS_URL'), 'URL for the warehouse-transforms repository.')
                 stringParam('WAREHOUSE_TRANSFORMS_BRANCH', allVars.get('WAREHOUSE_TRANSFORMS_BRANCH'), 'Branch of warehouse-transforms repository to use.')


### PR DESCRIPTION
This disables all the jobs that manage warehouse-transforms Schema Builder PR merges and also disables the WT monthly job. In the latter case I had thought it was disabled, only to learn that the disabling code was not included.
