### PR TITLE
feat: add DRY_RUN and BATCH_SIZE parameters to RetireCertificates job and check_retire_users script

### DIFF
--- a/dataeng/jobs/analytics/RetireCertificates.groovy
+++ b/dataeng/jobs/analytics/RetireCertificates.groovy
@@ -35,6 +35,8 @@ class RetireCertificates {
                         stringParam('CONFIGURATION_REPO', 'https://github.com/edx/configuration.git', 'Repo URL for edx/configuration.')
                         stringParam('CONFIGURATION_BRANCH', 'master', 'Repo branch for edx/configuration.')
                         stringParam('RETIREMENT_JOBS_MAILING_LIST', allVars.get('RETIREMENT_JOBS_MAILING_LIST'), 'Space separated list of emails to send notifications to.')
+                        booleanParam('DRY_RUN', true, 'Run in dry-run mode (no S3 deletions or DB updates).')
+                        stringParam('BATCH_SIZE', '0', 'Max certificates to process per run (0 = no limit).')
                     }
 
                     environmentVariables {

--- a/devops/resources/check_retire_users.sh
+++ b/devops/resources/check_retire_users.sh
@@ -36,6 +36,19 @@ set -x
 export LMS_CLIENT_ID
 export LMS_CLIENT_SECRET
 
+DRY_RUN="${DRY_RUN:-true}"
+if [ "${DRY_RUN}" != "true" ] && [ "${DRY_RUN}" != "false" ]; then
+    echo "Error: DRY_RUN must be 'true' or 'false', got '${DRY_RUN}'" >&2
+    exit 1
+fi
+
+BATCH_SIZE="${BATCH_SIZE:-0}"
+if ! echo "${BATCH_SIZE}" | grep -qE '^[0-9]+$'; then
+    echo "Error: BATCH_SIZE must be a non-negative integer, got '${BATCH_SIZE}'" >&2
+    exit 1
+fi
+
 python ./retired_user_cert_remover.py \
     --lms-host="${LMS_HOST}" \
-    --dry-run
+    --dry-run="${DRY_RUN}" \
+    --batch-size="${BATCH_SIZE}"


### PR DESCRIPTION
### Overview:

Adds two new user-controllable parameters (DRY_RUN and BATCH_SIZE) to the RetireCertificates Jenkins job and the check_retire_users.sh script that the job invokes. This allows operators to toggle dry-run behavior and limit the number of certificates processed per run, instead of the previous hard-coded dry-run-only invocation.

Changes:

- Added DRY_RUN (boolean, default true) and BATCH_SIZE (string, default 0) parameters to the RetireCertificates job DSL.
- Added validation of DRY_RUN (must be true/false) and BATCH_SIZE (must be non-negative integer) in check_retire_users.sh.
- Updated the retired_user_cert_remover.py invocation to pass --dry-run=... and --batch-size=... instead of an unconditional --dry-run flag.

**JIRA ticket:**

- https://2u-internal.atlassian.net/browse/BOMS-488

**Related PR:**

- https://github.com/edx/edx-arch-experiments/pull/1203
-https://github.com/edx/configuration/pull/341
- https://github.com/edx/edx-internal/pull/14343