### PR TITLE
chore: added authorization configuration for Analytics Exporter and Email Opt-in jobs

### DIFF
--- a/dataeng/jobs/analytics/AnalyticsEmailOptin.groovy
+++ b/dataeng/jobs/analytics/AnalyticsEmailOptin.groovy
@@ -9,6 +9,7 @@ class AnalyticsEmailOptin {
     public static def job = { dslFactory, allVars ->
         dslFactory.job('analytics-email-optin-worker') {
             description('A version of the Analytics Exporter job that only runs the OrgEmailOptInTask task.')
+            authorization common_authorization(allVars)
             parameters {
                 stringParam('NOTIFY')
                 stringParam('MASTER_WORKSPACE')
@@ -68,6 +69,7 @@ class AnalyticsEmailOptin {
             }
         }
         dslFactory.job('analytics-email-optin-master') {
+            authorization common_authorization(allVars)
             parameters{
                 stringParam('ORGS','*', 'Space separated list of organizations to process. Can use wildcards. e.g.: idbx HarvardX')
                 stringParam('EXPORTER_BRANCH','origin/master',

--- a/dataeng/jobs/analytics/AnalyticsEmailOptin.groovy
+++ b/dataeng/jobs/analytics/AnalyticsEmailOptin.groovy
@@ -1,4 +1,5 @@
 package analytics
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_authorization
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_publishers
 import static org.edx.jenkins.dsl.AnalyticsConstants.secure_scm
 import static org.edx.jenkins.dsl.AnalyticsConstants.secure_scm_parameters

--- a/dataeng/jobs/analytics/AnalyticsExporter.groovy
+++ b/dataeng/jobs/analytics/AnalyticsExporter.groovy
@@ -1,4 +1,5 @@
 package analytics
+import static org.edx.jenkins.dsl.AnalyticsConstants.common_authorization
 import static org.edx.jenkins.dsl.AnalyticsConstants.common_publishers
 import static org.edx.jenkins.dsl.AnalyticsConstants.secure_scm
 import static org.edx.jenkins.dsl.AnalyticsConstants.secure_scm_parameters
@@ -10,6 +11,7 @@ class AnalyticsExporter {
     public static def job = { dslFactory, allVars ->
         dslFactory.job('analytics-exporter-course') {
             description('The course-level one-off version of the Analytics Exporter job.  Use this to export only a single course rather than a whole org.  Mainly for RDX purposes.')
+            authorization common_authorization(allVars)
             parameters {
                 stringParam('COURSES', '', 'Space separated list of courses to process. E.g. --course=course-v1:BerkleeX+BMPR365_3x+1T2015')
                 stringParam('EXPORTER_BRANCH', 'environment/production', 'Branch from the analytics-exporter repository. For tags use tags/[tag-name].')
@@ -77,6 +79,7 @@ class AnalyticsExporter {
 
         dslFactory.job('analytics-exporter-worker') {
             description('This is a worker/downstream job to the Analytics Exporter. It does all of the legwork of exporting/encrypting the data for a given org. See also: analytics-exporter-master.')
+            authorization common_authorization(allVars)
             parameters {
                 stringParam('NOTIFY')
                 stringParam('MASTER_WORKSPACE')
@@ -143,6 +146,7 @@ class AnalyticsExporter {
 
         dslFactory.job('analytics-exporter-master') {
             description('The Analytics Exporter weekly job, which exports tons of structure and state data for every course for every participating org and delivers them encrypted to our partners via S3.  Specifically, this sets up the shared edx-platform execution environment, fetches a list of all the orgs, then kicks off downstream analytics-exporter-worker jobs for each one that corresponds to a partner which is configured to receive export data.')
+            authorization common_authorization(allVars)
             parameters {
                 stringParam('ORGS', '*', 'Space separated list of organizations to process. Can use wildcards. e.g.: idbx HarvardX')
                 stringParam('EXPORTER_BRANCH', 'origin/master', 'Branch from the edx-analytics-exporter repository. For tags use tags/[tag-name].')


### PR DESCRIPTION
Neither the email opt-in nor the Analytics Exporter jobs have any user authorization blocks set up. Since we have folks outside the Data Team working on them, at least the Email opt-in jobs, we need to provide them access for now.

I created the edX group [jenkins-analytics-exporter-jobs](https://github.com/orgs/edx/teams/jenkins-analytics-exporter-jobs) and am referencing it in the configuration.