### PR TITLE
chore: rename job to retirement-certificates and streamline check_retire_users script

### DIFF
--- a/dataeng/jobs/analytics/RetireCertificates.groovy
+++ b/dataeng/jobs/analytics/RetireCertificates.groovy
@@ -11,7 +11,7 @@ class RetireCertificates {
         allVars.get('DEPLOYMENTS').each { deployment, configuration ->
             configuration.get('environments').each { environment ->
 
-                dslFactory.job("retire-certificates-${deployment}-${environment}") {
+                dslFactory.job("retirement-certificates-${deployment}-${environment}") {
                     description(
                         "Delete S3 certificate files and mark GeneratedCertificate records as deleted " +
                         "for retired users in the ${environment}-${deployment} environment."
@@ -27,9 +27,6 @@ class RetireCertificates {
                         buildName('#${BUILD_NUMBER}')
                         timestamps()
                         colorizeOutput('xterm')
-                        credentialsBinding {
-                            string('ROLE_ARN', "${deployment}-retired-users-certs")
-                        }
                     }
                     wrappers common_wrappers(allVars)
                     parameters secure_scm_parameters(allVars)
@@ -78,7 +75,7 @@ class RetireCertificates {
                                 failure {
                                     attachBuildLog(false)  // build log contains PII!
                                     compressBuildLog(false)  // build log contains PII!
-                                    subject('Build failed in Jenkins: retire-certificates-${deployment}-${environment} #${BUILD_NUMBER}')
+                                    subject('Build failed in Jenkins: retirement-certificates-${deployment}-${environment} #${BUILD_NUMBER}')
                                     content('Build #${BUILD_NUMBER} failed.\n\nSee ${BUILD_URL} for details.')
                                     contentType('text/plain')
                                     sendTo {

--- a/devops/resources/check_retire_users.sh
+++ b/devops/resources/check_retire_users.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-VENV="venv"
+VENV="venv-${BUILD_NUMBER}"
 virtualenv --python=python3.8 --clear "${VENV}"
 source "${VENV}/bin/activate"
 

--- a/devops/resources/check_retire_users.sh
+++ b/devops/resources/check_retire_users.sh
@@ -1,19 +1,14 @@
 #!/bin/bash
 
-set +u
-. /edx/var/jenkins/jobvenvs/virtualenv_tools.sh
-# creates a venv with its location stored in variable "venvpath"
-create_virtualenv --python=python3.8 --clear
-. "$venvpath/bin/activate"
-set -u
+set -ex
+
+VENV="venv"
+virtualenv --python=python3.8 --clear "${VENV}"
+source "${VENV}/bin/activate"
 
 cd $WORKSPACE/configuration/util/jenkins/retired_user_cert_remover
 
 pip install -r requirements.txt
-. ../assume-role.sh
-
-# Assume role for different envs
-assume-role ${ROLE_ARN}
 
 set +x
 


### PR DESCRIPTION
### Description:

Renames the Jenkins analytics job for retired-user certificate cleanup and updates the associated shell script to simplify virtualenv setup and remove role-assumption wiring.

Changes:

Rename job from retire-certificates-* to retirement-certificates-* (including failure email subject).
Remove ROLE_ARN credentials binding from the job definition.
Update check_retire_users.sh to create/activate a venv directly instead of using virtualenv_tools.sh.

JIRA ticket:
https://2u-internal.atlassian.net/browse/BOMS-488