### PR TITLE
feat: add parameters for age and deletion warning

### DIFF
--- a/dataeng/jobs/analytics/RetirementJobs.groovy
+++ b/dataeng/jobs/analytics/RetirementJobs.groovy
@@ -351,6 +351,21 @@ class RetirementJobs{
                         cleanBeforeCheckout()
                     }
                 }
+                git {
+                    remote {
+                        url('git@github.com:edx/edx-internal.git')
+                        credentials(allVars.get('SECURE_GIT_CREDENTIALS'))
+                    }
+                    branch('master')
+                    extensions {
+                        relativeTargetDirectory('edx-internal')
+                        cloneOptions {
+                            shallow()
+                            timeout(10)
+                        }
+                        cleanBeforeCheckout()
+                    }
+                }
             }
 
             environmentVariables {

--- a/dataeng/jobs/analytics/RetirementJobs.groovy
+++ b/dataeng/jobs/analytics/RetirementJobs.groovy
@@ -314,7 +314,7 @@ class RetirementJobs{
             parameters {
                 stringParam('TUBULAR_BRANCH', 'master', 'Repo branch for the tubular scripts.')
                 stringParam('ENVIRONMENT', '', 'edx environment which contains the user in question, in ENVIRONMENT-DEPLOYMENT format.')
-                stringParam('AGE_IN_DAYS', '60', 'Number of days to keep partner reports (must match cleanup job AGE_IN_DAYS).')
+                stringParam('AGE_IN_DAYS', '60', 'Number of days to keep partner reports; should match cleanup job AGE_IN_DAYS to keep retention and cleanup in sync.')
                 stringParam('DELETION_WARNING_DAYS', '7', 'Number of days before deletion to send warning notification.')
                 stringParam('RETIREMENT_JOBS_MAILING_LIST', allVars.get('RETIREMENT_JOBS_MAILING_LIST'), 'Space separated list of emails to send notifications to.')
             }

--- a/dataeng/jobs/analytics/RetirementJobs.groovy
+++ b/dataeng/jobs/analytics/RetirementJobs.groovy
@@ -314,7 +314,7 @@ class RetirementJobs{
             parameters {
                 stringParam('TUBULAR_BRANCH', 'master', 'Repo branch for the tubular scripts.')
                 stringParam('ENVIRONMENT', '', 'edx environment which contains the user in question, in ENVIRONMENT-DEPLOYMENT format.')
-                stringParam('AGE_IN_DAYS', '60', 'Number of days to keep partner reports; should match cleanup job AGE_IN_DAYS to keep retention and cleanup in sync.')
+                stringParam('AGE_IN_DAYS', '60', 'Number of days to keep partner reports; should match retirement-partner-report-cleanup job AGE_IN_DAYS to keep retention and cleanup in sync.')
                 stringParam('DELETION_WARNING_DAYS', '7', 'Number of days before deletion to send warning notification.')
                 stringParam('RETIREMENT_JOBS_MAILING_LIST', allVars.get('RETIREMENT_JOBS_MAILING_LIST'), 'Space separated list of emails to send notifications to.')
             }

--- a/dataeng/jobs/analytics/RetirementJobs.groovy
+++ b/dataeng/jobs/analytics/RetirementJobs.groovy
@@ -314,6 +314,8 @@ class RetirementJobs{
             parameters {
                 stringParam('TUBULAR_BRANCH', 'master', 'Repo branch for the tubular scripts.')
                 stringParam('ENVIRONMENT', '', 'edx environment which contains the user in question, in ENVIRONMENT-DEPLOYMENT format.')
+                stringParam('AGE_IN_DAYS', '60', 'Number of days to keep partner reports (must match cleanup job AGE_IN_DAYS).')
+                stringParam('DELETION_WARNING_DAYS', '7', 'Number of days before deletion to send warning notification.')
                 stringParam('RETIREMENT_JOBS_MAILING_LIST', allVars.get('RETIREMENT_JOBS_MAILING_LIST'), 'Space separated list of emails to send notifications to.')
             }
 

--- a/dataeng/resources/retirement-partner-reporter.sh
+++ b/dataeng/resources/retirement-partner-reporter.sh
@@ -91,7 +91,12 @@ if [[ "${DELETION_WARNING_DAYS}" -ge "${AGE_IN_DAYS}" ]]; then
     exit 1
 fi
 
-echo "Using retention settings: AGE_IN_DAYS=${AGE_IN_DAYS}, DELETION_WARNING_DAYS=${DELETION_WARNING_DAYS}"
+echo "Using retention settings: AGE_IN_DAYS=${AGE_IN_DAYS}, ENABLE_CHECK_EXPIRING_FILES=${ENABLE_CHECK_EXPIRING_FILES}"
+if [[ "${ENABLE_CHECK_EXPIRING_FILES}" == "true" ]]; then
+    echo "Deletion warning enabled: DELETION_WARNING_DAYS=${DELETION_WARNING_DAYS}"
+else
+    echo "DELETION_WARNING_DAYS=${DELETION_WARNING_DAYS} (unused, ENABLE_CHECK_EXPIRING_FILES=false)"
+fi
 
 # Call the script to generate the reports and upload them to Google Drive
 python scripts/retirement_partner_report.py \
@@ -100,7 +105,7 @@ python scripts/retirement_partner_report.py \
     --output_dir=$PARTNER_REPORTS_DIR \
     --age_in_days=$AGE_IN_DAYS \
     --deletion_warning_days=$DELETION_WARNING_DAYS \
-    --ENABLE_CHECK_EXPIRING_FILES=$ENABLE_CHECK_EXPIRING_FILES
+    --enable_check_expiring_files=$ENABLE_CHECK_EXPIRING_FILES
 
 # Remove the temporary files after processing
 rm -f "$TEMP_CONFIG_YAML"

--- a/dataeng/resources/retirement-partner-reporter.sh
+++ b/dataeng/resources/retirement-partner-reporter.sh
@@ -45,6 +45,11 @@ echo "$GOOGLE_SERVICE_ACCOUNT_JSON" > "$TEMP_GOOGLE_SECRETS"
 
 set -x
 
+# Load public configuration from edx-internal Git repo
+cd $WORKSPACE/edx-internal
+ENABLE_CHECK_EXPIRING_FILES=$(yq -r ".PARTNER_REPORTER_VARS[] | select(.ENVIRONMENT_DEPLOYMENT == \"${ENVIRONMENT}\") | .ENABLE_CHECK_EXPIRING_FILES // false" \
+    tools-edx-jenkins/user-retirement.yml)
+
 # prepare tubular
 cd $WORKSPACE/tubular
 # snapshot the current latest versions of pip and setuptools.
@@ -94,7 +99,8 @@ python scripts/retirement_partner_report.py \
     --google_secrets_file=$TEMP_GOOGLE_SECRETS \
     --output_dir=$PARTNER_REPORTS_DIR \
     --age_in_days=$AGE_IN_DAYS \
-    --deletion_warning_days=$DELETION_WARNING_DAYS
+    --deletion_warning_days=$DELETION_WARNING_DAYS \
+    --ENABLE_CHECK_EXPIRING_FILES=$ENABLE_CHECK_EXPIRING_FILES
 
 # Remove the temporary files after processing
 rm -f "$TEMP_CONFIG_YAML"

--- a/dataeng/resources/retirement-partner-reporter.sh
+++ b/dataeng/resources/retirement-partner-reporter.sh
@@ -59,7 +59,9 @@ mkdir $PARTNER_REPORTS_DIR
 python scripts/retirement_partner_report.py \
     --config_file=$TEMP_CONFIG_YAML \
     --google_secrets_file=$TEMP_GOOGLE_SECRETS \
-    --output_dir=$PARTNER_REPORTS_DIR
+    --output_dir=$PARTNER_REPORTS_DIR \
+    --age_in_days=$AGE_IN_DAYS \
+    --deletion_warning_days=$DELETION_WARNING_DAYS
 
 # Remove the temporary files after processing
 rm -f "$TEMP_CONFIG_YAML"

--- a/dataeng/resources/retirement-partner-reporter.sh
+++ b/dataeng/resources/retirement-partner-reporter.sh
@@ -55,6 +55,39 @@ pip install -r requirements.txt
 rm -rf $PARTNER_REPORTS_DIR
 mkdir $PARTNER_REPORTS_DIR
 
+# Validate and set defaults for Jenkins parameters
+# AGE_IN_DAYS: defaults to 60 if not provided
+if [[ -z "${AGE_IN_DAYS}" ]]; then
+    AGE_IN_DAYS=60
+    echo "AGE_IN_DAYS not set, defaulting to ${AGE_IN_DAYS}"
+fi
+
+# DELETION_WARNING_DAYS: defaults to 7 if not provided
+if [[ -z "${DELETION_WARNING_DAYS}" ]]; then
+    DELETION_WARNING_DAYS=7
+    echo "DELETION_WARNING_DAYS not set, defaulting to ${DELETION_WARNING_DAYS}"
+fi
+
+# Validate AGE_IN_DAYS is a positive integer
+if ! [[ "${AGE_IN_DAYS}" =~ ^[0-9]+$ ]] || [[ "${AGE_IN_DAYS}" -le 0 ]]; then
+    echo "ERROR: AGE_IN_DAYS must be a positive integer, got: '${AGE_IN_DAYS}'"
+    exit 1
+fi
+
+# Validate DELETION_WARNING_DAYS is a positive integer
+if ! [[ "${DELETION_WARNING_DAYS}" =~ ^[0-9]+$ ]] || [[ "${DELETION_WARNING_DAYS}" -le 0 ]]; then
+    echo "ERROR: DELETION_WARNING_DAYS must be a positive integer, got: '${DELETION_WARNING_DAYS}'"
+    exit 1
+fi
+
+# Validate DELETION_WARNING_DAYS is less than AGE_IN_DAYS
+if [[ "${DELETION_WARNING_DAYS}" -ge "${AGE_IN_DAYS}" ]]; then
+    echo "ERROR: DELETION_WARNING_DAYS (${DELETION_WARNING_DAYS}) must be less than AGE_IN_DAYS (${AGE_IN_DAYS})"
+    exit 1
+fi
+
+echo "Using retention settings: AGE_IN_DAYS=${AGE_IN_DAYS}, DELETION_WARNING_DAYS=${DELETION_WARNING_DAYS}"
+
 # Call the script to generate the reports and upload them to Google Drive
 python scripts/retirement_partner_report.py \
     --config_file=$TEMP_CONFIG_YAML \


### PR DESCRIPTION
### Overview:

Adds configurable retention and pre-deletion warning windows for the “retirement-partner-reporter” Jenkins job, wiring those values through to the underlying tubular reporting script.

**Changes:**

- Pass --age_in_days and --deletion_warning_days to retirement_partner_report.py from the reporter shell wrapper.
- Add Jenkins job parameters AGE_IN_DAYS and DELETION_WARNING_DAYS to allow configuring these values per run.
- Read ENABLE_CHECK_EXPIRING_FILES from edx-internal/tools-edx-jenkins/user-retirement.yml and pass it through to retirement_partner_report.py

**JIRA ticket**

- https://2u-internal.atlassian.net/browse/BOMS-398

**Related PR:**

- https://github.com/edx/tubular/pull/59
- https://github.com/edx/edx-internal/pull/14150