### PR TITLE
fix: update retirement job parameters to use RETIREMENT_USER_ID instead of RETIREMENT_USERNAME

### DIFF
--- a/dataeng/jobs/analytics/RetirementJobs.groovy
+++ b/dataeng/jobs/analytics/RetirementJobs.groovy
@@ -214,17 +214,13 @@ class RetirementJobs{
             }
 
             steps {
-                // This step calls out to the LMS and collects a list of learners to
-                // retire.  The output is several generated properties files, one per
-                // learner. Each file contains RETIREMENT_USERNAME and RETIREMENT_USER_ID,
-                // both of which are injected by the tubular get_learners_to_retire script.
-                // RETIREMENT_USER_ID is used to name the build (avoids exposing PII in job titles).
-                // RETIREMENT_USERNAME is still required by the downstream retire_one_learner script.
+                // Collects a list of learners ready for retirement from the LMS
+                // and generates a properties file per learner. Each file is named
+                // using the learner's unique identifier and contains the parameters
+                // needed by the downstream retirement driver job.
                 shell(dslFactory.readFileFromWorkspace('dataeng/resources/user-retirement-collector.sh'))
-                // This takes as input the properties files created in the previous
-                // step, and triggers user-retirement-driver jobs per file.
-                // The fileBuildParameterFactory reads the file contents as build parameters,
-                // making RETIREMENT_USERNAME and RETIREMENT_USER_ID available to the driver job.
+                // Reads the generated properties files and triggers a
+                // user-retirement-driver build for each learner.
                 downstreamParameterized {
                     trigger('user-retirement-driver') {
                         // This section causes the build to block on completion of downstream builds.

--- a/dataeng/jobs/analytics/RetirementJobs.groovy
+++ b/dataeng/jobs/analytics/RetirementJobs.groovy
@@ -34,7 +34,7 @@ class RetirementJobs{
             }
             configure { project ->
                 project / 'properties' / 'hudson.plugins.throttleconcurrents.ThrottleJobProperty' <<
-                    'paramsToUseForLimit'('ENVIRONMENT,RETIREMENT_USERNAME')
+                    'paramsToUseForLimit'('ENVIRONMENT,RETIREMENT_USER_ID')
                 project / 'properties' / 'hudson.plugins.throttleconcurrents.ThrottleJobProperty' <<
                     'limitOneJobWithMatchingParams'('true')
             }
@@ -216,10 +216,15 @@ class RetirementJobs{
             steps {
                 // This step calls out to the LMS and collects a list of learners to
                 // retire.  The output is several generated properties files, one per
-                // learner.
+                // learner. Each file contains RETIREMENT_USERNAME and RETIREMENT_USER_ID,
+                // both of which are injected by the tubular get_learners_to_retire script.
+                // RETIREMENT_USER_ID is used to name the build (avoids exposing PII in job titles).
+                // RETIREMENT_USERNAME is still required by the downstream retire_one_learner script.
                 shell(dslFactory.readFileFromWorkspace('dataeng/resources/user-retirement-collector.sh'))
                 // This takes as input the properties files created in the previous
                 // step, and triggers user-retirement-driver jobs per file.
+                // The fileBuildParameterFactory reads the file contents as build parameters,
+                // making RETIREMENT_USERNAME and RETIREMENT_USER_ID available to the driver job.
                 downstreamParameterized {
                     trigger('user-retirement-driver') {
                         // This section causes the build to block on completion of downstream builds.

--- a/dataeng/jobs/analytics/RetirementJobs.groovy
+++ b/dataeng/jobs/analytics/RetirementJobs.groovy
@@ -49,7 +49,7 @@ class RetirementJobs{
                     failBuild()
                 }
                 buildUserVars() /* gives us access to BUILD_USER_ID, among other things */
-                buildName('#${BUILD_NUMBER}, ${ENV,var="RETIREMENT_USERNAME"}')
+                buildName('#${BUILD_NUMBER}, ${ENV,var="RETIREMENT_USER_ID"}')
                 timestamps()
                 colorizeOutput('xterm')
                 credentialsBinding {
@@ -62,6 +62,7 @@ class RetirementJobs{
                 stringParam('TUBULAR_BRANCH', 'master', 'Repo branch for the tubular scripts.')
                 stringParam('ENVIRONMENT', '', 'edx environment which contains the user in question, in ENVIRONMENT-DEPLOYMENT format.')
                 stringParam('RETIREMENT_USERNAME', '', 'Current username of learner to retire.')
+                stringParam('RETIREMENT_USER_ID', '', 'LMS user ID of the learner to retire.')
             }
 
             // retry cloning repositories

--- a/dataeng/jobs/analytics/RetirementJobs.groovy
+++ b/dataeng/jobs/analytics/RetirementJobs.groovy
@@ -214,13 +214,12 @@ class RetirementJobs{
             }
 
             steps {
-                // Collects a list of learners ready for retirement from the LMS
-                // and generates a properties file per learner. Each file is named
-                // using the learner's unique identifier and contains the parameters
-                // needed by the downstream retirement driver job.
+                // This step calls out to the LMS and collects a list of learners to
+                // retire.  The output is several generated properties files, one per
+                // learner.
                 shell(dslFactory.readFileFromWorkspace('dataeng/resources/user-retirement-collector.sh'))
-                // Reads the generated properties files and triggers a
-                // user-retirement-driver build for each learner.
+                // This takes as input the properties files created in the previous
+                // step, and triggers user-retirement-driver jobs per file.
                 downstreamParameterized {
                     trigger('user-retirement-driver') {
                         // This section causes the build to block on completion of downstream builds.


### PR DESCRIPTION
## Summary 
The Jenkins properties files generated for user retirement were using the learner's username in their filenames (e.g., `learner_retire_username`). This exposed learner usernames (PII) in public-facing Jenkins build lists and job names.

This PR changes the properties filename generator to use the learner's unique numeric user ID instead of their username. It also injects RETIREMENT_USER_ID as a parameter inside the properties file. The RETIREMENT_USERNAME parameter remains present in the file content as it is still required by backend retirement scripts.

## Ticket
https://2u-internal.atlassian.net/browse/BOMS-593