### PR TITLE
fix: update GitHub repository URL in AnalyticsEmailOptin and AnalyticsExporter jobs

### DIFF
--- a/dataeng/jobs/analytics/AnalyticsEmailOptin.groovy
+++ b/dataeng/jobs/analytics/AnalyticsEmailOptin.groovy
@@ -94,7 +94,7 @@ class AnalyticsEmailOptin {
             multiscm secure_scm(allVars) << {
                 git {
                     remote {
-                        url('git@github.com:openedx/edx-platform.git')
+                        url('git@github.com:edx/edx-platform.git')
                         branch('$PLATFORM_BRANCH')
                         credentials('1')
                     }

--- a/dataeng/jobs/analytics/AnalyticsExporter.groovy
+++ b/dataeng/jobs/analytics/AnalyticsExporter.groovy
@@ -171,7 +171,7 @@ class AnalyticsExporter {
             multiscm secure_scm(allVars) << {
                 git {
                     remote {
-                        url('git@github.com:openedx/edx-platform.git')
+                        url('git@github.com:edx/edx-platform.git')
                         branch('$PLATFORM_BRANCH')
                         credentials('1')
                     }


### PR DESCRIPTION
This pull request updates the Git remote URLs in two data engineering job scripts to use the new GitHub organization name. This ensures that the jobs reference the correct repository location.

Repository URL updates:

* Changed the Git remote URL from `openedx/edx-platform` to `edx/edx-platform` in `AnalyticsEmailOptin.groovy` to reflect the `edx` organization name.
* Changed the Git remote URL from `openedx/edx-platform` to `edx/edx-platform` in `AnalyticsExporter.groovy` to reflect the `edx` organization name.

**JIRA:**: https://2u-internal.atlassian.net/browse/COSMO2-911